### PR TITLE
Made check for (UI/NS)TextAlignment be an ifdef

### DIFF
--- a/braintree/BTPayment/BTPaymentActivityOverlayView.m
+++ b/braintree/BTPayment/BTPaymentActivityOverlayView.m
@@ -59,13 +59,11 @@ static BTPaymentActivityOverlayView *sharedOverlayView = nil;
         titleLabel.shadowOffset = CGSizeMake(0, 2);
         titleLabel.font = [UIFont boldSystemFontOfSize:16.0f];
         titleLabel.tag = 2;
-        if (([[[UIDevice currentDevice] systemVersion] compare:@"6" options:NSNumericSearch] != NSOrderedAscending)) {
-            // Is iOS 6 or higher
-            titleLabel.textAlignment = NSTextAlignmentCenter;
-        } else {
-            titleLabel.textAlignment = UITextAlignmentCenter;
-        }
-
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+        titleLabel.textAlignment = NSTextAlignmentCenter;
+#else
+        titleLabel.textAlignment = UITextAlignmentCenter;
+#endif
         [self addSubview:titleLabel];
     }
     return self;


### PR DESCRIPTION
This should behave the same, since both the constants maps to 1, but without the deprecation warning if you use a modern version of Xcode.
