### PR TITLE
Crash when scrolling BTPaymentViewController

### DIFF
--- a/braintree/BTPayment/BTPaymentViewController.m
+++ b/braintree/BTPayment/BTPaymentViewController.m
@@ -178,7 +178,7 @@
 
 // Hide keyboard when the user scrolls
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
-    UITextField *firstResponder;
+    UITextField *firstResponder = nil;
     if ([_paymentFormView.cardNumberTextField isFirstResponder]) firstResponder = _paymentFormView.cardNumberTextField;
     else if ([_paymentFormView.monthYearTextField isFirstResponder]) firstResponder = _paymentFormView.monthYearTextField;
     else if ([_paymentFormView.cvvTextField isFirstResponder]) firstResponder = _paymentFormView.cvvTextField;


### PR DESCRIPTION
Steps to recreate:
- Display a BTPaymentViewController
- Attempt to scroll before selecting a form field.

Looks like a message is being sent to an uninitialized pointer.
