### PR TITLE
Added Compatibility of the Client Side Encryption Framework to Mac OS X 10.7 and higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Braintree iOS SDK
+# Braintree iOS/OS X SDK
 
 The iOS SDK provides developers with a collection of easy-to-use APIs for adding native payments to their iOS application. It has three components:
 
@@ -30,6 +30,7 @@ Checkout `braintree/SampleCheckout/README.md` for more details on running the sa
 * [Encryption](https://www.braintreepayments.com/docs/ios/encryption/overview): Client-side encryption allowing you to encrypt credit card data before sending it to your servers and on to the Braintree gateway, making PCI compliance a breeze.
 
 These components are designed to work together, but can be used independently of each other. For example, you could use Venmo Touch and client-side encryption without using the prebuilt payment form.
+On OS X, you need to implement a custom payment form and follow the [Encryption](https://www.braintreepayments.com/docs/ios/encryption/overview) guidelines.
 
 ## Documentation
 

--- a/braintree/BTEncryption/BTRSA.m
+++ b/braintree/BTEncryption/BTRSA.m
@@ -34,10 +34,42 @@
     if(publicKeyRef != NULL)
         return publicKeyRef;
 
-    BTSecKeyWrapper * wrapper = [[BTSecKeyWrapper alloc] init];
     NSData * publicKeyData  = [NSData dataWithBase64EncodedString: publicKey];
+#ifdef TARGET_OS_IPHONE 
+    BTSecKeyWrapper * wrapper = [[BTSecKeyWrapper alloc] init];
 
     return [wrapper addPeerPublicKey:applicationTag keyBits: publicKeyData];
+#elif
+	    CFDataRef cfdata = CFDataCreate(NULL, [pk bytes], [pk length]);
+	    SecItemImportExportKeyParameters params;
+	    CFArrayRef temparray = nil;
+	    OSStatus oserr = 0;
+
+	    params.version = SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION;
+	    params.flags = 0; // See SecKeyImportExportFlags for details.
+	    params.passphrase = NULL;
+	    params.alertTitle = NULL;
+	    params.alertPrompt = NULL;
+	    params.accessRef = NULL;
+
+	    /* These two values are for import. */
+	    params.keyUsage = NULL;
+	    params.keyAttributes = NULL;
+	    SecExternalItemType itemType = kSecItemTypePublicKey;
+	    SecExternalFormat externalFormat = kSecFormatBSAFE;
+	    int flags = 0;
+	    oserr = SecItemImport(cfdata,
+	                        NULL, // filename or extension
+	                        &externalFormat, // See SecExternalFormat for details
+	                        &itemType, // item type
+	                        flags, // See SecItemImportExportFlags for details
+	                        &params,
+	                        NULL, // Don't import into a keychain
+	                        &temparray);
+	    if(oserr != 0) NSLog(@"Secure Key Encryption Failed With Error: %ld", result);
+
+	    return (SecKeyRef)CFArrayGetValueAtIndex(temparray, 0);
+#endif
 }
 
 -(NSData*) encrypt:(NSData*) data {

--- a/braintree/BTEncryption/BTRSA.m
+++ b/braintree/BTEncryption/BTRSA.m
@@ -40,7 +40,7 @@
 
     return [wrapper addPeerPublicKey:applicationTag keyBits: publicKeyData];
 #elif
-	    CFDataRef cfdata = CFDataCreate(NULL, [pk bytes], [pk length]);
+	    CFDataRef cfdata = CFDataCreate(NULL, [publicKeyData bytes], [publicKeyData length]);
 	    SecItemImportExportKeyParameters params;
 	    CFArrayRef temparray = nil;
 	    OSStatus oserr = 0;


### PR DESCRIPTION
The encryption framework was not compatible to OS X. My contribution makes use of Security Transforms as suggested by Apple (https://developer.apple.com/library/mac/documentation/security/conceptual/SecTransformPG/SigningandVerifying/SigningandVerifying.html) in order to provide this compatibility.

On top of that, I changed the title in the README and added a description on how to use the SDK on Mac OS X.