### PR TITLE
Remove unnecessary default method implementations

### DIFF
--- a/Braintree/Drop-In/BTDropInSelectPaymentMethodViewController.m
+++ b/Braintree/Drop-In/BTDropInSelectPaymentMethodViewController.m
@@ -23,11 +23,6 @@
     return self;
 }
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     [self.tableView reloadData];
@@ -40,11 +35,6 @@
 }
 
 #pragma mark - Table view data source
-
-- (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView
-{
-    return 1;
-}
 
 - (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(__unused NSInteger)section
 {


### PR DESCRIPTION
- Remove `viewDidLoad` which just calls the super class implementation
- Remove `numberOfSectionsInTableView:` since `return 1` is the default implementation and is publicly documented by Apple
