### PR TITLE
Credit Card tokenization function now utilizes credit card's CVV and postal code

### DIFF
--- a/Braintree/Braintree.h
+++ b/Braintree/Braintree.h
@@ -70,11 +70,15 @@
 /// @param cardNumber      Card number to tokenize
 /// @param expirationMonth Card's expiration month
 /// @param expirationYear  Card's expiration year
+/// @param CVV		       Card's CVV
+/// @param postalCode      Postal code of the billing address
 /// @param completionBlock Completion block that is called exactly once asynchronously, providing either a nonce upon success or an error upon failure.
 - (void)tokenizeCardWithNumber:(NSString *)cardNumber
                expirationMonth:(NSString *)expirationMonth
                 expirationYear:(NSString *)expirationYear
-                    completion:(void (^)(NSString *nonce, NSError *error))completionBlock;
+                           CVV:(NSString *)CVV
+                    postalCode:(NSString *)postalCode
+                    completion:(void (^)(NSString *, NSError *))completionBlock;
 
 
 #pragma mark Advanced Integrations

--- a/Braintree/Braintree.m
+++ b/Braintree/Braintree.m
@@ -32,16 +32,19 @@
 - (void)tokenizeCardWithNumber:(NSString *)cardNumber
                expirationMonth:(NSString *)expirationMonth
                 expirationYear:(NSString *)expirationYear
-                    completion:(void (^)(NSString *nonce, NSError *error))completionBlock {
+                           CVV:(NSString *)CVV
+                    postalCode:(NSString *)postalCode
+                    completion:(void (^)(NSString *, NSError *))completionBlock
+{
     [self.client postAnalyticsEvent:@"custom.ios.tokenize.call"
                             success:nil
                             failure:nil];
-
+    
     [self.client saveCardWithNumber:cardNumber
                     expirationMonth:expirationMonth
                      expirationYear:expirationYear
-                                cvv:nil
-                         postalCode:nil
+                                cvv:CVV
+                         postalCode:postalCode
                            validate:NO
                             success:^(BTCardPaymentMethod *card) {
                                 if (completionBlock) {
@@ -52,6 +55,7 @@
                                 completionBlock(nil, error);
                             }];
 }
+
 
 #pragma mark Drop-In
 


### PR DESCRIPTION
Seeing that both CVV and postal code are often required by Braintree gateway for successful transactions, I felt that passing nil to these should be optional
