### PR TITLE
fix crash due to unretained copy of billingAddress/shippingAddress in BTApplePayPaymentMethod.m

### DIFF
--- a/Braintree/API/Models/BTApplePayPaymentMethod.m
+++ b/Braintree/API/Models/BTApplePayPaymentMethod.m
@@ -8,9 +8,9 @@
 - (id)copyWithZone:(NSZone *)zone {
     BTApplePayPaymentMethod *copy = [[BTApplePayPaymentMethod allocWithZone:zone] init];
     copy->_nonce = [self.nonce copy];
-    copy->_billingAddress = self.billingAddress;
     copy->_shippingMethod = [self.shippingMethod copy];
-    copy->_shippingAddress = self.shippingAddress;
+    copy.billingAddress = self.billingAddress;
+    copy.shippingAddress = self.shippingAddress;
     return copy;
 }
 


### PR DESCRIPTION
I was seeing crashes trying to access the shippingAddress in BTApplePayPaymentMethod -- looks like mutableCopy is not properly retaining or copying the records.  This change uses the setters to get the CFRetains invoked.
