### PR TITLE
Allow soft keyboard 'Return' key to dismiss keyboard on BTUIFormField

### DIFF
--- a/Braintree/UI/Views/Custom Views/BTUIFormField.h
+++ b/Braintree/UI/Views/Custom Views/BTUIFormField.h
@@ -30,4 +30,7 @@
 - (void)formFieldDidChange:(BTUIFormField *)formField;
 - (void)formFieldDidDeleteWhileEmpty:(BTUIFormField *)formField;
 
+@optional
+- (BOOL)formFieldShouldReturn:(BTUIFormField *)formField;
+
 @end

--- a/Braintree/UI/Views/Custom Views/BTUIFormField.m
+++ b/Braintree/UI/Views/Custom Views/BTUIFormField.m
@@ -110,6 +110,10 @@ const CGFloat formFieldBottomMargin = 11;
     return [self.textField becomeFirstResponder];
 }
 
+- (BOOL)resignFirstResponder {
+    return [super resignFirstResponder] || [self.textField resignFirstResponder];
+}
+
 #pragma mark - Theme
 
 - (void)setTheme:(BTUI *)theme {
@@ -331,6 +335,14 @@ const CGFloat formFieldBottomMargin = 11;
 - (BOOL)textField:(__unused UITextField *)textField shouldChangeCharactersInRange:(__unused NSRange)range replacementString:(__unused NSString *)newText {
     // To be implemented by subclass
     return YES;
+}
+
+- (BOOL)textFieldShouldReturn:(__unused UITextField *)textField {
+    if ([self.delegate respondsToSelector:@selector(formFieldShouldReturn:)]) {
+        return [self.delegate formFieldShouldReturn:self];
+    } else {
+        return YES;
+    }
 }
 
 - (void)tappedField {

--- a/Braintree/UI/Views/Form Fields/BTUICardPostalCodeField.m
+++ b/Braintree/UI/Views/Form Fields/BTUICardPostalCodeField.m
@@ -9,6 +9,7 @@
     if (self) {
         [self setThemedPlaceholder:BTUILocalizedString(POSTAL_CODE_PLACEHOLDER)];
         self.nonDigitsSupported = NO;
+        self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
     }
     return self;
 }

--- a/Braintree/UI/Views/Forms/BTUICardFormView.m
+++ b/Braintree/UI/Views/Forms/BTUICardFormView.m
@@ -241,6 +241,11 @@
     [self switchToPreviousField:formField];
 }
 
+- (BOOL)formFieldShouldReturn:(BTUIFormField *)formField {
+    [formField resignFirstResponder];
+    return NO;
+}
+
 #pragma mark - Auto-advancing
 
 - (void)advanceToNextInvalidFieldFrom:(BTUIFormField *)field {


### PR DESCRIPTION
- Add a new optional delegate method `formFieldShouldReturn:` to `BTUIFormFieldDelegate` to allow handling the soft keyboard Return key
- Ask the form field to resign first responder when this fires in `BTUICardFormView`
- Implement `resignFirstResponder` to mirror the existing `becomeFirstResponder` of BTUIFormField
- Additionally, disable autocorrection for `BTUICardPostalCodeField`, to prevent iOS 8 text suggestions from appearing

This is needed particularly for `BTUICardPostalCodeField` (which isn't enabled for the default Braintree-Demo app), as it's the only standard card field that presents a keyboard with a Return/Done button, which before these changes does nothing.
