### PR TITLE
Implementing remaining PKPaymentAuthorizationViewControllerDelegate methods

### DIFF
--- a/Braintree/Payments/@Public/BTPaymentMethodCreationDelegate.h
+++ b/Braintree/Payments/@Public/BTPaymentMethodCreationDelegate.h
@@ -74,4 +74,13 @@
 /// @param error  An error that characterizes the failure
 - (void)paymentMethodCreator:(id)sender didFailWithError:(NSError *)error;
 
+@optional
+
+// Passthrough for PKPaymentAuthorizationViewControllerDelegate's shipping address selection callback
+- (void)paymentMethodCreator:(id)sender didSelectShippingAddress:(ABRecordRef)address completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *, NSArray *))completion;
+
+// Passthrough for PKPaymentAuthorizationViewControllerDelegate's shipping method selection callback
+- (void)paymentMethodCreator:(id)sender didSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *))completion;
+
+
 @end

--- a/Braintree/Payments/BTPaymentApplePayProvider.m
+++ b/Braintree/Payments/BTPaymentApplePayProvider.m
@@ -213,6 +213,20 @@
     [self applePayPaymentAuthorizationViewControllerDidFinish:controller];
 }
 
+- (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
+                  didSelectShippingAddress:(ABRecordRef)address
+                                completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *, NSArray *))completion {
+    [self informDelegatePaymentAuthorizationViewControllerDidSelectShippingAddress:address
+                                                                        completion:completion];
+}
+
+- (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
+                   didSelectShippingMethod:(PKShippingMethod *)shippingMethod
+                                completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *))completion {
+    [self informDelegatePaymentAuthorizationViewControllerDidSelectShippingMethod:shippingMethod
+                                                                       completion:completion];
+}
+
 #pragma mark MockApplePayPaymentAuthorizationViewController Delegate
 
 - (void)mockApplePayPaymentAuthorizationViewController:(__unused BTMockApplePayPaymentAuthorizationViewController *)viewController
@@ -301,6 +315,22 @@
     [self.client postAnalyticsEvent:@"ios.apple-pay-provider.completion.cancel"];
     if ([self.delegate respondsToSelector:@selector(paymentMethodCreatorDidCancel:)]) {
         [self.delegate paymentMethodCreatorDidCancel:self];
+    }
+}
+
+- (void)informDelegatePaymentAuthorizationViewControllerDidSelectShippingAddress:(ABRecordRef)address completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *, NSArray *))completion {
+    if ([self.delegate respondsToSelector:@selector(paymentMethodCreator:didSelectShippingAddress:completion:)]) {
+        [self.delegate paymentMethodCreator:self
+                   didSelectShippingAddress:address
+                                 completion:completion];
+    }
+}
+
+- (void)informDelegatePaymentAuthorizationViewControllerDidSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *))completion {
+    if ([self.delegate respondsToSelector:@selector(paymentMethodCreator:didSelectShippingMethod:completion:)]) {
+        [self.delegate paymentMethodCreator:self
+                    didSelectShippingMethod:shippingMethod
+                                 completion:completion];
     }
 }
 

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -224,6 +224,22 @@
     }
 }
 
+- (void)informDelegatePaymentAuthorizationViewControllerDidSelectShippingAddress:(ABRecordRef)address completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *, NSArray *))completion {
+    if ([self.delegate respondsToSelector:@selector(paymentMethodCreator:didSelectShippingAddress:completion:)]) {
+        [self.delegate paymentMethodCreator:self
+                   didSelectShippingAddress:address
+                                 completion:completion];
+    }
+}
+
+- (void)informDelegatePaymentAuthorizationViewControllerDidSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *))completion {
+    if ([self.delegate respondsToSelector:@selector(paymentMethodCreator:didSelectShippingMethod:completion:)]) {
+        [self.delegate paymentMethodCreator:self
+                    didSelectShippingMethod:shippingMethod
+                                 completion:completion];
+    }
+}
+
 #pragma mark BTPayPalViewControllerDelegate
 
 - (void)payPalViewControllerWillCreatePayPalPaymentMethod:(__unused BTPayPalViewController *)viewController {
@@ -299,6 +315,14 @@
 
 - (void)paymentMethodCreator:(__unused id)sender didFailWithError:(NSError *)error {
     [self informDelegateDidFailWithError:error];
+}
+
+- (void)paymentMethodCreator:(__unused id)sender didSelectShippingAddress:(ABRecordRef)address completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *, NSArray *))completion {
+    [self informDelegatePaymentAuthorizationViewControllerDidSelectShippingAddress:address completion:completion];
+}
+
+- (void)paymentMethodCreator:(__unused id)sender didSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(void (^)(PKPaymentAuthorizationStatus, NSArray *))completion {
+    [self informDelegatePaymentAuthorizationViewControllerDidSelectShippingMethod:shippingMethod completion:completion];
 }
 
 #pragma mark Payment Request Details


### PR DESCRIPTION
I haven't written any tests since this is basically just a passthrough of the delegate calls. We found it useful since we're calculating tax when a user selects an address on the Apple Pay sheet.

Not sure if defining methods in `BTPaymentMethodCreationDelegate.h` as `@optional` is the best way to go. Any suggestions?