### PR TITLE
Switch delegate notification order

### DIFF
--- a/Braintree/Payments/@Public/BTPaymentMethodCreationDelegate.h
+++ b/Braintree/Payments/@Public/BTPaymentMethodCreationDelegate.h
@@ -7,6 +7,8 @@
 /// an object creating a payment method, such as BTPaymentButton or BTPaymentProvider.
 @protocol BTPaymentMethodCreationDelegate <NSObject>
 
+@optional
+
 /// The payment method creator requires presentation of a view controller in order to
 /// proceed.
 ///

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -231,8 +231,8 @@
 }
 
 - (void)payPalViewController:(BTPayPalViewController *)viewController didCreatePayPalPaymentMethod:(BTPayPalPaymentMethod *)payPalPaymentMethod {
-    [self informDelegateRequestsDismissalOfAuthorizationViewController:viewController];
     [self informDelegateDidCreatePaymentMethod:payPalPaymentMethod];
+    [self informDelegateRequestsDismissalOfAuthorizationViewController:viewController];
 }
 
 - (void)payPalViewController:(__unused BTPayPalViewController *)viewController didFailWithError:(NSError *)error {

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -241,8 +241,8 @@
 }
 
 - (void)payPalViewControllerDidCancel:(BTPayPalViewController *)viewController {
-    [self informDelegateRequestsDismissalOfAuthorizationViewController:viewController];
     [self informDelegateDidCancel];
+    [self informDelegateRequestsDismissalOfAuthorizationViewController:viewController];
 }
 
 #pragma mark BTAppSwitchingDelegate


### PR DESCRIPTION
In our app, we slightly divert from the (probably common) pattern of presenting the PayPal view controller modally because we are already in a modal context. Instead, we push the PayPal view controller on the current navigation stack. When the user taps Cancel in the top left corner, we pop the view controller and return to our modal context. If the user successfully authenticates with PayPal, we dismiss the entire modal stack and return to our main app.

Right now, when our delegate gets sent `paymentMethodCreator:requestsDismissalOfViewController:`, we have no idea if the request happens because the user tapped Cancel or because the payment method had been created. We need to know this, because in case of a Cancel we need to pop, but in case of authentication we need to dismiss the entire modal stack. By sending `paymentMethodCreator:didCreatePaymentMethod:` first, we can distinguish these two events from each other and do the right thing based on that.

I ran unit tests, they still pass, so it looks like this is a safe change to make.