### PR TITLE
Added status property to BTPaymentProvider

### DIFF
--- a/Braintree/Payments/@Public/BTPaymentProvider.h
+++ b/Braintree/Payments/@Public/BTPaymentProvider.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSInteger, BTPaymentProviderType) {
 
 /// Status of the last (or ongoing) transaction
 typedef NS_ENUM(NSInteger, BTPaymentProviderStatus) {
-    /// First status: The payment method was not created yet
+    /// The payment method was not created yet (default status)
     BTPaymentProviderStatusUninitialized = 0,
 
     /// Payment method created (either PayPal, Venmo or ApplePay)
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, BTPaymentProviderStatus) {
     BTPaymentProviderStatusError,
 
     /// Payment method creation is complete with success
-    BTPaymentProviderStatusSuccees,
+    BTPaymentProviderStatusSuccess,
 
     /// The payment method creator has cancelled
     BTPaymentProviderStatusCancelled

--- a/Braintree/Payments/@Public/BTPaymentProvider.h
+++ b/Braintree/Payments/@Public/BTPaymentProvider.h
@@ -18,7 +18,7 @@ typedef NS_ENUM(NSInteger, BTPaymentProviderType) {
     BTPaymentProviderTypeApplePay
 };
 
-/// Status of the last (or ongoing) transaction
+/// Status of the last (or ongoing) payment method creation
 typedef NS_ENUM(NSInteger, BTPaymentProviderStatus) {
     /// The payment method was not created yet (default status)
     BTPaymentProviderStatusUninitialized = 0,
@@ -118,7 +118,7 @@ typedef NS_OPTIONS(NSInteger, BTPaymentMethodCreationOptions) {
 - (BOOL)canCreatePaymentMethodWithProviderType:(BTPaymentProviderType)type;
 
 
-/// Status of the last (or ongoing) transaction 
+/// Status of the last (or ongoing) payment method creation 
 @property (nonatomic, assign) BTPaymentProviderStatus status;
 
 #if BT_ENABLE_APPLE_PAY

--- a/Braintree/Payments/@Public/BTPaymentProvider.h
+++ b/Braintree/Payments/@Public/BTPaymentProvider.h
@@ -36,8 +36,8 @@ typedef NS_ENUM(NSInteger, BTPaymentProviderStatus) {
     /// Payment method creation is complete with success
     BTPaymentProviderStatusSuccess,
 
-    /// The payment method creator has cancelled
-    BTPaymentProviderStatusCancelled
+    /// The payment method creator has canceled
+    BTPaymentProviderStatusCanceled
 };
 
 

--- a/Braintree/Payments/@Public/BTPaymentProvider.h
+++ b/Braintree/Payments/@Public/BTPaymentProvider.h
@@ -18,6 +18,29 @@ typedef NS_ENUM(NSInteger, BTPaymentProviderType) {
     BTPaymentProviderTypeApplePay
 };
 
+/// Status of the last (or ongoing) transaction
+typedef NS_ENUM(NSInteger, BTPaymentProviderStatus) {
+    /// First status: The payment method was not created yet
+    BTPaymentProviderStatusUninitialized = 0,
+
+    /// Payment method created (either PayPal, Venmo or ApplePay)
+    BTPaymentProviderStatusInitialized,
+
+    /// The payment method creator, having obtained user payment details and/or user
+    /// authorization, is now processing the results
+    BTPaymentProviderStatusProcessing,
+
+    /// Payment method failed with error
+    BTPaymentProviderStatusError,
+
+    /// Payment method creation is complete with success
+    BTPaymentProviderStatusSuccees,
+
+    /// The payment method creator has cancelled
+    BTPaymentProviderStatusCancelled
+};
+
+
 /// Options for payment method creation
 typedef NS_OPTIONS(NSInteger, BTPaymentMethodCreationOptions) {
 
@@ -94,6 +117,9 @@ typedef NS_OPTIONS(NSInteger, BTPaymentMethodCreationOptions) {
 /// @return YES if this payment provider could create a payment method of the specified type
 - (BOOL)canCreatePaymentMethodWithProviderType:(BTPaymentProviderType)type;
 
+
+/// Status of the last (or ongoing) transaction 
+@property (nonatomic, assign) BTPaymentProviderStatus status;
 
 #if BT_ENABLE_APPLE_PAY
 

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -9,7 +9,6 @@
 #import "BTPayPalViewController.h"
 #import "BTPayPalAppSwitchHandler.h"
 #import "BTClient+BTPayPal.h"
-#import "BTClientApplePayConfiguration.h"
 #import "BTPaymentApplePayProvider.h"
 #import "BTLogger_Internal.h"
 

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -228,7 +228,7 @@
 }
 
 - (void)informDelegateDidCancel {
-    [self setStatus:BTPaymentProviderStatusCancelled];
+    [self setStatus:BTPaymentProviderStatusCanceled];
 
     [self.client postAnalyticsEvent:@"ios.authorizer.did-cancel"];
     if ([self.delegate respondsToSelector:@selector(paymentMethodCreatorDidCancel:)]) {
@@ -257,7 +257,7 @@
 }
 
 - (void)payPalViewControllerDidCancel:(BTPayPalViewController *)viewController {
-    [self setStatus:BTPaymentProviderStatusCancelled];
+    [self setStatus:BTPaymentProviderStatusCanceled];
 
     [self informDelegateRequestsDismissalOfAuthorizationViewController:viewController];
     [self informDelegateDidCancel];

--- a/Braintree/Payments/BTPaymentProvider.m
+++ b/Braintree/Payments/BTPaymentProvider.m
@@ -207,7 +207,7 @@
 }
 
 - (void)informDelegateDidCreatePaymentMethod:(BTPaymentMethod *)paymentMethod {
-    [self setStatus:BTPaymentProviderStatusSuccees];
+    [self setStatus:BTPaymentProviderStatusSuccess];
 
     [self.client postAnalyticsEvent:@"ios.authorizer.did-create-payment-method"];
     if ([self.delegate respondsToSelector:@selector(paymentMethodCreator:didCreatePaymentMethod:)]) {

--- a/Specs/Braintree-Payments-Specs/BTPaymentsSpec.m
+++ b/Specs/Braintree-Payments-Specs/BTPaymentsSpec.m
@@ -141,7 +141,7 @@ describe(@"createPaymentMethod:", ^{
                 [[delegate expect] paymentMethodCreatorDidCancel:provider];
                 provider.delegate = delegate;
                 [(id<BTPaymentMethodCreationDelegate>)provider paymentMethodCreatorDidCancel:nil];
-                expect([provider status]).to.equal(BTPaymentProviderStatusCancelled);
+                expect([provider status]).to.equal(BTPaymentProviderStatusCanceled);
             });
 
             it(@"invokes error delegate method", ^{
@@ -187,7 +187,7 @@ describe(@"createPaymentMethod:", ^{
                 }]];
                 [[delegate expect] paymentMethodCreatorDidCancel:[OCMArg isNotNil]];
                 [[delegate expect] paymentMethodCreator:[OCMArg checkWithBlock:^BOOL(id obj) {
-                    return [(BTPaymentProvider *)obj status] == BTPaymentProviderStatusCancelled;
+                    return [(BTPaymentProvider *)obj status] == BTPaymentProviderStatusCanceled;
                 }]
                       requestsDismissalOfViewController:nil];
                 provider.delegate = delegate;

--- a/Specs/Braintree-Payments-Specs/BTPaymentsSpec.m
+++ b/Specs/Braintree-Payments-Specs/BTPaymentsSpec.m
@@ -10,6 +10,7 @@
 
 #import "BTPayPalAppSwitchHandler.h"
 #import "BTVenmoAppSwitchHandler.h"
+#import "BTPayPalViewController.h"
 
 @interface BTPaymentProvider () <PKPaymentAuthorizationViewControllerDelegate>
 @end
@@ -125,10 +126,43 @@ describe(@"createPaymentMethod:", ^{
                 [[[payPalAppSwitchHandler stub] andReturnValue:@YES] initiateAppSwitchWithClient:OCMOCK_ANY delegate:OCMOCK_ANY error:(NSError *__autoreleasing *)[OCMArg anyPointer]];
             });
 
+            it(@"status is uninitialized", ^{
+                expect([provider status]).to.equal(BTPaymentProviderStatusUninitialized);
+            });
+
             it(@"invokes an app switch delegate method", ^{
                 [[delegate expect] paymentMethodCreatorWillPerformAppSwitch:provider];
                 provider.delegate = delegate;
                 [provider createPaymentMethod:BTPaymentProviderTypePayPal];
+                expect([provider status]).to.equal(BTPaymentProviderStatusInitialized);
+            });
+
+            it(@"invokes didcancel delegate method", ^{
+                [[delegate expect] paymentMethodCreatorDidCancel:provider];
+                provider.delegate = delegate;
+                [(id<BTPaymentMethodCreationDelegate>)provider paymentMethodCreatorDidCancel:nil];
+                expect([provider status]).to.equal(BTPaymentProviderStatusCancelled);
+            });
+
+            it(@"invokes error delegate method", ^{
+                [[delegate expect] paymentMethodCreator:provider didFailWithError:nil];
+                provider.delegate = delegate;
+                [(id<BTPaymentMethodCreationDelegate>)provider paymentMethodCreator:provider didFailWithError:nil];
+                expect([provider status]).to.equal(BTPaymentProviderStatusError);
+            });
+
+            it(@"invokes success delegate method", ^{
+                [[delegate expect] paymentMethodCreator:provider didCreatePaymentMethod:nil];
+                provider.delegate = delegate;
+                [(id<BTPaymentMethodCreationDelegate>)provider paymentMethodCreator:provider didCreatePaymentMethod:nil];
+                expect([provider status]).to.equal(BTPaymentProviderStatusSuccess);
+            });
+
+            it(@"invokes willprocess delegate method", ^{
+                [[delegate expect] paymentMethodCreatorWillProcess:provider];
+                provider.delegate = delegate;
+                [(id<BTPaymentMethodCreationDelegate>)provider paymentMethodCreatorWillProcess:provider];
+                expect([provider status]).to.equal(BTPaymentProviderStatusProcessing);
             });
         });
 
@@ -145,6 +179,20 @@ describe(@"createPaymentMethod:", ^{
                 provider.delegate = delegate;
 
                 [provider createPaymentMethod:BTPaymentProviderTypePayPal];
+            });
+
+            it(@"provider has the right state and cancels view controller", ^{
+                [[delegate expect] paymentMethodCreator:provider requestsPresentationOfViewController:[OCMArg checkWithBlock:^BOOL(id obj) {
+                    return [obj isKindOfClass:[UIViewController class]];
+                }]];
+                [[delegate expect] paymentMethodCreatorDidCancel:[OCMArg isNotNil]];
+                [[delegate expect] paymentMethodCreator:[OCMArg checkWithBlock:^BOOL(id obj) {
+                    return [(BTPaymentProvider *)obj status] == BTPaymentProviderStatusCancelled;
+                }]
+                      requestsDismissalOfViewController:nil];
+                provider.delegate = delegate;
+                [provider createPaymentMethod:BTPaymentProviderTypePayPal];
+                [(id<BTPayPalViewControllerDelegate>)provider payPalViewControllerDidCancel:nil];
             });
         });
     });


### PR DESCRIPTION
This provides information about the status of the transaction by the time that requestsDismissalOfViewController: is called. See #73