### PR TITLE
Added missing `BT_ENABLE_APPLE_PAY` check

### DIFF
--- a/Braintree/API/@Public/BTClientToken.h
+++ b/Braintree/API/@Public/BTClientToken.h
@@ -96,6 +96,8 @@ extern NSString *const BTClientTokenPayPalNonLiveDefaultValueMerchantUserAgreeme
 
 - (NSString *)btVenmo_status;
 
+#if BT_ENABLE_APPLE_PAY
+
 #pragma mark Apple Pay
 
 @property (nonatomic, readonly, strong) NSDictionary *applePayConfiguration DEPRECATED_MSG_ATTRIBUTE("");
@@ -105,6 +107,8 @@ extern NSString *const BTClientTokenPayPalNonLiveDefaultValueMerchantUserAgreeme
 - (NSString *)applePayCurrencyCode;
 - (NSString *)applePayMerchantIdentifier;
 - (NSArray *)applePaySupportedNetworks;
+
+#endif
 
 #pragma mark -
 

--- a/Braintree/API/Client/BTClientToken.m
+++ b/Braintree/API/Client/BTClientToken.m
@@ -100,6 +100,8 @@ NSString *const BTClientTokenPayPalNonLiveDefaultValueMerchantUserAgreementUrl =
     return [self.configuration stringForKey:BTClientTokenKeyMerchantAccountId];
 }
 
+#if BT_ENABLE_APPLE_PAY
+
 - (NSDictionary *)applePayConfiguration {
     return [self.configuration dictionaryForKey:BTClientTokenKeyApplePay];
 }
@@ -124,6 +126,8 @@ NSString *const BTClientTokenPayPalNonLiveDefaultValueMerchantUserAgreementUrl =
     return [[self.configuration responseParserForKey:BTClientTokenKeyApplePay] arrayForKey:@"supportedNetworks"
                                                 withValueTransformer:[BTClientTokenApplePayPaymentNetworksValueTransformer sharedInstance]];
 }
+
+#endif
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     BTClientToken *copiedClientToken = [[[self class] allocWithZone:zone] init];


### PR DESCRIPTION
Without this, when `BT_ENABLE_APPLE_PAY` is undefined the compiler complains about `BTClientTokenApplePayStatusValueTransformer` not being defined.