### PR TITLE
[Bugfix] SSL Pinning should pass through unexpected authentication methods

### DIFF
--- a/Braintree/API/Networking/BTHTTP.m
+++ b/Braintree/API/Networking/BTHTTP.m
@@ -373,8 +373,8 @@
 }
 
 
-- (void)URLSession:(__unused NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler{
-    if ([[[challenge protectionSpace] authenticationMethod] isEqualToString: NSURLAuthenticationMethodServerTrust]) {
+- (void)URLSession:(__unused NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler {
+    if ([[[challenge protectionSpace] authenticationMethod] isEqualToString:NSURLAuthenticationMethodServerTrust]) {
         SecTrustRef serverTrust = [[challenge protectionSpace] serverTrust];
 
         BOOL ok = [self evaluateServerTrust:serverTrust forDomain:challenge.protectionSpace.host];
@@ -382,7 +382,7 @@
             NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
             completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
         } else {
-            completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
+            completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, NULL);
         }
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, NULL);

--- a/Braintree/API/Networking/BTHTTP.m
+++ b/Braintree/API/Networking/BTHTTP.m
@@ -179,7 +179,6 @@
         BTHTTPResponse *btHTTPResponse = [[BTHTTPResponse alloc] initWithStatusCode:httpResponse.statusCode responseObject:responseObject];
         NSError *returnedError = [self defaultDomainErrorForStatusCode:httpResponse.statusCode error:error];
         [self callCompletionBlock:completionBlock response:btHTTPResponse error:returnedError];
-
     } else {
         // Return error for unsupported response type
         NSError *returnedError = [NSError errorWithDomain:BTBraintreeAPIErrorDomain
@@ -376,7 +375,6 @@
 
 - (void)URLSession:(__unused NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler{
     if ([[[challenge protectionSpace] authenticationMethod] isEqualToString: NSURLAuthenticationMethodServerTrust]) {
-
         SecTrustRef serverTrust = [[challenge protectionSpace] serverTrust];
 
         BOOL ok = [self evaluateServerTrust:serverTrust forDomain:challenge.protectionSpace.host];
@@ -386,6 +384,8 @@
         } else {
             completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
         }
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, NULL);
     }
 }
 

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ namespace :spec do
     desc 'Run api integration tests'
     task :integration do
       with_https_server do
-        run! xctool('Braintree-API-Integration-Specs', 'test', :build_settings => {'GCC_PREPROCESSOR_DEFINITIONS' => 'SKIP_SSL_PINNING_SPECS=1'})
+        run! xctool('Braintree-API-Integration-Specs', 'test', :build_settings => {'GCC_PREPROCESSOR_DEFINITIONS' => 'RUN_SSL_PINNING_SPECS=1'})
       end
     end
   end

--- a/Specs/Braintree-API-Integration-Specs/BTHTTPSSLPinningSpec.m
+++ b/Specs/Braintree-API-Integration-Specs/BTHTTPSSLPinningSpec.m
@@ -2,11 +2,8 @@
 
 SpecBegin(BTHTTPSSLPinning)
 
-
 describe(@"SSL Pinning", ^{
-#ifdef SKIP_SSL_PINNING_SPECS
-    pending(@"specs only pass when run in Xcode");
-#else
+#ifdef RUN_SSL_PINNING_SPECS
     it(@"trusts pinned root certificates", ^{
         waitUntil(^(DoneCallback done){
             NSURL *url = [NSURL URLWithString:@"https://localhost:9443"];
@@ -20,7 +17,6 @@ describe(@"SSL Pinning", ^{
             }];
         });
     });
-#endif
 
     it(@"rejects an untrusted (unpinned) root certificates from otherwise legitimate hosts", ^{
         waitUntil(^(DoneCallback done){
@@ -55,34 +51,35 @@ describe(@"SSL Pinning", ^{
             }];
         });
     });
+#else
+    pending(@"specs only pass when run in Xcode");
+#endif
 
-    pending(@"gateway changes to support JSON heartbeats", ^{
-        describe(@"the default installed certificates", ^{
-            it(@"trusts the production ssl certificates", ^{
-                waitUntil(^(DoneCallback done){
-                    NSURL *url   = [NSURL URLWithString:@"https://api.braintreegateway.com"];
-                    BTHTTP *http = [[BTHTTP alloc] initWithBaseURL:url];
+    it(@"trusts the production ssl certificates", ^{
+        waitUntil(^(DoneCallback done){
+            NSURL *url   = [NSURL URLWithString:@"https://api.braintreegateway.com"];
+            BTHTTP *http = [[BTHTTP alloc] initWithBaseURL:url];
 
-                    [http GET:@"/heartbeat" completion:^(BTHTTPResponse *response, NSError *error) {
-                        expect(response.isSuccess).to.beTruthy();
-                        expect(error).to.beNil();
-                        done();
-                    }];
-                });
-            });
+            [http GET:@"/heartbeat.json" completion:^(BTHTTPResponse *response, NSError *error) {
+                expect(response.isSuccess).to.beTruthy();
+                expect([response.object stringForKey:@"heartbeat"]).to.equal(@"d2765eaa0dad9b300b971f074-production");
+                expect(error).to.beNil();
+                done();
+            }];
+        });
+    });
 
-            it(@"trusts the sandbox ssl certificates", ^{
-                waitUntil(^(DoneCallback done){
-                    NSURL *url   = [NSURL URLWithString:@"https://api.sandbox.braintreegateway.com"];
-                    BTHTTP *http = [[BTHTTP alloc] initWithBaseURL:url];
+    it(@"trusts the sandbox ssl certificates", ^{
+        waitUntil(^(DoneCallback done){
+            NSURL *url   = [NSURL URLWithString:@"https://api.sandbox.braintreegateway.com"];
+            BTHTTP *http = [[BTHTTP alloc] initWithBaseURL:url];
 
-                    [http GET:@"/heartbeat" completion:^(BTHTTPResponse *response, NSError *error) {
-                        expect(response.isSuccess).to.beTruthy();
-                        expect(error).to.beNil();
-                        done();
-                    }];
-                });
-            });
+            [http GET:@"/heartbeat.json" completion:^(BTHTTPResponse *response, NSError *error) {
+                expect(response.isSuccess).to.beTruthy();
+                expect([response.object stringForKey:@"heartbeat"]).to.equal(@"d2765eaa0dad9b300b971f074-sandbox");
+                expect(error).to.beNil();
+                done();
+            }];
         });
     });
 });

--- a/Specs/Braintree-API-Integration-Specs/BTHTTPSSLPinningSpec.m
+++ b/Specs/Braintree-API-Integration-Specs/BTHTTPSSLPinningSpec.m
@@ -52,7 +52,7 @@ describe(@"SSL Pinning", ^{
         });
     });
 #else
-    pending(@"specs only pass when run in Xcode");
+    pending(@"specs only pass when the test https server (https_server.rb) is running");
 #endif
 
     it(@"trusts the production ssl certificates", ^{


### PR DESCRIPTION
#### Background

Today, there was a configuration change in sandbox that caused our HTTP client to break. In particular, the sandbox began to request [SSL client certificates](https://docs.oracle.com/cd/E19424-01/820-4811/aakhe/index.html). Our [status page](https://status.braintreepayments.com/incidents/ypbc8csb6hpk) has more details about the incident.

Unfortunately, our HTTP client, `BTHTTP`, uses [SSL pinning code](https://github.com/braintree/braintree_ios/blob/3.5.0/Braintree/API/Networking/BTHTTP.m#L378-L389) that did not handle a challenge with this type of authentication method. Specifically, we never called the callback in 
our implementation of `URLSession:didReceiveChallenge:completionHandler:` when the authentication method type was anything other than `NSURLAuthenticationMethodServerTrust`. (Note the missing `else` [here](https://github.com/braintree/braintree_ios/blob/3.5.0/Braintree/API/Networking/BTHTTP.m#L389).)

#### Resolution

The primary issue has now resolved with deployment to our sandbox API servers, reverting the SSL client certificate request.

In addition, this PR fixes our SSL pinning code to avoid the "infinite spinning" in case of future changes to our server-side SSL implementation.

One thing that is missing here is a test case to reproduce the specific issue, but I do not know how to add client verification to the [test HTTPS server](https://github.com/braintree/braintree_ios/blob/3.5.0/Specs/Braintree-API-Integration-Specs/SSL/https_server.rb).