### PR TITLE
Fix wrapping of texts in SummaryView

### DIFF
--- a/Braintree/Drop-In/BTDropInContentView.m
+++ b/Braintree/Drop-In/BTDropInContentView.m
@@ -262,7 +262,7 @@
 }
 
 - (NSArray*) evaluateVisualFormat{
-    NSString *summaryViewVisualFormat = self.summaryView.hidden ? @"" : @"[summaryView(==60)]";
+    NSString *summaryViewVisualFormat = self.summaryView.hidden ? @"" : @"[summaryView(>=60)]";
     NSString *ctaControlVisualFormat = self.ctaControl.hidden ? @"" : @"[ctaControl(==50)]";
 
     if (self.state == BTDropInContentViewStateActivity) {

--- a/Braintree/UI/Views/Payments Components/BTUISummaryView.m
+++ b/Braintree/UI/Views/Payments Components/BTUISummaryView.m
@@ -30,9 +30,17 @@
 
     // Create subviews
     self.slugLabel = [[UILabel alloc] init];
+    self.slugLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    self.slugLabel.numberOfLines = 0;
+    
     self.summaryLabel = [[UILabel alloc] init];
+    self.summaryLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    self.summaryLabel.numberOfLines = 0;
+    
     self.amountLabel = [[UILabel alloc] init];
-
+    [self.amountLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
+    [self.amountLabel setContentHuggingPriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
+    
     [self setTheme:self.theme];
 
     // Configure subviews
@@ -67,31 +75,25 @@
                               @"horizontalMargin": @(self.theme.horizontalMargin)};
 
     // View Constraints
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[view(>=height)]"
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[view(>=height)]"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];
 
-    // Slug Label Constraints
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(horizontalMargin)-[slugLabel]"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-
-    // Amount Label Constraints
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[amountLabel]-(horizontalMargin)-|"
+    // Slug and Amount Label Constraints
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(horizontalMargin)-[slugLabel]-[amountLabel]-(horizontalMargin)-|"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];
 
     // Summary Label Constraints
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(horizontalMargin)-[summaryLabel]"
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(horizontalMargin)-[summaryLabel]-(horizontalMargin)-|"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];
 
     // Vertical Constraints
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(topPadding)-[slugLabel]-(middlePadding)-[summaryLabel]"
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(topPadding)-[slugLabel]-(middlePadding)-[summaryLabel]-(topPadding)-|"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];


### PR DESCRIPTION
This should fix https://github.com/braintree/braintree_ios/issues/101.

Please note that, since I'm not an Obj C developer, I haven't written any tests to validate correct behaviour. If anyone is more comfortable with the testing frameworks braintree uses, feel free to pick it up and add tests.

Here are two screenshots demonstrating the issue before and after the fix:
**Before fix**
![alt text](https://dl.dropboxusercontent.com/u/8948900/BeforeFix.png "Before the fix")
**After fix**
![alt text](https://dl.dropboxusercontent.com/u/8948900/AfterFix.png "After the fix")