### PR TITLE
Fix setupViews being called twice in BTPaymentButton

### DIFF
--- a/Braintree/Drop-In/BTPaymentButton.m
+++ b/Braintree/Drop-In/BTPaymentButton.m
@@ -24,9 +24,6 @@ NSString *BTPaymentButtonPaymentButtonCellIdentifier = @"BTPaymentButtonPaymentB
 
 - (id)init {
     self = [super init];
-    if (self) {
-        [self setupViews];
-    }
     return self;
 }
 


### PR DESCRIPTION
Also gets rid of "negative or zero sizes are not supported in the flow layout" log message when BTPaymentButton is shown.