### PR TITLE
Fix import of BraintreeCore.h

### DIFF
--- a/BraintreeApplePay/Public/BTConfiguration+ApplePay.h
+++ b/BraintreeApplePay/Public/BTConfiguration+ApplePay.h
@@ -1,4 +1,4 @@
-#import <BraintreeCore/BraintreeCore.h>
+#import "BraintreeCore.h"
 
 @interface BTConfiguration (ApplePay)
 


### PR DESCRIPTION
Fix the following error when integrating via CocoaPods with `use_frameworks!`

'BraintreeCore/BraintreeCore.h' file not found