### PR TITLE
Hotfix/ios8 paymentmethod

### DIFF
--- a/Braintree/API/Client/BTClient.m
+++ b/Braintree/API/Client/BTClient.m
@@ -338,25 +338,28 @@
     if (encodedPaymentData) {
         tokenParameterValue[@"paymentData"] = encodedPaymentData;
     }
-
+	
+	if ([payment.token respondsToSelector:@selector(paymentMethod)]) {
+		if (payment.token.paymentMethod.network) {
+			tokenParameterValue[@"paymentNetwork"] = payment.token.paymentMethod.network;
+		}
+		
+		if (payment.token.paymentMethod.displayName) {
+			tokenParameterValue[@"paymentInstrumentName"] = payment.token.paymentMethod.displayName;
+		}
+	}else
+	{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if (payment.token.paymentInstrumentName) {
-        tokenParameterValue[@"paymentInstrumentName"] = payment.token.paymentInstrumentName;
-    }
-    
-    if (payment.token.paymentNetwork) {
-        tokenParameterValue[@"paymentNetwork"] = payment.token.paymentNetwork;
-    }
+		if (payment.token.paymentInstrumentName) {
+			tokenParameterValue[@"paymentInstrumentName"] = payment.token.paymentInstrumentName;
+		}
+		
+		if (payment.token.paymentNetwork) {
+			tokenParameterValue[@"paymentNetwork"] = payment.token.paymentNetwork;
+		}
 #pragma clang diagnostic pop
-    
-    if (payment.token.paymentMethod.network) {
-        tokenParameterValue[@"paymentNetwork"] = payment.token.paymentMethod.network;
-    }
-    
-    if (payment.token.paymentMethod.displayName) {
-        tokenParameterValue[@"paymentInstrumentName"] = payment.token.paymentMethod.displayName;
-    }
+	}
 
     if (payment.token.transactionIdentifier) {
         tokenParameterValue[@"transactionIdentifier"] = payment.token.transactionIdentifier;

--- a/Braintree/API/Client/BTClient.m
+++ b/Braintree/API/Client/BTClient.m
@@ -378,13 +378,26 @@
                 BTMutableApplePayPaymentMethod *paymentMethod = [applePayCards firstObject];
 
                 paymentMethod.shippingMethod = payment.shippingMethod;
+				
+				if ([payment respondsToSelector:@selector(shippingContact)]) {
+					paymentMethod.shippingContact = payment.shippingContact;
+				}else
+				{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                paymentMethod.shippingAddress = payment.shippingAddress;
-                paymentMethod.billingAddress = payment.billingAddress;
+					paymentMethod.shippingAddress = payment.shippingAddress;
 #pragma clang diagnostic pop
-                paymentMethod.shippingContact = payment.shippingContact;
-                paymentMethod.billingContact = payment.billingContact;
+				}
+				
+				if ([payment respondsToSelector:@selector(billingContact)]) {
+					paymentMethod.billingContact = payment.billingContact;
+				}else
+				{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+					paymentMethod.billingAddress = payment.billingAddress;
+#pragma clang diagnostic pop
+				}
                 
                 successBlock([paymentMethod copy]);
             }


### PR DESCRIPTION
The last version of the sdk breaks backward compatibility with Apple Pay on iOS8.
The BTClient is using both the new iOS9 and the old iOS8 properties for PKPayment and PKPaymentToken without validating if they actually exist at runtime.

I added the corresponding validation checks.

Please check the interface changes on the following ApplePay objects:
https://developer.apple.com/library/prerelease/ios/documentation/PassKit/Reference/PKPayment_Ref/index.html#//apple_ref/occ/instp/PKPayment/shippingAddress
https://developer.apple.com/library/ios/documentation/PassKit/Reference/PKPaymentToken_Ref/#//apple_ref/occ/instp/PKPaymentToken/paymentInstrumentName 

Best,
Juan