### PR TITLE
Prevent calling requestsDismissalOfViewController

### DIFF
--- a/BraintreePayPal/BTPayPalDriver.m
+++ b/BraintreePayPal/BTPayPalDriver.m
@@ -317,7 +317,10 @@ typedef NS_ENUM(NSUInteger, BTPayPalPaymentType) {
 - (void)setAppSwitchReturnBlock:(void (^)(BTPayPalAccountNonce *tokenizedAccount, NSError *error))completionBlock
                  forPaymentType:(BTPayPalPaymentType)paymentType {
     appSwitchReturnBlock = ^(NSURL *url) {
-        [self informDelegatePresentingViewControllerNeedsDismissal];
+        if (self.safariViewController) {
+            [self informDelegatePresentingViewControllerNeedsDismissal];
+        }
+
         [self informDelegateWillProcessAppSwitchReturn];
         
         // Before parsing the return URL, check whether the user cancelled by breaking


### PR DESCRIPTION
This fix prevents calling requestsDismissalOfViewController when there is nothing to dismiss. The same way `requestsPresentationOfViewController` is not being called when there is nothing to present.

Before this, the library was crashing on runtime when using swift and iOS < 9 as this is passing `nil` to a function signature that is marked as `non_null`.