### PR TITLE
Add missing _Nullable specification

### DIFF
--- a/BraintreePayPal/PayPalOneTouch/Analytics/PPFPTITracker.h
+++ b/BraintreePayPal/PayPalOneTouch/Analytics/PPFPTITracker.h
@@ -33,7 +33,7 @@
 
 
 /// The delegate which actually sends the data
-@property (nonatomic, weak, readwrite) id<PPFPTINetworkAdapterDelegate> networkAdapterDelegate;
+@property (nonatomic, weak, readwrite, nullable) id<PPFPTINetworkAdapterDelegate> networkAdapterDelegate;
 
 /// Sends an event with various metrics and data
 ///


### PR DESCRIPTION
This missing specifier is preventing the project to build in Xcode 7.3 (beta 3). I realize 7.3 is not officially released and things could change between now and the final release, but it's probably good to add this regardless of Xcode version.