### PR TITLE
Fix the flow issue when choosing paypal from inner adding payment met…

### DIFF
--- a/BraintreeUI/Drop-In/BTDropInViewController.m
+++ b/BraintreeUI/Drop-In/BTDropInViewController.m
@@ -685,10 +685,15 @@
         
         [errorAlert show];
     } else if (paymentMethodNonce) {
-        NSMutableArray *newPaymentMethods = [NSMutableArray arrayWithArray:self.paymentMethodNonces];
-        [newPaymentMethods insertObject:paymentMethodNonce atIndex:0];
-        self.paymentMethodNonces = newPaymentMethods;
-        [self informDelegateDidAddPaymentInfo:paymentMethodNonce];
+        if ([viewController isKindOfClass:[self class]] && ((BTDropInViewController *)viewController).delegate == self) {
+            // From the inner add payment method view controller
+            [self dropInViewController:(BTDropInViewController *)viewController didSucceedWithTokenization:paymentMethodNonce];
+        } else {
+            NSMutableArray *newPaymentMethods = [NSMutableArray arrayWithArray:self.paymentMethodNonces];
+            [newPaymentMethods insertObject:paymentMethodNonce atIndex:0];
+            self.paymentMethodNonces = newPaymentMethods;
+            [self informDelegateDidAddPaymentInfo:paymentMethodNonce];
+        }
     } else {
         // Refresh payment methods display
         self.paymentMethodNonces = self.paymentMethodNonces;


### PR DESCRIPTION
Currently if I present a `BTDropInViewController` from my own view controller, then tap "change payment method", tap "+" on the navigation bar to add a payment method, then select Paypal. After Paypal flow is done, my own view controller will be notified directly through `dropInViewController:didSucceedWithTokenization` delegate method, which is wrong (At least It's very different from other flows).

I think the correct flow here is to return to the "Payment Method Selection" view, where user can see the new added Paypal method, and can tap 'Pay' button there.

