### PR TITLE
Update theme on child components if set/changed

### DIFF
--- a/BraintreeUI/Views/Custom Views/BTUIFloatLabel.m
+++ b/BraintreeUI/Views/Custom Views/BTUIFloatLabel.m
@@ -109,6 +109,15 @@
     }
 }
 
+#pragma mark - Theme
+
+- (void)setTheme:(BTUI *)theme {
+  [super setTheme:theme];
+  
+  self.label.font = self.theme.textFieldFloatLabelFont;
+  self.label.textColor = self.theme.textFieldFloatLabelTextColor;
+}
+
 - (NSDictionary *)viewBindings {
     return @{ @"label": self.label };
 }

--- a/BraintreeUI/Views/Forms/BTUICardFormView.m
+++ b/BraintreeUI/Views/Forms/BTUICardFormView.m
@@ -190,6 +190,17 @@
 
 }
 
+#pragma mark - Theme
+
+- (void)setTheme:(BTUI *)theme {
+  [super setTheme:theme];
+  
+  _numberField.theme = theme;
+  _expiryField.theme = theme;
+  _cvvField.theme = theme;
+  _postalCodeField.theme = theme;
+}
+
 #pragma mark - Drawing
 
 - (void)drawRect:(CGRect)rect {


### PR DESCRIPTION
If you setup a theme on `BTUICardFormView` it's not correctly propagated to children for fields and float labels. This patch does that.