### PR TITLE
BTAPIClient.h - Update init unavailable message

### DIFF
--- a/BraintreeCore/Public/BTAPIClient.h
+++ b/BraintreeCore/Public/BTAPIClient.h
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSInteger, BTAPIClientErrorType) {
   parameters:(nullable NSDictionary *)parameters
   completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
 
-- (instancetype)init __attribute__((unavailable("Use initWithClientKeyOrToken: instead.")));
+- (instancetype)init __attribute__((unavailable("Use initWithAuthorization: instead.")));
 
 @end
 


### PR DESCRIPTION
Developers should use `initWithAuthorization:`