### PR TITLE
Do not call viewControllerPresentingDelegate for dismissal if breakout via Done button

### DIFF
--- a/BraintreePayPal/BTPayPalDriver.m
+++ b/BraintreePayPal/BTPayPalDriver.m
@@ -328,17 +328,17 @@ typedef NS_ENUM(NSUInteger, BTPayPalPaymentType) {
 - (void)setAppSwitchReturnBlock:(void (^)(BTPayPalAccountNonce *tokenizedAccount, NSError *error))completionBlock
                  forPaymentType:(BTPayPalPaymentType)paymentType {
     appSwitchReturnBlock = ^(NSURL *url) {
-        if (self.safariViewController) {
-            [self informDelegatePresentingViewControllerNeedsDismissal];
-        } else {
-            [self informDelegateWillProcessAppSwitchReturn];
-        }
-        
         // Before parsing the return URL, check whether the user cancelled by breaking
         // out of the PayPal app switch flow (e.g. "Done" button in SFSafariViewController)
         if ([url.absoluteString isEqualToString:SFSafariViewControllerFinishedURL]) {
             if (completionBlock) completionBlock(nil, nil);
             return;
+        }
+        
+        if (self.safariViewController) {
+            [self informDelegatePresentingViewControllerNeedsDismissal];
+        } else {
+            [self informDelegateWillProcessAppSwitchReturn];
         }
         
         [[self.class payPalClass] parseResponseURL:url completionBlock:^(PPOTResult *result) {


### PR DESCRIPTION
On iOS 10 when the PayPal flow is presented in a SFSafariViewController a user can break out by pressing the builtin 'Done' button. (as addressed in a2af94cf5d01b06e0cf81834ad3cb3f543ac984c back in Oct 2015 and then again here 077ee24aafacfc6d019141eb823cbb39bdf1c330 and here c7ee6748a1ce4c2b528dcb1cd52642b36602763d).

Currently if the PayPal view is presented on an already presented view controller, the act of hitting the 'Done' button will dismiss PayPal AND dismiss the first party view controller that was underneath it.

All this PR does is move the existing check for the `SFSafariViewControllerFinishedURL` to before the `informDelegatePresentingViewControllerNeedsDismissal` method. This prevents the delegate from being called if the `SFSafariViewController` is being cancelled via the 'Done' button and therefore prevents the double dismissal.

The existing behaviour for dismissal when either tapping the X in the top right hand corner of the PayPal UI or successfully authenticating still both occur as expected.

Thanks