### PR TITLE
[fix] Add app extension compatibility

### DIFF
--- a/BraintreeCore/BTAnalyticsMetadata.m
+++ b/BraintreeCore/BTAnalyticsMetadata.m
@@ -175,8 +175,13 @@
     if ([UIApplication class] == nil) {
         return nil;
     }
-
-    UIInterfaceOrientation deviceOrientation = [[[[UIApplication sharedApplication] keyWindow] rootViewController] interfaceOrientation];
+    
+    if ([self.class isAppExtension]) {
+        return nil;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
+    UIInterfaceOrientation deviceOrientation = [[[sharedApplication keyWindow] rootViewController] interfaceOrientation];
 
     switch (deviceOrientation) {
         case UIInterfaceOrientationPortrait:
@@ -219,24 +224,46 @@
 }
 
 - (BOOL)isPaypalInstalled {
+    if ([self.class isAppExtension]) {
+        return false;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
     static BOOL paypalInstalled;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURL *paypalV1URL = [NSURL URLWithString:@"com.paypal.ppclient.touch.v1://"];
         NSURL *paypalV2URL = [NSURL URLWithString:@"com.paypal.ppclient.touch.v2://"];
-        paypalInstalled = [[UIApplication sharedApplication] canOpenURL:paypalV1URL] || [[UIApplication sharedApplication] canOpenURL:paypalV2URL];
+        paypalInstalled = [sharedApplication canOpenURL:paypalV1URL] || [sharedApplication canOpenURL:paypalV2URL];
     });
     return paypalInstalled;
 }
 
 - (BOOL)isVenmoInstalled {
+    if ([self.class isAppExtension]) {
+        return false;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
     static BOOL venmoInstalled;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURL *venmoURL = [NSURL URLWithString:@"com.venmo.touch.v2://x-callback-url/vzero/auth"];
-        venmoInstalled = [[UIApplication sharedApplication] canOpenURL:venmoURL];
+        venmoInstalled = [sharedApplication canOpenURL:venmoURL];
     });
     return venmoInstalled;
+}
+    
++ (BOOL)isAppExtension {
+    static BOOL isExtension;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        NSDictionary *extensionDictionary = [[NSBundle mainBundle] infoDictionary][@"NSExtension"];
+        isExtension = [extensionDictionary isKindOfClass:[NSDictionary class]];
+    });
+    
+    return isExtension;
 }
 
 @end


### PR DESCRIPTION
#290 

This is the implementation that was used in PINCache: https://github.com/pinterest/PINCache/pull/72

It has since been removed, but as far as I can tell, only because the feature requiring `[UIApplication sharedApplication]` was removed as well:
https://github.com/pinterest/PINCache/pull/99