### PR TITLE
Add support for App Extensions

### DIFF
--- a/BraintreeCore/BTAnalyticsMetadata.m
+++ b/BraintreeCore/BTAnalyticsMetadata.m
@@ -225,7 +225,7 @@
 
 - (BOOL)isPaypalInstalled {
     if ([self.class isAppExtension]) {
-        return false;
+        return NO;
     }
     
     UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
@@ -241,7 +241,7 @@
 
 - (BOOL)isVenmoInstalled {
     if ([self.class isAppExtension]) {
-        return false;
+        return NO;
     }
     
     UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];

--- a/BraintreeCore/BTAnalyticsMetadata.m
+++ b/BraintreeCore/BTAnalyticsMetadata.m
@@ -175,8 +175,13 @@
     if ([UIApplication class] == nil) {
         return nil;
     }
-
-    UIInterfaceOrientation deviceOrientation = [[[[UIApplication sharedApplication] keyWindow] rootViewController] interfaceOrientation];
+    
+    if ([self.class isAppExtension]) {
+        return nil;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
+    UIInterfaceOrientation deviceOrientation = [[[sharedApplication keyWindow] rootViewController] interfaceOrientation];
 
     switch (deviceOrientation) {
         case UIInterfaceOrientationPortrait:
@@ -219,24 +224,46 @@
 }
 
 - (BOOL)isPaypalInstalled {
+    if ([self.class isAppExtension]) {
+        return false;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
     static BOOL paypalInstalled;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURL *paypalV1URL = [NSURL URLWithString:@"com.paypal.ppclient.touch.v1://"];
         NSURL *paypalV2URL = [NSURL URLWithString:@"com.paypal.ppclient.touch.v2://"];
-        paypalInstalled = [[UIApplication sharedApplication] canOpenURL:paypalV1URL] || [[UIApplication sharedApplication] canOpenURL:paypalV2URL];
+        paypalInstalled = [sharedApplication canOpenURL:paypalV1URL] || [sharedApplication canOpenURL:paypalV2URL];
     });
     return paypalInstalled;
 }
 
 - (BOOL)isVenmoInstalled {
+    if ([self.class isAppExtension]) {
+        return false;
+    }
+    
+    UIApplication *sharedApplication = [UIApplication performSelector:@selector(sharedApplication)];
     static BOOL venmoInstalled;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURL *venmoURL = [NSURL URLWithString:@"com.venmo.touch.v2://x-callback-url/vzero/auth"];
-        venmoInstalled = [[UIApplication sharedApplication] canOpenURL:venmoURL];
+        venmoInstalled = [sharedApplication canOpenURL:venmoURL];
     });
     return venmoInstalled;
+}
+    
++ (BOOL)isAppExtension {
+    static BOOL isExtension;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        NSDictionary *extensionDictionary = [[NSBundle mainBundle] infoDictionary][@"NSExtension"];
+        isExtension = [extensionDictionary isKindOfClass:[NSDictionary class]];
+    });
+    
+    return isExtension;
 }
 
 @end

--- a/BraintreeCore/BTAnalyticsMetadata.m
+++ b/BraintreeCore/BTAnalyticsMetadata.m
@@ -201,6 +201,9 @@
 }
 
 - (NSString *)deviceScreenOrientation {
+    if ([self.class isAppExtension]) {
+        return @"AppExtension";
+    }
     if ([UIDevice class] == nil) {
         return nil;
     }
@@ -255,15 +258,8 @@
 }
     
 + (BOOL)isAppExtension {
-    static BOOL isExtension;
-    static dispatch_once_t onceToken;
-    
-    dispatch_once(&onceToken, ^{
-        NSDictionary *extensionDictionary = [[NSBundle mainBundle] infoDictionary][@"NSExtension"];
-        isExtension = [extensionDictionary isKindOfClass:[NSDictionary class]];
-    });
-    
-    return isExtension;
+    NSDictionary *extensionDictionary = [[NSBundle mainBundle] infoDictionary][@"NSExtension"];
+    return [extensionDictionary isKindOfClass:[NSDictionary class]];
 }
 
 @end

--- a/UnitTests/BTAnalyticsMetadataSpec.m
+++ b/UnitTests/BTAnalyticsMetadataSpec.m
@@ -130,6 +130,12 @@ describe(@"metadata", ^{
             expect([BTAnalyticsMetadata metadata][@"deviceScreenOrientation"]).to.equal(@"FaceUp");
             [mockDevice stopMocking];
         });
+        it(@"returns AppExtension when running in an App Extension", ^{
+            id stubMainBundle = OCMPartialMock([NSBundle mainBundle]);
+            OCMStub([stubMainBundle infoDictionary]).andReturn(@{@"NSExtension": @{}});
+            expect([BTAnalyticsMetadata metadata][@"deviceScreenOrientation"]).to.equal(@"AppExtension");
+            [stubMainBundle stopMocking];
+        });
     });
     describe(@"userInterfaceOrientation", ^{
         it(@"returns the user interface orientation, e.g. Portrait or Landscape", ^{


### PR DESCRIPTION
See also https://github.com/braintree/braintree_ios/pull/291

### Summary

When running in an iOS app extension, we don't have access to `[UIApplication sharedApplication]`, which is used in BraintreeCore's BTAnalyticsMetadata.

We've also hijacked the `deviceScreenOrientation` analytics property to return `AppExtension` when running inside an app extension, which may be useful later.