### PR TITLE
Enabling BTMockApplePayPaymentAuthorizationViewController

### DIFF
--- a/BraintreeCore/BTAnalyticsMetadata.m
+++ b/BraintreeCore/BTAnalyticsMetadata.m
@@ -1,4 +1,4 @@
-#import "BTAnalyticsMetaData.h"
+#import "BTAnalyticsMetadata.h"
 
 #import "Braintree-Version.h"
 #import "BTKeychain.h"

--- a/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationView.h
+++ b/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationView.h
@@ -1,11 +1,10 @@
-#if BT_ENABLE_APPLE_PAY
 #import <UIKit/UIKit.h>
 
 @protocol BTMockApplePayPaymentAuthorizationViewDelegate;
 
 @interface BTMockApplePayPaymentAuthorizationView : UIView
 
-- (instancetype)initWithDelegate:(id<BTMockApplePayPaymentAuthorizationViewDelegate>)delegate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(id<BTMockApplePayPaymentAuthorizationViewDelegate>)delegate;
 
 @end
 
@@ -15,4 +14,3 @@
 - (void)mockApplePayPaymentAuthorizationViewDidCancel:(BTMockApplePayPaymentAuthorizationView *)view;
 
 @end
-#endif

--- a/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationView.m
+++ b/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationView.m
@@ -1,4 +1,3 @@
-#if BT_ENABLE_APPLE_PAY
 #import "BTMockApplePayPaymentAuthorizationView.h"
 
 @interface BTMockApplePayPaymentAuthorizationView () <UITableViewDataSource, UITableViewDelegate>
@@ -97,4 +96,3 @@ NSString *const BTMockApplePayPaymentAuthorizationControlCell =  @"BTMockApplePa
 }
 
 @end
-#endif

--- a/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationViewController.h
+++ b/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationViewController.h
@@ -1,4 +1,3 @@
-#if BT_ENABLE_APPLE_PAY
 #import <UIKit/UIKit.h>
 @import PassKit;
 
@@ -8,7 +7,7 @@
 
 @property (nonatomic, weak) id<BTMockApplePayPaymentAuthorizationViewControllerDelegate> delegate;
 
-- (instancetype)initWithPaymentRequest:(PKPaymentRequest *)request NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithPaymentRequest:(PKPaymentRequest *)request;
 
 + (BOOL)canMakePayments;
 
@@ -23,4 +22,3 @@
 - (void)mockApplePayPaymentAuthorizationViewControllerDidFinish:(BTMockApplePayPaymentAuthorizationViewController *)viewController;
 
 @end
-#endif

--- a/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationViewController.m
+++ b/BraintreeUI/Views/Apple Pay/BTMockApplePayPaymentAuthorizationViewController.m
@@ -1,4 +1,3 @@
-#if BT_ENABLE_APPLE_PAY
 #import "BTMockApplePayPaymentAuthorizationViewController.h"
 
 #import "BTMockApplePayPaymentAuthorizationView.h"
@@ -65,4 +64,3 @@
 }
 
 @end
-#endif


### PR DESCRIPTION
Enabling BTMockApplePayPaymentAuthorizationView, BTMockApplePayPaymentAuthorizationViewController and fixing NS_DESIGNATED_INITIALIZER build issue.

since BT_ENABLE_APPLE_PAY is no longer needed we need to cancel the pre-proccesing macro protection.