### PR TITLE
Make CI passable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 install:
   - bundle install
-  - bundle exec pod repo update
+  - bundle exec pod repo update --silent
   - bundle exec pod install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
   - bundle install
   - bundle exec pod repo update --silent
-  - bundle exec pod install
+  - bundle exec pod install || { rm -rf ./Pods; bundle exec pod install; }
 
 script:
   - echo $SIMULATOR_ID

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   BraintreeDropIn:
-    :commit: 76720563ac5f2eed1a7a366111a97edc123e4c32
+    :commit: f4959b823bea51c5ccaee40bd33de5963ce41473
     :git: https://github.com/braintree/braintree-ios-drop-in.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
As titled.

It seems that `pod install` fails if BraintreeDropIn is already installed under ./Pods directory and its latest commit hash differs from the hash written in .lock file. So as a workaround, delete ./Pods directory and retry installation when `pod install` failed.