### PR TITLE
Fixing compilation under Xcode 8.3 beta.

### DIFF
--- a/Braintree/API/Utility/BTAnalyticsMetadata.m
+++ b/Braintree/API/Utility/BTAnalyticsMetadata.m
@@ -1,4 +1,4 @@
-#import "BTAnalyticsMetaData.h"
+#import "BTAnalyticsMetadata.h"
 #import "BTClient.h"
 
 #import "BTKeychain.h"


### PR DESCRIPTION
Xcode 8.3 beta has new errors when importing files under with the wrong case. In this case, there was "Meta*D*ata", while the file is named "Meta*d*ata".