### PR TITLE
Resolve build errors in XCode 8.3  caused by the use incorrect case o…

### DIFF
--- a/Braintree/API/Utility/BTAnalyticsMetadata.m
+++ b/Braintree/API/Utility/BTAnalyticsMetadata.m
@@ -1,4 +1,4 @@
-#import "BTAnalyticsMetaData.h"
+#import "BTAnalyticsMetadata.h"
 #import "BTClient.h"
 
 #import "BTKeychain.h"

--- a/Braintree/Drop-In/BTDropInSelectPaymentMethodViewController.m
+++ b/Braintree/Drop-In/BTDropInSelectPaymentMethodViewController.m
@@ -2,7 +2,7 @@
 #import "BTDropInUtil.h"
 #import "BTUIViewUtil.h"
 #import "BTUI.h"
-#import "BTDropinViewController.h"
+#import "BTDropInViewController.h"
 #import "BTDropInLocalizedString.h"
 #import "BTUILocalizedString.h"
 


### PR DESCRIPTION
    Resolve build errors in XCode 8.3  caused by the use incorrect case of include files