### PR TITLE
Fix documentation issue

### DIFF
--- a/BraintreePayPal/PayPalOneTouch/Public/PPOTRequest.h
+++ b/BraintreePayPal/PayPalOneTouch/Public/PPOTRequest.h
@@ -9,6 +9,8 @@
 
 /*!
  @brief Completion block for receiving the result of preflighting a request
+ 
+ Target can be `PPOTRequestTargetBrowser`, `PPOTRequestTargetOnDeviceApplication`, or `PPPOTRequestTargetNone`
 */
 typedef void (^PPOTRequestPreflightCompletionBlock) (PPOTRequestTarget target);
 
@@ -39,8 +41,6 @@ extern NSString * _Nonnull const PayPalEnvironmentMock;
 
 /*!
  @brief Optional preflight method, to determine in advance to which app we will switch when this request's `performWithCompletionBlock:` method is called.
-
- @return `PPOTRequestTargetBrowser`, `PPOTRequestTargetOnDeviceApplication`, or `PPPOTRequestTargetNone`
 
  @note As currently implemented, `completionBlock` will be called synchronously.
  We use a completion block here to allow for future changes in implementation that might cause


### PR DESCRIPTION
'@return' command used in a comment that is attached to a method returning void