### PR TITLE
Update BraintreePayPal framework to support system/framework imports

### DIFF
--- a/BraintreePayPal/BTPayPalDriver.m
+++ b/BraintreePayPal/BTPayPalDriver.m
@@ -1,7 +1,12 @@
 #import "BTPayPalDriver_Internal.h"
 
+#if __has_include("PayPalOneTouch.h")
 #import "PPOTRequest.h"
 #import "PPOTCore.h"
+#else
+#import <PayPalOneTouch/PPOTRequest.h>
+#import <PayPalOneTouch/PPOTCore.h>
+#endif
 
 #if __has_include("BraintreeCore.h")
 #import "BTAPIClient_Internal.h"
@@ -10,11 +15,17 @@
 #import "BTLogger_Internal.h"
 #else
 #import <BraintreeCore/BTAPIClient_Internal.h>
-#import <BraintreeCore/BTPayPalAccountNonce_Internal.h>
-#import <BraintreeCore/BTTokenizedPayPalCheckout_Internal.h>
 #import <BraintreeCore/BTPostalAddress.h>
 #import <BraintreeCore/BTLogger_Internal.h>
 #endif
+
+#if __has_include("BTPayPalAccountNonce_Internal.h")
+#import "BTPayPalAccountNonce_Internal.h"
+#else
+#import <BraintreePayPal/BTPayPalAccountNonce_Internal.h>
+#endif
+
+
 #import <SafariServices/SafariServices.h>
 #import "BTConfiguration+PayPal.h"
 

--- a/BraintreePayPal/BTPayPalRequestFactory.h
+++ b/BraintreePayPal/BTPayPalRequestFactory.h
@@ -1,6 +1,12 @@
 #import <Foundation/Foundation.h>
+
+#if __has_include("PayPalOneTouch.h")
 #import "PPOTRequest.h"
 #import "PPOTCore.h"
+#else
+#import <PayPalOneTouch/PPOTRequest.h>
+#import <PayPalOneTouch/PPOTCore.h>
+#endif
 
 @interface BTPayPalRequestFactory : NSObject
 

--- a/BraintreePayPal/BTPayPalRequestFactory.m
+++ b/BraintreePayPal/BTPayPalRequestFactory.m
@@ -1,5 +1,9 @@
 #import "BTPayPalRequestFactory.h"
+#if __has_include("PPOTRequestFactory.h")
 #import "PPOTRequestFactory.h"
+#else
+#import <PayPalOneTouch/PPOTRequestFactory.h>
+#endif
 
 @implementation BTPayPalRequestFactory
 

--- a/BraintreePayPal/PayPalDataCollector/PPDataCollector.m
+++ b/BraintreePayPal/PayPalDataCollector/PPDataCollector.m
@@ -7,11 +7,17 @@
 
 #import "PPDataCollector_Internal.h"
 #import "PPRCClientMetadataIDProvider.h"
-
+#if __has_include("PayPalUtils.h")
 #import "PPOTDevice.h"
 #import "PPOTVersion.h"
 #import "PPOTMacros.h"
 #import "PPOTURLSession.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTVersion.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTURLSession.h>
+#endif
 
 @implementation PPDataCollector
 

--- a/BraintreePayPal/PayPalOneTouch/Analytics/PPFPTITracker.m
+++ b/BraintreePayPal/PayPalOneTouch/Analytics/PPFPTITracker.m
@@ -8,10 +8,15 @@
 #import <UIKit/UIKit.h>
 
 #import "PPFPTITracker.h"
-
 #import "PPFPTIData.h"
+
+#if __has_include("PayPalUtils.h")
 #import "PPOTDevice.h"
 #import "PPOTVersion.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTVersion.h>
+#endif
 
 static NSString* const kTrackerURLAsNSString = @"https://api-m.paypal.com/v1/tracking/events";
 

--- a/BraintreePayPal/PayPalOneTouch/Analytics/PPOTAnalyticsTracker.m
+++ b/BraintreePayPal/PayPalOneTouch/Analytics/PPOTAnalyticsTracker.m
@@ -10,12 +10,21 @@
 #import "PPOTAnalyticsTracker.h"
 
 #import "PPOTCore_Internal.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTVersion.h"
 #import "PPOTDevice.h"
 #import "PPOTMacros.h"
 #import "PPOTSimpleKeychain.h"
 #import "PPOTString.h"
 #import "PPOTURLSession.h"
+#else
+#import <PayPalUtils/PPOTVersion.h>
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTSimpleKeychain.h>
+#import <PayPalUtils/PPOTString.h>
+#import <PayPalUtils/PPOTURLSession.h>
+#endif
 #import "PPFPTIData.h"
 #import "PPFPTITracker.h"
 #import "PPOTAnalyticsDefines.h"

--- a/BraintreePayPal/PayPalOneTouch/Configuration/PPOTConfiguration.m
+++ b/BraintreePayPal/PayPalOneTouch/Configuration/PPOTConfiguration.m
@@ -6,10 +6,17 @@
 //
 
 #import "PPOTConfiguration.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTJSONHelper.h"
 #import "PPOTMacros.h"
 #import "PPOTSimpleKeychain.h"
 #import "PPOTURLSession.h"
+#else
+#import <PayPalUtils/PPOTJSONHelper.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTSimpleKeychain.h>
+#import <PayPalUtils/PPOTURLSession.h>
+#endif
 #if __has_include("BraintreeCore.h")
 #import "BTLogger_Internal.h"
 #else

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTAppSwitchResponse.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTAppSwitchResponse.m
@@ -6,10 +6,17 @@
 //
 
 #import "PPOTAppSwitchResponse.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTString.h"
 #import "PPOTTime.h"
 #import "PPOTEncryptionHelper.h"
 #import "PPOTJSONHelper.h"
+#else
+#import <PayPalUtils/PPOTString.h>
+#import <PayPalUtils/PPOTTime.h>
+#import <PayPalUtils/PPOTEncryptionHelper.h>
+#import <PayPalUtils/PPOTJSONHelper.h>
+#endif
 
 @implementation PPOTAppSwitchResponse
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTAppSwitchUtil.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTAppSwitchUtil.m
@@ -8,13 +8,20 @@
 
 #import "PPOTAppSwitchUtil.h"
 #import "PPOTConfiguration.h"
-#import "PPOTMacros.h"
+#import "PPOTAnalyticsDefines.h"
 #import "PPOTAnalyticsTracker.h"
-#import "PPOTVersion.h"
 #import "PPOTPersistentRequestData.h"
+#if __has_include("PayPalUtils.h")
+#import "PPOTMacros.h"
+#import "PPOTVersion.h"
 #import "PPOTString.h"
 #import "PPOTJSONHelper.h"
-#import "PPOTAnalyticsDefines.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTVersion.h>
+#import <PayPalUtils/PPOTString.h>
+#import <PayPalUtils/PPOTJSONHelper.h>
+#endif
 
 #define STR_TO_URL_SCHEME(str) [NSURL URLWithString:[NSString stringWithFormat:@"%@://", str]]
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTAuthorizationRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTAuthorizationRequest.m
@@ -8,12 +8,19 @@
 #import "PPOTRequest_Internal.h"
 #import "PPOTAppSwitchUtil.h"
 #import "PPOTConfiguration.h"
-#import "PPOTDevice.h"
-#import "PPOTMacros.h"
 #import "PPOTOAuth2AppSwitchRequest.h"
 #import "PPOTOAuth2BrowserSwitchRequest.h"
+#if __has_include("PayPalUtils.h")
+#import "PPOTDevice.h"
+#import "PPOTMacros.h"
 #import "PPOTEncryptionHelper.h"
 #import "PPOTString.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTEncryptionHelper.h>
+#import <PayPalUtils/PPOTString.h>
+#endif
 
 #define PPRequestEnvironmentDevelop  @"develop"
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTBillingAgreementRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTBillingAgreementRequest.m
@@ -9,8 +9,13 @@
 #import "PPOTCheckoutAppSwitchRequest.h"
 #import "PPOTCheckoutBrowserSwitchRequest.h"
 #import "PPOTConfiguration.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTDevice.h"
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 #pragma mark - PPOTBillingAgreementRequest implementation
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutAppSwitchRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutAppSwitchRequest.m
@@ -6,7 +6,11 @@
 //
 
 #import "PPOTCheckoutAppSwitchRequest.h"
+#if __has_include("PPOTMacros.h")
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 @implementation PPOTCheckoutAppSwitchRequest
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutBrowserSwitchRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutBrowserSwitchRequest.m
@@ -8,9 +8,15 @@
 #import "PPOTCheckoutBrowserSwitchRequest.h"
 #import "PPOTAppSwitchUtil.h"
 #import "PPOTPersistentRequestData.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTTime.h"
 #import "PPOTString.h"
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTTime.h>
+#import <PayPalUtils/PPOTString.h>
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 // TODO: have a factory/builder/json reader of sandbox, mock, etc
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTCheckoutRequest.m
@@ -9,8 +9,13 @@
 #import "PPOTCheckoutAppSwitchRequest.h"
 #import "PPOTCheckoutBrowserSwitchRequest.h"
 #import "PPOTConfiguration.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTDevice.h"
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 #pragma mark - PPOTCheckoutRequest implementation
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTCore.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTCore.m
@@ -10,11 +10,21 @@
 #import "PPOTResult_Internal.h"
 #import "PPOTRequest_Internal.h"
 #import "PPOTConfiguration.h"
+#import "PPOTPersistentRequestData.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTDevice.h"
 #import "PPOTMacros.h"
-#import "PPOTPersistentRequestData.h"
-#import "PPDataCollector.h"
 #import "PPOTVersion.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTVersion.h>
+#endif
+#if __has_include("PayPalDataCollector.h")
+#import "PPDataCollector.h"
+#else
+#import <PayPalDataCollector/PPDataCollector.h>
+#endif
 
 // PayPalTouch v1 version
 #import "PPOTAppSwitchUtil.h"

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTOAuth2BrowserSwitchRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTOAuth2BrowserSwitchRequest.m
@@ -6,13 +6,20 @@
 //
 
 #import "PPOTOAuth2BrowserSwitchRequest.h"
+#import "PPOTPersistentRequestData.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTTime.h"
 #import "PPOTString.h"
 #import "PPOTMacros.h"
-#import "PPOTPersistentRequestData.h"
 #import "PPOTJSONHelper.h"
 #import "PPOTEncryptionHelper.h"
-
+#else
+#import <PayPalUtils/PPOTTime.h>
+#import <PayPalUtils/PPOTString.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTJSONHelper.h>
+#import <PayPalUtils/PPOTEncryptionHelper.h>
+#endif
 
 @interface PPOTOAuth2BrowserSwitchRequest ()
 @property (nonatomic, readwrite) NSString *msgID;

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTOAuth2SwitchRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTOAuth2SwitchRequest.m
@@ -6,7 +6,11 @@
 //
 
 #import "PPOTOAuth2SwitchRequest.h"
+#if __has_include("PPOTMacros.h")
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 @implementation PPOTOAuth2SwitchRequest
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTPersistentRequestData.h
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTPersistentRequestData.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if __has_include("PPOTMacros.h")
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 #define kPPOTRequestDataDataDictionaryMsgIdKey        CARDIO_STR(@"msg_id")
 #define kPPOTRequestDataDataDictionaryEncryptionKey   CARDIO_STR(@"encryption_key")

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTPersistentRequestData.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTPersistentRequestData.m
@@ -8,8 +8,13 @@
 #import "PPOTPersistentRequestData.h"
 #import "PPOTOAuth2SwitchRequest.h"
 #import "PPOTConfiguration.h"
+#if __has_include("PayPalUtils.h")
 #import "PPOTMacros.h"
 #import "PPOTSimpleKeychain.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTSimpleKeychain.h>
+#endif
 
 #define kPPOTCoderKeyRequestDataConfigurationRecipe   CARDIO_STR(@"configuration_recipe")
 #define kPPOTCoderKeyRequestDataEnvironment           CARDIO_STR(@"environment")

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTRequest.m
@@ -9,12 +9,17 @@
 #import "PPOTAnalyticsDefines.h"
 #import "PPOTAppSwitchUtil.h"
 #import "PPOTConfiguration.h"
-#import "PPOTDevice.h"
-#import "PPOTMacros.h"
 #import "PPOTOAuth2SwitchRequest.h"
 #import "PPOTAnalyticsTracker.h"
 #import "PPOTPersistentRequestData.h"
 #import "PPOTError.h"
+#if __has_include("PayPalUtils.h")
+#import "PPOTDevice.h"
+#import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#endif
 
 #import <UIKit/UIKit.h>
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTResult.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTResult.m
@@ -10,13 +10,19 @@
 #import "PPOTCore_Internal.h"
 #import "PPOTAppSwitchResponse.h"
 #import "PPOTConfiguration.h"
-#import "PPOTDevice.h"
-#import "PPOTError.h"
-#import "PPOTMacros.h"
-#import "PPOTAnalyticsTracker.h"
-#import "PPOTVersion.h"
-#import "PPOTPersistentRequestData.h"
 #import "PPOTAnalyticsDefines.h"
+#import "PPOTAnalyticsTracker.h"
+#import "PPOTError.h"
+#import "PPOTPersistentRequestData.h"
+#if __has_include("PayPalUtils.h")
+#import "PPOTDevice.h"
+#import "PPOTMacros.h"
+#import "PPOTVersion.h"
+#else
+#import <PayPalUtils/PPOTDevice.h>
+#import <PayPalUtils/PPOTMacros.h>
+#import <PayPalUtils/PPOTVersion.h>
+#endif
 
 #define PP_TIMESTAMP_TIMEOUT 10*60 // 10 minutes
 

--- a/BraintreePayPal/PayPalOneTouch/Models/PPOTSwitchRequest.m
+++ b/BraintreePayPal/PayPalOneTouch/Models/PPOTSwitchRequest.m
@@ -6,8 +6,16 @@
 //
 
 #import "PPOTSwitchRequest.h"
+#if __has_include("PPOTMacros.h")
 #import "PPOTMacros.h"
+#else
+#import <PayPalUtils/PPOTMacros.h>
+#endif
+#if __has_include("PPDataCollector_Internal.h")
 #import "PPDataCollector_Internal.h"
+#else
+#import <PayPalDataCollector/PPDataCollector_Internal.h>
+#endif
 
 @implementation PPOTSwitchRequest
 


### PR DESCRIPTION
Build systems (like BUCK) require imports from other frameworks to use the angled bracket syntax. This pull request addresses this for the BraintreePayPal framework.