### PR TITLE
Chore: Support Update Card Tokenization

### DIFF
--- a/BraintreeCard/BTCard.m
+++ b/BraintreeCard/BTCard.m
@@ -77,6 +77,17 @@ NSString *const BTCardGraphQLTokenizationMutation = @""
     return self;
 }
 
+- (instancetype)initWithExpirationMonth:(NSString *)expirationMonth
+                         expirationYear:(NSString *)expirationYear
+                                    cvv:(nullable NSString *)cvv {
+    if (self = [self initWithParameters:@{}]) {
+        _expirationMonth = expirationMonth;
+        _expirationYear = expirationYear;
+        _cvv = cvv;
+    }
+    return self;
+}
+
 #pragma mark -
 
 - (NSDictionary *)parameters {

--- a/BraintreeCard/Public/BTCard.h
+++ b/BraintreeCard/Public/BTCard.h
@@ -16,6 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
                            cvv:(nullable NSString *)cvv;
 
 /**
+ A convenience initializer for creating an update card tokenization request
+ */
+- (instancetype)initWithExpirationMonth:(NSString *)expirationMonth
+                expirationYear:(NSString *)expirationYear
+                            cvv:(nullable NSString *)cvv;
+
+/**
 Designated initializer.
  */
 - (instancetype)initWithParameters:(NSDictionary *)parameters NS_DESIGNATED_INITIALIZER;

--- a/UnitTests/BTCard_Internal_Tests.m
+++ b/UnitTests/BTCard_Internal_Tests.m
@@ -20,6 +20,16 @@
     XCTAssertTrue([parameters[@"options"][@"validate"] isFalse]);
 }
 
+- (void)testParameters_updateCardProperties {
+    BTCard *card = [[BTCard alloc] initWithExpirationMonth:@"12"
+                                            expirationYear:"2038"
+                                                       cvv:"123"];
+    BTJSON *parameters = [[BTJSON alloc] initWithValue:card.parameters];
+    XCTAssertEqualObjects([parameters[@"expiration_date"] asString], @"12/2038");
+    XCTAssertEqualObjects([parameters[@"cvv"] asString], @"123");
+    XCTAssertTrue([parameters[@"options"][@"validate"] isFalse]);
+    }
+
 - (void)testParameters_whenShouldValidateIsTrue_encodesParametersCorrectly {
     BTCard *card = [[BTCard alloc] init];
     card.shouldValidate = YES;


### PR DESCRIPTION
Problem:
While leveeraging BTCardClient tokenization process, I found Venmo Android was able to leverage the tokenization process to updating a card, but iOS client was not. This leads to any update card process initialized on iOS to fail.

Upon further inspection, I found Android's builder process never setting the card number, while iOS implementation was setting value to "" given the requirement of BTCard.h for a non-null parameter.

Approach:
Remove number from a requirement for creating a BTCard for use in tokenization. Create a separate init function which states its use is for updating card rather than making current init number optional.

Change:
+ Update update card variant of BTCard initializer
+ Add test