### PR TITLE
Luhn validate UnionPay cards

### DIFF
--- a/BraintreeUI/Models/BTUICardType.m
+++ b/BraintreeUI/Models/BTUICardType.m
@@ -209,7 +209,7 @@
 #pragma mark - Validation
 
 - (BOOL)validAndNecessarilyCompleteNumber:(NSString *)number {
-    return (number.length == self.validNumberLengths.lastIndex && [BTUIUtil luhnValid:number]);
+    return number.length == self.validNumberLengths.lastIndex && [BTUIUtil luhnValid:number];
 }
 
 - (BOOL)validNumber:(NSString *)number {

--- a/BraintreeUI/Models/BTUICardType.m
+++ b/BraintreeUI/Models/BTUICardType.m
@@ -209,13 +209,11 @@
 #pragma mark - Validation
 
 - (BOOL)validAndNecessarilyCompleteNumber:(NSString *)number {
-    return (number.length == self.validNumberLengths.lastIndex &&
-            ([BTUIUtil luhnValid:number] || [self.brand isEqualToString:BTUILocalizedString(CARD_TYPE_UNION_PAY)]));
+    return (number.length == self.validNumberLengths.lastIndex && [BTUIUtil luhnValid:number]);
 }
 
 - (BOOL)validNumber:(NSString *)number {
-    return ([self completeNumber:number] &&
-            ([BTUIUtil luhnValid:number] || [self.brand isEqualToString:BTUILocalizedString(CARD_TYPE_UNION_PAY)]));
+    return ([self completeNumber:number] && [BTUIUtil luhnValid:number]);
 }
 
 - (BOOL)completeNumber:(NSString *)number {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Luhn validate UnionPay cards
+  * Luhn-invalid UnionPay cards were previously rejected server side rather than client side
 
 ## 4.19.0 (2018-09-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## Unreleased
+
+* Luhn validate UnionPay cards
+
 ## 4.19.0 (2018-09-13)
 
 * Update properties on BTLocalPaymentRequest


### PR DESCRIPTION
UnionPay cards used to be issued with luhn invalid card numbers. We have always rejected luhn invalid cards on the backend, so this just brings the front end in line with that behavior.

@braintree/team-dx 