### PR TITLE
Fix a static analyzer memory error in BTAPIClient

### DIFF
--- a/BraintreeCore/BTAPIClient_Internal.h
+++ b/BraintreeCore/BTAPIClient_Internal.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, BTAPIClientHTTPType) {
 /**
  Gets base GraphQL URL
 */
-+ (NSURL *)graphQLURLForEnvironment:(NSString *)environment;
++ (nullable NSURL *)graphQLURLForEnvironment:(NSString *)environment;
 
 @end
 


### PR DESCRIPTION
`graphQLURLForEnvironment:` could return `nil` but was marked as returning a `nonnull` object.