### PR TITLE
Correct importing of BTConfiguration+ThreeDSecure

### DIFF
--- a/BraintreePaymentFlow/ThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/BraintreePaymentFlow/ThreeDSecure/BTThreeDSecureV2Provider.m
@@ -1,5 +1,5 @@
 #import "BTThreeDSecureV2Provider.h"
-#import "BTConfiguration+ThreeDSecure.m"
+#import "BTConfiguration+ThreeDSecure.h"
 #import "BTPaymentFlowDriver+ThreeDSecure_Internal.h"
 #import "BTThreeDSecureAuthenticateJWT.h"
 #if __has_include("BTAPIClient_Internal.h")


### PR DESCRIPTION
This PR fixes the following warning cased by importing the `BTConfiguration+ThreeDSecure` implementation file rather than the header:
> instance method ‘cardinalAuthenticationJWT’ in category from BTConfiguration+ThreeDSecure.o conflicts with same method from another category