### PR TITLE
- Improvement of url query parameter parsing method

### DIFF
--- a/BraintreeCore/BTURLUtils.m
+++ b/BraintreeCore/BTURLUtils.m
@@ -58,26 +58,15 @@
 }
 
 + (NSDictionary *)dictionaryForQueryString:(NSString *)queryString {
-    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    NSArray *components = [queryString componentsSeparatedByString:@"&"];
-    for (NSString *keyValueString in components) {
-        if ([keyValueString length] == 0) {
-            continue;
-        }
-
-        NSArray *keyValueArray = [keyValueString componentsSeparatedByString:@"="];
-        NSString *key = [self percentDecodedStringForString:keyValueArray[0]];
-        if (!key) {
-            continue;
-        }
-        if (keyValueArray.count == 2) {
-            NSString *value = [self percentDecodedStringForString:keyValueArray[1]];
-            parameters[key] = value;
-        } else {
-            parameters[key] = [NSNull null];
+    NSURLComponents *comps = [NSURLComponents componentsWithString:queryString];
+    NSArray<NSURLQueryItem*> *queryItems = [comps queryItems];
+    
+    for (NSURLQueryItem *item in queryItems) {
+        if ([item.name isEqualToString:@"auth_response"]) {
+            return @{@"auth_response": item.value};
         }
     }
-    return [NSDictionary dictionaryWithDictionary:parameters];
+    return [NSDictionary dictionary];
 }
 
 + (NSString *)percentDecodedStringForString:(NSString *)string {

--- a/BraintreePaymentFlow/ThreeDSecure/BTThreeDSecureRequest.m
+++ b/BraintreePaymentFlow/ThreeDSecure/BTThreeDSecureRequest.m
@@ -201,7 +201,7 @@ paymentDriverDelegate:(id<BTPaymentFlowDriverDelegate>)delegate {
 }
 
 - (void)handleOpenURL:(NSURL *)url {
-    NSString *jsonAuthResponse = [BTURLUtils dictionaryForQueryString:url.query][@"auth_response"];
+    NSString *jsonAuthResponse = [BTURLUtils dictionaryForQueryString:url.absoluteString][@"auth_response"];
     if (!jsonAuthResponse || jsonAuthResponse.length == 0) {
         [self.paymentFlowDriverDelegate.apiClient sendAnalyticsEvent:[NSString stringWithFormat:@"ios.three-d-secure.missing-auth-response"]];
         [self.paymentFlowDriverDelegate onPaymentComplete:nil error:[NSError errorWithDomain:BTThreeDSecureFlowErrorDomain


### PR DESCRIPTION
**Issue:** 

The parsing method is assuming that there will be only one "=" symbol. used to find the auth_response value. This assumption causes a crash when some other key has a value with a "=" symbol.

Ex URL that crashes the SDK (keys cavv and xid have "=" symbol): 

url-scheme://x-callback-url/braintree/threedsecure?auth_response=%7B%22paymentMethod%22:%7B%22type%22:%22CreditCard%22,%22nonce%22:%229619abd3-7792-05c7-74e4-848b583de1fa%22,%22description%22:%22ending+in+04%22,%22isLocked%22:false,%22securityQuestions%22:%5B%22cvv%22%5D,%22details%22:%7B%22cardType%22:%22Visa%22,%22lastTwo%22:%2204%22,%22lastFour%22:%220004%22,%22bin%22:%22400551%22%7D,%22threeDSecureInfo%22:%7B%22liabilityShifted%22:true,%22liabilityShiftPossible%22:true,%22status%22:%22authenticate_successful%22,%22enrolled%22:%22Y%22,%22cavv%22:%22AAABAWFlmQAAAABjRWWZEEFgFz8=%22,%22xid%22:%22ZHVrYVJ1UkZTYUFtQTRXN2thUTA=%22,%22eci_flag%22:%2205%22,%22three_d_secure_version%22:%221.0.2%22%7D,%22consumed%22:false,%22default%22:false,%22hasSubscription%22:false,%22bin_data%22:%7B%22prepaid%22:%22No%22,%22healthcare%22:%22Unknown%22,%22debit%22:%22Yes%22,%22durbin_regulated%22:%22Yes%22,%22commercial%22:%22Unknown%22,%22payroll%22:%22Unknown%22,%22issuing_bank%22:%22Unknown%22,%22country_of_issuance%22:%22Unknown%22,%22product_id%22:%22Unknown%22%7D%7D,%22threeDSecureInfo%22:%7B%22liabilityShifted%22:true,%22liabilityShiftPossible%22:true%7D,%22success%22:true%7D

**Solution:**

Using NSURLComponents to find the auth_response value.

