### PR TITLE
Issue 485: Carthage Submodule Integration Dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ DerivedData
 # CocoaPods
 Pods
 
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts
+Carthage/Build
+
 # This file is needed for signing the ipa with our enterprise cert;
 # you can get it from the iOS Developer Center.
 EverybodyVenmo.mobileprovision
@@ -32,4 +38,3 @@ EverybodyVenmo.mobileprovision
 .hockeyapp
 
 *.pid
-


### PR DESCRIPTION
### Summary of changes

#### Issue:
https://github.com/braintree/braintree_ios/issues/485

#### Problem:
When integrating braintree_ios sdk via Carthage (as submodules), consumer Applications repos are dirtied due to a SYMLink between the cloned carthage checkout directory, and the Applications root Carthage/Checkout directory.

This had not been an issue with our previous integration of Release 4.24.0, which didn't have the Cardinal dependency yet to reveal this issue.

#### Why
When Carthage integrates dependencies, it inspects each dependency as that dependencies dependency, and eventually constructs a Cartfile.resolved include all dependencies in the graph.

As part of this resolution, all dependencies of dependencies are cloned to the top level which may then be shared with dependencies (if multiple dependencies reuse the same item). This is done via a SYMLink.

In our case, this exibited the behavior of a new file being created in the cloned braintree submodule:
`<App_ProjectDir>/Carthage/Checkouts/braintree_ios/Carthage/Checkouts/CardinalMobile`

This new SYMLINK left our project dirty. Given the SYMLink exists in the braintree_ios folder structure, the folder which needs this .gitignore is the braintree_ios repo.

[Default Swift Github gitignore](https://github.com/github/gitignore/blob/master/Swift.gitignore)
By default, when creating new github repo's a .gitignore may be provided by Github, often with default items such as this as well as CocoaPods. In this case, this is mirroring what the CocoaPods Pods path is doing just above this change.

### Outcome
CardinalMobile will still be included when an application integrated braintree_ios based on Carthage dependency resolution by the public Cartfile in this repo. The difference is, after this change, consuming applications will be able to still consume as a submodule, but not have a dirty repo.

### Reproduction Example:
https://github.com/dmiluski/braintree-ios-issue-demo

### Precedent already used at Braintree
https://github.com/braintree/braintree-ios-drop-in/blob/master/.gitignore#L38

This was likely overlooked in this repo as it did not include Carthage dependencies of its own prior to `CardinalMobile`

### Checklist

- [x] Include Carthage Directory .gitignore to play friendly with Carthage integrations.
