### PR TITLE
Fixing calls to deprecated BTUIKAppearance methods to make Demo app c…

### DIFF
--- a/Demo/Features/Drop In/BraintreeDemoDropInViewController.m
+++ b/Demo/Features/Drop In/BraintreeDemoDropInViewController.m
@@ -235,9 +235,9 @@
     //dropInRequest.amount = @"10.00";
     //dropInRequest.threeDSecureVerification = YES;
     if (self.dropinThemeSwitch.selectedSegmentIndex == 0) {
-        [BTUIKAppearance lightTheme];
+        [[BTUIKAppearance sharedInstance] setColorScheme:BTUIKColorSchemeLight];
     } else {
-        [BTUIKAppearance darkTheme];
+        [[BTUIKAppearance sharedInstance] setColorScheme:BTUIKColorSchemeDark];
     }
     BTDropInController *dropIn = [[BTDropInController alloc] initWithAuthorization:self.authorizationString request:dropInRequest handler:^(BTDropInController * _Nonnull dropInController, BTDropInResult * _Nullable result, NSError * _Nullable error) {
         if (error) {


### PR DESCRIPTION
…ompile again.

### Summary of changes

Fixed calls to deprecated `BTUIKAppearance` class methods in `BraintreeDemoDropInViewController.m` to make Demo app compile again.

### Checklist

- [ ] Fixed Demo app build errors.

### Authors

- @thirtified
