### PR TITLE
Update Braintree.podspec

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -26,7 +26,6 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |s|
     s.source_files  = "BraintreeCore/**/*.{h,m}"
     s.public_header_files = "BraintreeCore/Public/*.h"
-    s.frameworks = "AddressBook"
     s.weak_frameworks = "Contacts"
   end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Remove `AddressBook.framework` from Podspec
+* Remove `AddressBook.framework` from Podspec (thanks @ignotusverum)
 
 ## 4.32.1 (2020-02-21) 
 
@@ -937,4 +937,3 @@ Thanks for the feedback so far. Keep it coming!
     * Incomplete / unpolished UI
         * Minor UX card validation issues in the card form
         * Drop-in UX flow issues and unaddressed edge cases
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Remove `AddressBook.framework` from Podspec
+
 ## 4.32.1 (2020-02-21) 
 
 * Fix crash when `ThreeDSecureRequest` `amount` field is set to NaN (resolves #507)


### PR DESCRIPTION
### Summary of changes

Follow up for https://github.com/braintree/braintree_ios/issues/515

Removing `AddressBook.framework` from .podspec.
