### PR TITLE
Cleanup unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,5 @@ source "https://rubygems.org"
 
 gem 'cocoapods'
 gem 'rake'
-gem 'git-pairing'
 gem 'highline', :require => 'highline/import'
-gem 'rake_commit'
 gem 'jazzy', '~>0.13.0'
-gem 'xcpretty'
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    awesome_print (1.8.0)
     claide (1.0.3)
     cocoapods (1.10.0)
       addressable (~> 2.6)
@@ -61,11 +60,6 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git-pairing (0.5.3)
-      awesome_print (>= 1.1.0)
-      highline (>= 1.6.15)
-      paint (>= 0.8.5)
-      trollop (>= 2.0)
     highline (2.0.3)
     httpclient (2.8.3)
     i18n (1.8.5)
@@ -88,10 +82,8 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     open4 (1.3.4)
-    paint (2.2.0)
     public_suffix (4.0.6)
     rake (13.0.1)
-    rake_commit (1.2.0)
     redcarpet (3.5.0)
     rouge (2.0.7)
     ruby-macho (1.4.0)
@@ -99,7 +91,6 @@ GEM
       ffi (~> 1.9)
     sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    trollop (2.9.10)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
@@ -112,20 +103,15 @@ GEM
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-    xcpretty (0.3.0)
-      rouge (~> 2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cocoapods
-  git-pairing
   highline
   jazzy (~> 0.13.0)
   rake
-  rake_commit
-  xcpretty
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
### Summary of changes

- Clean up unused gems
    - `git-pairing`
    - `xcpretty` _was replaced by the xcbeautify Pod_
    - `rake_commit`

### Question
There is a slight chance some folks are using `git-pairing`, though I haven't seen it used. I see more commonly people have `git duet` enabled configured on their machines. Let us know if you have objections to removing it!

### Checklist

~- [ ] Added a changelog entry~

### Authors
@scannillo 