### PR TITLE
Remove old delegate method from 3DS demo view controller

### DIFF
--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -124,6 +124,7 @@
         request.email = @"test@example.com";
         request.shippingMethod = @"01";
 
+        // TODO: - fix UiCustomization imports
 //        UiCustomization *ui = [UiCustomization new];
 //        ToolbarCustomization *toolbarCustomization = [ToolbarCustomization new];
 //        [toolbarCustomization setHeaderText:@"Braintree 3DS Checkout"];
@@ -173,11 +174,6 @@
 }
 
 #pragma mark BTThreeDSecureRequestDelegate
-
-- (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request result:(__unused BTThreeDSecureLookup *)result next:(void (^)(void))next {
-    // Optionally inspect the result and prepare UI if a challenge is required
-    next();
-}
 
 - (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request lookupResult:(__unused BTThreeDSecureResult *)result next:(void (^)(void))next {
     // Optionally inspect the result and prepare UI if a challenge is required


### PR DESCRIPTION


### Summary of changes

- The method signature for `onLookupComplete` changed in v5-beta1, so we can remove the old method from the 3DS demo view controller.

- It looks like `UiCustomization` (and related classes) are not being exposed to merchants property, so I also added a TODO. We'll fix this in a separate PR.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens
