### PR TITLE
Update 3DS Unit Test

### DIFF
--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -87,6 +87,12 @@ paymentDriverDelegate:(id<BTPaymentFlowDriverDelegate>)delegate {
                                                userInfo:@{NSLocalizedDescriptionKey: @"BTThreeDSecureRequest amount can not be nil or NaN."}];
         }
 
+        if (self.versionRequested == BTThreeDSecureVersion2 && self.threeDSecureRequestDelegate == nil) {
+            integrationError = [NSError errorWithDomain:BTThreeDSecureFlowErrorDomain
+                                                   code:BTThreeDSecureFlowErrorTypeConfiguration
+                                               userInfo:@{NSLocalizedDescriptionKey: @"Configuration Error: threeDSecureRequestDelegate can not be nil when versionRequested is 2."}];
+        }
+
         if (integrationError != nil) {
             [delegate onPaymentComplete:nil error:integrationError];
             return;
@@ -136,16 +142,6 @@ paymentDriverDelegate:(id<BTPaymentFlowDriverDelegate>)delegate {
     BTThreeDSecureRequest *threeDSecureRequest = (BTThreeDSecureRequest *)request;
     BTAPIClient *apiClient = [self.paymentFlowDriverDelegate apiClient];
     BTPaymentFlowDriver *paymentFlowDriver = [[BTPaymentFlowDriver alloc] initWithAPIClient:apiClient];
-
-    if (threeDSecureRequest.versionRequested == BTThreeDSecureVersion2) {
-        if (threeDSecureRequest.threeDSecureRequestDelegate == nil) {
-            NSError *error = [NSError errorWithDomain:BTThreeDSecureFlowErrorDomain
-                                                 code:BTThreeDSecureFlowErrorTypeConfiguration
-                                             userInfo:@{NSLocalizedDescriptionKey: @"Configuration Error: threeDSecureRequestDelegate can not be nil when versionRequested is 2."}];
-            [self.paymentFlowDriverDelegate onPaymentComplete:nil error:error];
-            return;
-        }
-    }
     
     if (threeDSecureRequest.versionRequested == BTThreeDSecureVersion1 && threeDSecureRequest.threeDSecureRequestDelegate == nil) {
         threeDSecureRequest.threeDSecureRequestDelegate = self;

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
@@ -229,10 +229,11 @@ class BTThreeDSecure_UnitTests: XCTestCase {
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTThreeDSecureFlowErrorDomain)
             XCTAssertEqual(error.code, BTThreeDSecureFlowErrorType.configuration.rawValue)
+            XCTAssertEqual(error.localizedDescription, "Configuration Error: threeDSecureRequestDelegate can not be nil when versionRequested is 2.")
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 4, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testStartPayment_successfulResult_callsCompletionBlock() {


### PR DESCRIPTION

### Summary of changes

- Move check for nil delegate when 3DS 2 is requested earlier in flow. This should help with a unit test that's been flaky in CI.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
