### PR TITLE
Update v5 migration guide

### DIFF
--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -51,7 +51,7 @@ The `BraintreeThreeDSecure` library does not currently support Swift Package Man
 
 #### BTThreeDSecureRequestDelegate
 
-The signature for the `BTThreeDSecureRequestDelegate` method `onLookupComplete` method has changed:
+The signature for the `BTThreeDSecureRequestDelegate` method `onLookupComplete` has changed:
 
 ```swift
 public func onLookupComplete(_ request: BTThreeDSecureRequest, lookupResult result: BTThreeDSecureResult, next: @escaping () -> Void) {

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -16,7 +16,7 @@ v5 introduces limited support for Swift Package Manager. See the [README](/READM
 
 In v4, 3D Secure classes were housed in the `BraintreePaymentFlow` module. In v5, `BraintreeThreeDSecure` is a standalone module offering the same 3DS functionality. The `BraintreePaymentFlow` module still houses Local Payment functionality.
 
-### Integration
+#### Integration
 
 <details><summary>CocoaPods</summary>
 <p>
@@ -49,7 +49,7 @@ The `BraintreeThreeDSecure` library does not currently support Swift Package Man
 </p>
 </details>
 
-### BTThreeDSecureRequestDelegate
+#### BTThreeDSecureRequestDelegate
 
 The signature for the `BTThreeDSecureRequestDelegate` method `onLookupComplete` method has changed:
 

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -58,7 +58,7 @@ public func onLookupComplete(_ request: BTThreeDSecureRequest, lookupResult resu
 
 }
 ```
-The lookup information, such as `requiresUserAuthentication` can be found on the result's `lookup` property:
+The lookup information, such as `requiresUserAuthentication`, can be found on the result's `lookup` property:
 
 ```swift
 result.lookup?.requiresUserAuthentication

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -16,22 +16,57 @@ v5 introduces limited support for Swift Package Manager. See the [README](/READM
 
 In v4, 3D Secure classes were housed in the `BraintreePaymentFlow` module. In v5, `BraintreeThreeDSecure` is a standalone module offering the same 3DS functionality. The `BraintreePaymentFlow` module still houses Local Payment functionality.
 
-### CocoaPods
+### Integration
+
+<details><summary>CocoaPods</summary>
+<p>
+
 In your Podfile, add:
 ```
 pod `Braintree/ThreeDSecure`
 ```
 
-### Carthage
+</p>
+</details>
+
+<details><summary>Carthage</summary>
+<p>
+
 You will need to add the `BraintreeThreeDSecure` framework to your project. See the Carthage docs for [integration instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
 *Note:* In v5, using the `--no-use-binaries` flag with `carthage update` may result in a timeout.
 
 *Note:* Long term support for Carthage is not guaranteed. Please update to SPM, if possible. Open a GitHub issue if there are concerns.
 
-### Swift Package Manager
+</p>
+</details>
+
+<details><summary>Swift Package Manager</summary>
+<p>
 
 The `BraintreeThreeDSecure` library does not currently support Swift Package Manager. It relies on a third party framework which we do not yet have in the `.xcframework` format.
+
+</p>
+</details>
+
+### BTThreeDSecureRequestDelegate
+
+The signature for the `BTThreeDSecureRequestDelegate` method `onLookupComplete` method has changed:
+
+```swift
+public func onLookupComplete(_ request: BTThreeDSecureRequest, lookupResult result: BTThreeDSecureResult, next: @escaping () -> Void) {
+
+}
+```
+The lookup information, such as `requiresUserAuthentication` can be found on the result's `lookup` property:
+
+```swift
+result.lookup?.requiresUserAuthentication
+```
+
+## Apple Pay
+
+For CocoaPods integrations, the Braintree Apple Pay subspec has been renamed from `Braintree/Apple-Pay` to `Braintree/ApplePay`.
 
 ## PayPal
 


### PR DESCRIPTION

### Summary of changes

- In section on 3DS, make the comments for each integration method (CocoaPods, Carthage, SPM) collapsible so that the guide is easier to read
- Add section on changes to 3DS delegate method
- Add note about `Braintree/Apple-Pay` subspec being renamed to `Braintree/ApplePay`

**NOTE:** It might be helpful to look at the [rendered markdown file](https://github.com/braintree/braintree_ios/blob/v5-migration-guide-updates/V5_MIGRATION.md).

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
