### PR TITLE
Fix unhandled README.md

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -85,7 +85,7 @@ let package = Package(
         .target(
             name: "BraintreeDataCollector",
             dependencies: ["BraintreeCore", "KountDataCollector"],
-            exclude: ["Kount"],
+            exclude: ["Kount", "README.md"],
             publicHeadersPath: "Public"
         ),
         .target(


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

### Summary of changes

- Fixes swift package manager loading warning of unhandled README file in BraintreeDataCollector

Note: I've not updated the CHANGELOG since the BraintreeDataCollector SPM support is unreleased.

<img width="1287" alt="Screen Shot 2021-01-06 at 16 10 55" src="https://user-images.githubusercontent.com/2230175/103820337-2a200980-503a-11eb-87a5-174865babaca.png">
