### PR TITLE
Make GET and POST methods on BTAPIClient Public

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient_Internal.h
+++ b/Sources/BraintreeCore/BTAPIClient_Internal.h
@@ -16,17 +16,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, BTAPIClientHTTPType) {
-    /// Use the Gateway
-    BTAPIClientHTTPTypeGateway = 0,
-
-    /// Use the Braintree API
-    BTAPIClientHTTPTypeBraintreeAPI,
-
-    /// Use the GraphQL API
-    BTAPIClientHTTPTypeGraphQLAPI,
-};
-
 typedef NS_ENUM(NSInteger, BTAPIClientAuthorizationType) {
     BTAPIClientAuthorizationTypeTokenizationKey = 0,
     BTAPIClientAuthorizationTypeClientToken,
@@ -68,16 +57,6 @@ typedef NS_ENUM(NSInteger, BTAPIClientAuthorizationType) {
  This prevents copyWithSource:integration: from sending a duplicate event. It can also be used to suppress excessive network chatter during testing.
 */
 - (nullable instancetype)initWithAuthorization:(NSString *)authorization sendAnalyticsEvent:(BOOL)sendAnalyticsEvent;
-
-- (void)GET:(NSString *)path
- parameters:(nullable NSDictionary <NSString *, NSString *> *)parameters
- httpType:(BTAPIClientHTTPType)httpType
- completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
-
-- (void)POST:(NSString *)path
-  parameters:(nullable NSDictionary *)parameters
-  httpType:(BTAPIClientHTTPType)httpType
-  completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
 
 /**
  Gets base GraphQL URL

--- a/Sources/BraintreeCore/Public/BraintreeCore/BTAPIClient.h
+++ b/Sources/BraintreeCore/Public/BraintreeCore/BTAPIClient.h
@@ -33,6 +33,20 @@ typedef NS_ENUM(NSInteger, BTAPIClientErrorType) {
 };
 
 /**
+ :nodoc:
+*/
+typedef NS_ENUM(NSInteger, BTAPIClientHTTPType) {
+    /// Use the Gateway
+    BTAPIClientHTTPTypeGateway = 0,
+
+    /// Use the Braintree API
+    BTAPIClientHTTPTypeBraintreeAPI,
+
+    /// Use the GraphQL API
+    BTAPIClientHTTPTypeGraphQLAPI,
+};
+
+/**
  This class acts as the entry point for accessing the Braintree APIs via common HTTP methods performed on API endpoints.
 
  @note It also manages authentication via tokenization key and provides access to a merchant's gateway configuration.
@@ -91,6 +105,7 @@ typedef NS_ENUM(NSInteger, BTAPIClientErrorType) {
                       completion:(void(^)(NSArray <BTPaymentMethodNonce *> * _Nullable paymentMethodNonces, NSError * _Nullable error))completion;
 
 /**
+ :nodoc:
  Perfom an HTTP GET on a URL composed of the configured from environment and the given path.
 
  @param path The endpoint URI path.
@@ -105,6 +120,7 @@ typedef NS_ENUM(NSInteger, BTAPIClientErrorType) {
  completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
 
 /**
+ :nodoc:
  Perfom an HTTP POST on a URL composed of the configured from environment and the given path.
 
  @param path The endpoint URI path.
@@ -116,6 +132,22 @@ typedef NS_ENUM(NSInteger, BTAPIClientErrorType) {
 */
 - (void)POST:(NSString *)path
   parameters:(nullable NSDictionary *)parameters
+  completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
+
+/**
+ :nodoc:
+*/
+- (void)GET:(NSString *)path
+ parameters:(nullable NSDictionary <NSString *, NSString *> *)parameters
+ httpType:(BTAPIClientHTTPType)httpType
+ completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
+
+/**
+ :nodoc:
+*/
+- (void)POST:(NSString *)path
+  parameters:(nullable NSDictionary *)parameters
+  httpType:(BTAPIClientHTTPType)httpType
   completion:(nullable void(^)(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error))completionBlock;
 
 /**

--- a/Sources/BraintreeCore/Public/BraintreeCore/BTPreferredPaymentMethods.h
+++ b/Sources/BraintreeCore/Public/BraintreeCore/BTPreferredPaymentMethods.h
@@ -1,6 +1,10 @@
-#import <Foundation/Foundation.h>
-@class BTPreferredPaymentMethodsResult;
-@class BTAPIClient;
+#if __has_include(<Braintree/BraintreeCore.h>)
+#import <Braintree/BTAPIClient.h>
+#import <Braintree/BTPreferredPaymentMethodsResult.h>
+#else
+#import <BraintreeCore/BTAPIClient.h>
+#import <BraintreeCore/BTPreferredPaymentMethodsResult.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION

### Summary of changes

- Braintree Drop-in uses a couple of methods on BTAPIClient that are currently internal only. BT Drop-in was redeclaring these methods in an internal header in order to access them. We're making these methods public in order to avoid a "ambiguous reference" error in Drop-in. (See https://github.com/braintree/braintree-ios-drop-in/pull/256.)

We aren't adding a changelog entry or doc comments for these methods, since we don't intend them to be used by merchants.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo
- @sestevens 
