### PR TITLE
Change default 3DS version to 3DS2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     * `BTThreeDSecureV2LabelCustomization`
     * `BTThreeDSecureV2TextBoxCustomization`
     * `BTThreeDSecureV2ToolbarCustomization`
+  * Default `versionRequested` on `BTThreeDSecureRequest` to 3DS2 instead of 3DS1
 
 ## 5.0.0-beta1 (2020-12-01)
 * Add support for Swift Package Manager (resolves #462)

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -52,7 +52,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _versionRequested = BTThreeDSecureVersion1;
+        _versionRequested = BTThreeDSecureVersion2;
     }
 
     return self;

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -28,6 +28,13 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
         XCTAssertEqual(request.accountTypeAsString, nil)
     }
 
+    // MARK: - versionRequested
+
+    func testVersionRequested_defaultsToVersion2() {
+        let request = BTThreeDSecureRequest()
+        XCTAssertEqual(request.versionRequested, .version2)
+    }
+
     // MARK: - handleRequest
     
     func testHandleRequest_whenAmountIsNotANumber_throwsError() {

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -74,6 +74,10 @@ On `BTThreeDSecureRequest`, the `uiCustomization` property was replaced with `v2
 * `BTThreeDSecureV2TextBoxCustomization`
 * `BTThreeDSecureV2ToolbarCustomization`
 
+#### Default 3DS Version
+
+Previously, the `versionRequested` property on `BTThreeDSecureRequest` defaulted to `.version1`. It now defaults to `.version2`.
+
 ## Apple Pay
 
 For CocoaPods integrations, the Braintree Apple Pay subspec has been renamed from `Braintree/Apple-Pay` to `Braintree/ApplePay`.


### PR DESCRIPTION


### Summary of changes

- Change default 3DS version to 3DS2

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
