### PR TITLE
Update 3DS Unit Tests for defaulting to v2

### DIFF
--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -40,6 +40,9 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
     func testHandleRequest_whenAmountIsNotANumber_throwsError() {
         let request =  BTThreeDSecureRequest()
         request.amount = NSDecimalNumber.notANumber
+
+        let mockThreeDSecureRequestDelegate = MockThreeDSecureRequestDelegate()
+        request.threeDSecureRequestDelegate = mockThreeDSecureRequestDelegate
         
         let mockAPIClient = MockAPIClient(authorization: "development_client_key")!
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
@@ -15,6 +15,7 @@ class BTThreeDSecure_UnitTests: XCTestCase {
         threeDSecureRequest = BTThreeDSecureRequest()
         threeDSecureRequest.amount = 10.0
         threeDSecureRequest.nonce = "fake-card-nonce"
+        threeDSecureRequest.versionRequested = .version1
         mockAPIClient = MockAPIClient(authorization: tempClientToken)!
         mockThreeDSecureRequestDelegate = MockThreeDSecureRequestDelegate()
     }
@@ -23,14 +24,6 @@ class BTThreeDSecure_UnitTests: XCTestCase {
         for observer in observers { NotificationCenter.default.removeObserver(observer) }
         super.tearDown()
     }
-
-    // MARK: - ThreeDSecure Request Tests
-
-    func testThreeDSecureRequest_defaultsToV1() {
-        XCTAssertEqual(threeDSecureRequest.versionRequested, .version1)
-    }
-
-
 
     // MARK: - ThreeDSecure Authentication Tests
 

--- a/UnitTests/BraintreeThreeDSecureTests/MockDelegates.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/MockDelegates.swift
@@ -32,11 +32,6 @@ class MockPaymentFlowDriverDelegate: BTPaymentFlowDriverDelegate {
 class MockThreeDSecureRequestDelegate : NSObject, BTThreeDSecureRequestDelegate {
     var lookupCompleteExpectation : XCTestExpectation?
 
-    func onLookupComplete(_ request: BTThreeDSecureRequest, result: BTThreeDSecureLookup, next: @escaping () -> Void) {
-        lookupCompleteExpectation?.fulfill()
-        next()
-    }
-
     func onLookupComplete(_ request: BTThreeDSecureRequest, lookupResult: BTThreeDSecureResult, next: @escaping () -> Void) {
         lookupCompleteExpectation?.fulfill()
         next()


### PR DESCRIPTION
### Summary of changes

- This is a follow up to PR #585 
- Fix UnitTest that broke due to changing the default 3DS version from 1 to 2

### Checklist

- ~[ ] Added a changelog entry~

### Authors
- @scannillo @sestevens 
