### PR TITLE
Make shippingMethod property on BTThreeDSecureRequest an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Breaking Changes
+  * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
+
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`
 * Add SPM libraries for `KountDataCollector` and `PPRiskMagnes` to workaround Xcode bug (addresses #576)

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -123,7 +123,7 @@
         billingAddress.phoneNumber = @"8101234567";
         request.billingAddress = billingAddress;
         request.email = @"test@example.com";
-        request.shippingMethod = @"01";
+        request.shippingMethod = BTThreeDSecureShippingMethodSameDay;
 
         BTThreeDSecureV2UICustomization *ui = [BTThreeDSecureV2UICustomization new];
         BTThreeDSecureV2ToolbarCustomization *toolbarCustomization = [BTThreeDSecureV2ToolbarCustomization new];

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -69,8 +69,8 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
             additionalInformation[@"email"] = request.email;
         }
 
-        if (request.shippingMethod) {
-            additionalInformation[@"shippingMethod"] = request.shippingMethod;
+        if (request.shippingMethodAsString) {
+            additionalInformation[@"shippingMethod"] = request.shippingMethodAsString;
         }
 
         if (request.additionalInformation) {

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -69,6 +69,25 @@
     }
 }
 
+- (NSString *)shippingMethodAsString {
+    switch (self.shippingMethod) {
+        case BTThreeDSecureShippingMethodSameDay:
+            return @"01";
+        case BTThreeDSecureShippingMethodExpedited:
+            return @"02";
+        case BTThreeDSecureShippingMethodPriority:
+            return @"03";
+        case BTThreeDSecureShippingMethodGround:
+            return @"04";
+        case BTThreeDSecureShippingMethodElectronicDelivery:
+            return @"05";
+        case BTThreeDSecureShippingMethodShipToStore:
+            return @"06";
+        default:
+            return nil;
+    }
+}
+
 - (void)handleRequest:(BTPaymentFlowRequest *)request
                client:(BTAPIClient *)apiClient
 paymentDriverDelegate:(id<BTPaymentFlowDriverDelegate>)delegate {

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest_Internal.h
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest_Internal.h
@@ -26,6 +26,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *accountTypeAsString;
 
 /**
+ The shipping method as a two-digit code.
+ Possible Values:
+ 01 Same Day
+ 02 Overnight / Expedited
+ 03 Priority (2-3 Days)
+ 04 Ground
+ 05 Electronic Delivery
+ 06 Ship to Store
+ */
+@property (nonatomic, readonly, nullable) NSString *shippingMethodAsString;
+
+/**
  Prepare for a 3DS 2.0 flow.
 
  @param apiClient The API client.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -45,6 +45,32 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureAccountType) {
 };
 
 /**
+ The shipping method
+ */
+typedef NS_ENUM(NSInteger, BTThreeDSecureShippingMethod) {
+    /// Unspecified
+    BTThreeDSecureShippingMethodUnspecified,
+
+    /// Same Day
+    BTThreeDSecureShippingMethodSameDay,
+
+    /// Overnight / Expedited
+    BTThreeDSecureShippingMethodExpedited,
+
+    /// Priority
+    BTThreeDSecureShippingMethodPriority,
+
+    /// Ground
+    BTThreeDSecureShippingMethodGround,
+
+    /// Electronic Delivery
+    BTThreeDSecureShippingMethodElectronicDelivery,
+
+    /// Ship to Store
+    BTThreeDSecureShippingMethodShipToStore
+};
+
+/**
  Used to initialize a 3D Secure payment flow
  */
 @interface BTThreeDSecureRequest : BTPaymentFlowRequest <BTPaymentFlowRequestDelegate>
@@ -84,16 +110,9 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureAccountType) {
 @property (nonatomic, nullable, copy) NSString *email;
 
 /**
- Optional. The 2-digit string indicating the shipping method chosen for the transaction
- Possible Values:
- 01 Same Day
- 02 Overnight / Expedited
- 03 Priority (2-3 Days)
- 04 Ground
- 05 Electronic Delivery
- 06 Ship to Store
+ Optional. The shipping method chosen for the transaction
  */
-@property (nonatomic, nullable, copy) NSString *shippingMethod;
+@property (nonatomic, assign) BTThreeDSecureShippingMethod shippingMethod;
 
 /**
  Optional. The additional information used for verification

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -24,7 +24,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.accountType = .credit
         threeDSecureRequest.mobilePhoneNumber = "5151234321"
         threeDSecureRequest.email = "tester@example.com"
-        threeDSecureRequest.shippingMethod = "03"
+        threeDSecureRequest.shippingMethod = .priority
 
         let billingAddress = BTThreeDSecurePostalAddress()
         billingAddress.givenName = "Joe"

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -28,6 +28,55 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
         XCTAssertEqual(request.accountTypeAsString, nil)
     }
 
+    // MARK: - shippingMethodAsString
+
+    func testShippingMethodAsString_whenShippingMethodIsSameDay_returns01() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .sameDay
+        XCTAssertEqual(request.shippingMethodAsString, "01")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsExpedited_returns02() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .expedited
+        XCTAssertEqual(request.shippingMethodAsString, "02")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsPriority_returns03() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .priority
+        XCTAssertEqual(request.shippingMethodAsString, "03")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsGround_returns04() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .ground
+        XCTAssertEqual(request.shippingMethodAsString, "04")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsElectronicDelivery_returns05() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .electronicDelivery
+        XCTAssertEqual(request.shippingMethodAsString, "05")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsShipToStore_returns06() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .shipToStore
+        XCTAssertEqual(request.shippingMethodAsString, "06")
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsUnspecified_returnsNil() {
+        let request = BTThreeDSecureRequest()
+        request.shippingMethod = .unspecified
+        XCTAssertEqual(request.shippingMethodAsString, nil)
+    }
+
+    func testShippingMethodAsString_whenShippingMethodIsNotSet_returnsNil() {
+        let request = BTThreeDSecureRequest()
+        XCTAssertEqual(request.shippingMethodAsString, nil)
+    }
+
     // MARK: - versionRequested
 
     func testVersionRequested_defaultsToVersion2() {

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -78,6 +78,16 @@ On `BTThreeDSecureRequest`, the `uiCustomization` property was replaced with `v2
 
 Previously, the `versionRequested` property on `BTThreeDSecureRequest` defaulted to `.version1`. It now defaults to `.version2`.
 
+#### Shipping Method
+
+The `shippingMethod` property on `BTThreeDSecureRequest` is now an enum rather than a string. Possible values:
+* `.sameDay`
+* `.expedited`
+* `.priority`
+* `.ground`
+* `.electronicDelivery`
+* `.shipToStore`
+
 ## Apple Pay
 
 For CocoaPods integrations, the Braintree Apple Pay subspec has been renamed from `Braintree/Apple-Pay` to `Braintree/ApplePay`.


### PR DESCRIPTION


### Summary of changes

- Make shippingMethod property on BTThreeDSecureRequest an enum instead of a string

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens
- @scannillo 
