### PR TITLE
Add offerPayLater to BTPayPalRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Breaking Changes
   * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
   * Remove `BTTokenizationService`
+* Add `offerPayLater` to `BTPayPalRequest`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -158,6 +158,8 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
         parameters[@"offer_paypal_credit"] = @(request.offerCredit);
 
+        parameters[@"offer_pay_later"] = @(request.offerPayLater);
+
         experienceProfile[@"no_shipping"] = @(!request.isShippingAddressRequired);
 
         experienceProfile[@"brand_name"] = request.displayName ?: [configuration.json[@"paypal"][@"displayName"] asString];
@@ -618,6 +620,12 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
     if ((paymentType == BTPayPalPaymentTypeCheckout || paymentType == BTPayPalPaymentTypeBillingAgreement) && self.payPalRequest.offerCredit) {
         NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.credit.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
+
+        [self.apiClient sendAnalyticsEvent:eventName];
+    }
+
+    if (paymentType == BTPayPalPaymentTypeCheckout && self.payPalRequest.offerPayLater) {
+        NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.paylater.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
 
         [self.apiClient sendAnalyticsEvent:eventName];
     }

--- a/Sources/BraintreePayPal/BTPayPalRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalRequest.m
@@ -12,6 +12,7 @@
     if (self) {
         _shippingAddressRequired = NO;
         _offerCredit = NO;
+        _offerPayLater = NO;
         _shippingAddressEditable = NO;
         _intent = BTPayPalRequestIntentAuthorize;
         _userAction = BTPayPalRequestUserActionDefault;

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -169,7 +169,7 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic) BOOL offerCredit;
 
 /**
- Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false.
+ Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
  */
 @property (nonatomic) BOOL offerPayLater;
 

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -169,6 +169,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic) BOOL offerCredit;
 
 /**
+ Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false.
+ */
+@property (nonatomic) BOOL offerPayLater;
+
+/**
  Optional: A non-default merchant account to use for tokenization.
 */
 @property (nonatomic, nullable, copy) NSString *merchantAccountId;

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
@@ -363,6 +363,7 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
             return
         }
         XCTAssertEqual(lastPostParameters["offer_paypal_credit"] as? Bool, false)
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, false)
         XCTAssertEqual(experienceProfile["address_override"] as? Bool, true)
         XCTAssertEqual(lastPostParameters["line1"] as? String, "1234 Fake St.")
         XCTAssertEqual(lastPostParameters["line2"] as? String, "Apt. 0")
@@ -395,6 +396,7 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
             return
         }
         XCTAssertEqual(lastPostParameters["offer_paypal_credit"] as? Bool, false)
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, false)
         XCTAssertEqual(experienceProfile["address_override"] as? Bool, true)
         XCTAssertEqual(lastPostParameters["line1"] as? String, "1234 Fake St.")
         XCTAssertNil(lastPostParameters["line2"])

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
@@ -552,6 +552,30 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
         XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-single-payment.webswitch.credit.offered.started"))
     }
 
+    func testCheckout_whenPayPalPayLaterOffered_performsSwitchCorrectly() {
+        let request = BTPayPalRequest(amount: "1")
+        request.currencyCode = "GBP"
+        request.offerPayLater = true
+
+        payPalDriver.requestOneTimePayment(request) { _,_  in }
+
+        XCTAssertNotNil(payPalDriver.authenticationSession)
+        XCTAssertTrue(payPalDriver.isAuthenticationSessionStarted)
+
+        // Ensure the payment resource had the correct parameters
+        XCTAssertEqual("v1/paypal_hermes/create_payment_resource", mockAPIClient.lastPOSTPath)
+        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, true)
+
+        // Make sure analytics event was sent when switch occurred
+        let postedAnalyticsEvents = mockAPIClient.postedAnalyticsEvents
+
+        XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-single-payment.webswitch.paylater.offered.started"))
+    }
+
     func testCheckout_whenPayPalPaymentCreationSuccessful_performsAppSwitch() {
         let request = BTPayPalRequest(amount: "1")
         payPalDriver.requestOneTimePayment(request) { _,_  -> Void in }


### PR DESCRIPTION
### Summary of changes
Add `offerPayLater` to `BTPayPalRequest`. This will default the customer to the Pay Later tab if they qualify during the Checkout experience.

### Checklist

- [x] Added a changelog entry

### Authors
- @demerino 
