### PR TITLE
Update sdkVersion param for server-side 3DS lookup to include platform

### DIFF
--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -47,7 +47,9 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
         }
 
         NSMutableDictionary *customer = [[NSMutableDictionary alloc] init];
-        NSMutableDictionary *requestParameters = [@{ @"amount": request.amount, @"customer": customer } mutableCopy];
+        NSMutableDictionary *requestParameters = [@{ @"amount": request.amount,
+                                                     @"customer": customer,
+                                                     @"requestedThreeDSecureVersion": request.versionRequestedAsString } mutableCopy];
         if (request.dfReferenceId) {
             requestParameters[@"dfReferenceId"] = request.dfReferenceId;
         }

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -159,7 +159,7 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
             requestParameters[@"braintreeLibraryVersion"] = [NSString stringWithFormat:@"iOS-%@", BRAINTREE_VERSION];
 
             NSMutableDictionary *clientMetadata = [@{} mutableCopy];
-            clientMetadata[@"sdkVersion"] = BRAINTREE_VERSION;
+            clientMetadata[@"sdkVersion"] = [NSString stringWithFormat:@"iOS/%@", BRAINTREE_VERSION];
             clientMetadata[@"requestedThreeDSecureVersion"] = @"2";
             requestParameters[@"clientMetadata"] = clientMetadata;
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -88,6 +88,15 @@
     }
 }
 
+- (NSString *)versionRequestedAsString {
+    switch (self.versionRequested) {
+        case BTThreeDSecureVersion1:
+            return @"1";
+        default:
+            return @"2";
+    }
+}
+
 - (void)handleRequest:(BTPaymentFlowRequest *)request
                client:(BTAPIClient *)apiClient
 paymentDriverDelegate:(id<BTPaymentFlowDriverDelegate>)delegate {

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest_Internal.h
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest_Internal.h
@@ -38,6 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *shippingMethodAsString;
 
 /**
+ The requested 3DS version as a raw string.
+ */
+@property (nonatomic, readonly) NSString *versionRequestedAsString;
+
+/**
  Prepare for a 3DS 2.0 flow.
 
  @param apiClient The API client.

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -22,6 +22,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.nonce = "fake-card-nonce"
         threeDSecureRequest.accountType = .credit
+        threeDSecureRequest.versionRequested = .version2
         threeDSecureRequest.mobilePhoneNumber = "5151234321"
         threeDSecureRequest.email = "tester@example.com"
         threeDSecureRequest.shippingMethod = .priority
@@ -42,6 +43,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
             XCTAssertEqual(self.mockAPIClient.lastPOSTParameters!["amount"] as! NSDecimalNumber, 9.97)
             XCTAssertEqual(self.mockAPIClient.lastPOSTParameters!["accountType"] as! String, "credit")
+            XCTAssertEqual(self.mockAPIClient.lastPOSTParameters!["requestedThreeDSecureVersion"] as! String, "2")
 
             let additionalInfo = self.mockAPIClient.lastPOSTParameters!["additionalInfo"] as! Dictionary<String, String>
             XCTAssertEqual(additionalInfo["mobilePhoneNumber"], "5151234321")

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -77,11 +77,23 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
         XCTAssertEqual(request.shippingMethodAsString, nil)
     }
 
-    // MARK: - versionRequested
+    // MARK: - versionRequested and versionRequestedAsString
 
     func testVersionRequested_defaultsToVersion2() {
         let request = BTThreeDSecureRequest()
         XCTAssertEqual(request.versionRequested, .version2)
+    }
+
+    func testVersionRequestedAsString_whenVersion1IsRequested_returns1() {
+        let request = BTThreeDSecureRequest()
+        request.versionRequested = .version1
+        XCTAssertEqual(request.versionRequestedAsString, "1")
+    }
+
+    func testVersionRequestedAsString_whenVersion2IsRequested_returns2() {
+        let request = BTThreeDSecureRequest()
+        request.versionRequested = .version2
+        XCTAssertEqual(request.versionRequestedAsString, "2")
     }
 
     // MARK: - handleRequest

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecure_Tests.swift
@@ -554,7 +554,7 @@ class BTThreeDSecure_UnitTests: XCTestCase {
                 XCTAssertNotNil(json!["authorizationFingerprint"] as! String)
                 let clientMetadata = json!["clientMetadata"] as! [String: Any]
                 XCTAssertEqual(clientMetadata["requestedThreeDSecureVersion"] as! String, "2")
-                XCTAssertNotNil(clientMetadata["sdkVersion"] as! String)
+                XCTAssertEqual(clientMetadata["sdkVersion"] as! String, "iOS/\(BRAINTREE_VERSION)")
                 expectation.fulfill()
             }
         }

--- a/UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h
+++ b/UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h
@@ -8,3 +8,4 @@
 #import <BraintreeThreeDSecure/BTThreeDSecureV1BrowserSwitchHelper.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureV2UICustomization_Internal.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureV2BaseCustomization_Internal.h>
+#import <BraintreeCore/Braintree-Version.h>


### PR DESCRIPTION
### Summary of changes

- Update sdkVersion param for server-side 3DS lookup to include platform as well as version. This fixes a discrepancy observed between client-side and server-side lookups.
- We also discovered that client-side lookup requests were missing the requested version param, so we're adding it now.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
