### PR TITLE
Remove old frameworks linked to CarthageTest app

### DIFF
--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -7,19 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		42F174CA2576DB030092A66A /* BraintreeThreeDSecure.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42F174C82576DB030092A66A /* BraintreeThreeDSecure.framework */; };
-		42F174CC2576DB030092A66A /* PPRiskMagnes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42F174C92576DB030092A66A /* PPRiskMagnes.framework */; };
-		80214DCD2551F28C00695A6F /* BraintreeAmericanExpress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DCC2551F28C00695A6F /* BraintreeAmericanExpress.framework */; };
-		80214DD12551F29000695A6F /* BraintreeApplePay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DD02551F29000695A6F /* BraintreeApplePay.framework */; };
-		80214DD52551F29400695A6F /* BraintreeCard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DD32551F29400695A6F /* BraintreeCard.framework */; };
-		80214DD72551F29400695A6F /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DD42551F29400695A6F /* BraintreeCore.framework */; };
-		80214DDB2551F29A00695A6F /* BraintreePaymentFlow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DD92551F29A00695A6F /* BraintreePaymentFlow.framework */; };
-		80214DDD2551F29A00695A6F /* BraintreeDataCollector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DDA2551F29A00695A6F /* BraintreeDataCollector.framework */; };
-		80214DE02551F29F00695A6F /* BraintreePayPal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DDF2551F29F00695A6F /* BraintreePayPal.framework */; };
-		80214DE42551F2A200695A6F /* BraintreeVenmo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DE22551F2A200695A6F /* BraintreeVenmo.framework */; };
-		80214DE62551F2A200695A6F /* BraintreeUnionPay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DE32551F2A200695A6F /* BraintreeUnionPay.framework */; };
-		80214DEA2551F2A700695A6F /* PayPalDataCollector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DE82551F2A700695A6F /* PayPalDataCollector.framework */; };
-		80214DEC2551F2A700695A6F /* CardinalMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80214DE92551F2A700695A6F /* CardinalMobile.framework */; };
 		A74D4AF51BFBB3FB00BF36CD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74D4AF41BFBB3FB00BF36CD /* AppDelegate.swift */; };
 		A74D4AF71BFBB3FB00BF36CD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74D4AF61BFBB3FB00BF36CD /* ViewController.swift */; };
 		A74D4AFA1BFBB3FB00BF36CD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74D4AF81BFBB3FB00BF36CD /* Main.storyboard */; };
@@ -28,28 +15,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		03BFA5C91FB2F0BB0003ABCE /* BraintreeAmericanExpress.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeAmericanExpress.framework; path = ../../Carthage/Build/iOS/BraintreeAmericanExpress.framework; sourceTree = "<group>"; };
-		03BFA5CA1FB2F0BB0003ABCE /* BraintreeUnionPay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeUnionPay.framework; path = ../../Carthage/Build/iOS/BraintreeUnionPay.framework; sourceTree = "<group>"; };
-		03BFA5CB1FB2F0BB0003ABCE /* BraintreePaymentFlow.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreePaymentFlow.framework; path = ../../Carthage/Build/iOS/BraintreePaymentFlow.framework; sourceTree = "<group>"; };
-		03BFA5CC1FB2F0BB0003ABCE /* PayPalOneTouch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalOneTouch.framework; path = ../../Carthage/Build/iOS/PayPalOneTouch.framework; sourceTree = "<group>"; };
-		03BFA5CD1FB2F0BB0003ABCE /* PayPalUtils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalUtils.framework; path = ../../Carthage/Build/iOS/PayPalUtils.framework; sourceTree = "<group>"; };
-		03BFA5CE1FB2F0BB0003ABCE /* BraintreeVenmo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeVenmo.framework; path = ../../Carthage/Build/iOS/BraintreeVenmo.framework; sourceTree = "<group>"; };
-		03BFA5CF1FB2F0BB0003ABCE /* PayPalDataCollector.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalDataCollector.framework; path = ../../Carthage/Build/iOS/PayPalDataCollector.framework; sourceTree = "<group>"; };
-		42F174C82576DB030092A66A /* BraintreeThreeDSecure.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeThreeDSecure.framework; path = Carthage/Build/iOS/BraintreeThreeDSecure.framework; sourceTree = "<group>"; };
-		42F174C92576DB030092A66A /* PPRiskMagnes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PPRiskMagnes.framework; path = Carthage/Build/iOS/PPRiskMagnes.framework; sourceTree = "<group>"; };
-		80214DCC2551F28C00695A6F /* BraintreeAmericanExpress.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeAmericanExpress.framework; path = Carthage/Build/iOS/BraintreeAmericanExpress.framework; sourceTree = "<group>"; };
-		80214DD02551F29000695A6F /* BraintreeApplePay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeApplePay.framework; path = Carthage/Build/iOS/BraintreeApplePay.framework; sourceTree = "<group>"; };
-		80214DD32551F29400695A6F /* BraintreeCard.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeCard.framework; path = Carthage/Build/iOS/BraintreeCard.framework; sourceTree = "<group>"; };
-		80214DD42551F29400695A6F /* BraintreeCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeCore.framework; path = Carthage/Build/iOS/BraintreeCore.framework; sourceTree = "<group>"; };
-		80214DD92551F29A00695A6F /* BraintreePaymentFlow.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreePaymentFlow.framework; path = Carthage/Build/iOS/BraintreePaymentFlow.framework; sourceTree = "<group>"; };
-		80214DDA2551F29A00695A6F /* BraintreeDataCollector.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeDataCollector.framework; path = Carthage/Build/iOS/BraintreeDataCollector.framework; sourceTree = "<group>"; };
-		80214DDF2551F29F00695A6F /* BraintreePayPal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreePayPal.framework; path = Carthage/Build/iOS/BraintreePayPal.framework; sourceTree = "<group>"; };
-		80214DE22551F2A200695A6F /* BraintreeVenmo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeVenmo.framework; path = Carthage/Build/iOS/BraintreeVenmo.framework; sourceTree = "<group>"; };
-		80214DE32551F2A200695A6F /* BraintreeUnionPay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraintreeUnionPay.framework; path = Carthage/Build/iOS/BraintreeUnionPay.framework; sourceTree = "<group>"; };
-		80214DE82551F2A700695A6F /* PayPalDataCollector.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalDataCollector.framework; path = Carthage/Build/iOS/PayPalDataCollector.framework; sourceTree = "<group>"; };
-		80214DE92551F2A700695A6F /* CardinalMobile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CardinalMobile.framework; path = Carthage/Build/iOS/CardinalMobile.framework; sourceTree = "<group>"; };
-		80214DEE2551F35400695A6F /* PayPalOneTouch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalOneTouch.framework; path = Carthage/Build/iOS/PayPalOneTouch.framework; sourceTree = "<group>"; };
-		80214DEF2551F35400695A6F /* PayPalUtils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PayPalUtils.framework; path = Carthage/Build/iOS/PayPalUtils.framework; sourceTree = "<group>"; };
 		A74D4AF11BFBB3FB00BF36CD /* CarthageTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarthageTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A74D4AF41BFBB3FB00BF36CD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A74D4AF61BFBB3FB00BF36CD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -64,19 +29,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80214DDD2551F29A00695A6F /* BraintreeDataCollector.framework in Frameworks */,
-				80214DEA2551F2A700695A6F /* PayPalDataCollector.framework in Frameworks */,
-				80214DD72551F29400695A6F /* BraintreeCore.framework in Frameworks */,
-				80214DE02551F29F00695A6F /* BraintreePayPal.framework in Frameworks */,
-				80214DD52551F29400695A6F /* BraintreeCard.framework in Frameworks */,
-				80214DEC2551F2A700695A6F /* CardinalMobile.framework in Frameworks */,
-				80214DCD2551F28C00695A6F /* BraintreeAmericanExpress.framework in Frameworks */,
-				42F174CC2576DB030092A66A /* PPRiskMagnes.framework in Frameworks */,
-				80214DE42551F2A200695A6F /* BraintreeVenmo.framework in Frameworks */,
-				80214DD12551F29000695A6F /* BraintreeApplePay.framework in Frameworks */,
-				80214DE62551F2A200695A6F /* BraintreeUnionPay.framework in Frameworks */,
-				42F174CA2576DB030092A66A /* BraintreeThreeDSecure.framework in Frameworks */,
-				80214DDB2551F29A00695A6F /* BraintreePaymentFlow.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,28 +38,6 @@
 		03BFA5C81FB2F0BB0003ABCE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				42F174C82576DB030092A66A /* BraintreeThreeDSecure.framework */,
-				42F174C92576DB030092A66A /* PPRiskMagnes.framework */,
-				80214DEE2551F35400695A6F /* PayPalOneTouch.framework */,
-				80214DEF2551F35400695A6F /* PayPalUtils.framework */,
-				80214DE92551F2A700695A6F /* CardinalMobile.framework */,
-				80214DE82551F2A700695A6F /* PayPalDataCollector.framework */,
-				80214DE32551F2A200695A6F /* BraintreeUnionPay.framework */,
-				80214DE22551F2A200695A6F /* BraintreeVenmo.framework */,
-				80214DDF2551F29F00695A6F /* BraintreePayPal.framework */,
-				80214DDA2551F29A00695A6F /* BraintreeDataCollector.framework */,
-				80214DD92551F29A00695A6F /* BraintreePaymentFlow.framework */,
-				80214DD32551F29400695A6F /* BraintreeCard.framework */,
-				80214DD42551F29400695A6F /* BraintreeCore.framework */,
-				80214DD02551F29000695A6F /* BraintreeApplePay.framework */,
-				03BFA5C91FB2F0BB0003ABCE /* BraintreeAmericanExpress.framework */,
-				80214DCC2551F28C00695A6F /* BraintreeAmericanExpress.framework */,
-				03BFA5CB1FB2F0BB0003ABCE /* BraintreePaymentFlow.framework */,
-				03BFA5CA1FB2F0BB0003ABCE /* BraintreeUnionPay.framework */,
-				03BFA5CE1FB2F0BB0003ABCE /* BraintreeVenmo.framework */,
-				03BFA5CF1FB2F0BB0003ABCE /* PayPalDataCollector.framework */,
-				03BFA5CC1FB2F0BB0003ABCE /* PayPalOneTouch.framework */,
-				03BFA5CD1FB2F0BB0003ABCE /* PayPalUtils.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";


### PR DESCRIPTION


### Summary of changes

- Remove old frameworks linked to CarthageTest app. This fixes duplicate symbol errors when trying to build the app.

### Checklist

- Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
