### PR TITLE
Fix memory leak in BTPayPalDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Breaking Changes
   * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
   * Remove `BTTokenizationService`
+* Fix memory leak in `BTPayPalDriver`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -327,6 +327,9 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
     self.authenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:urlComponents.URL
                                                                   callbackURLScheme:BTCallbackURLScheme
                                                                   completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
+        // Required to avoid memory leak for BTPayPalDriver
+        self.authenticationSession = nil;
+
         if (error) {
             if (error.domain == ASWebAuthenticationSessionErrorDomain && error.code == ASWebAuthenticationSessionErrorCodeCanceledLogin) {
                 if (self.returnedToAppAfterPermissionAlert) {
@@ -354,8 +357,6 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
         [self handleBrowserSwitchReturnURL:callbackURL
                                paymentType:paymentType
                                 completion:completionBlock];
-        self.authenticationSession = nil;
-
     }];
 
     if (@available(iOS 13, *)) {


### PR DESCRIPTION
### Summary of changes

- This [GH issue](https://github.com/braintree/braintree_ios/issues/563) surfaced a memory leak in v4 of Braintree iOS for the PayPal flow
- This PR fixes the issue in v5 by making sure to set the `self.authenticationSession` property to nil for _both_ the success and cancel PayPal flows

### Checklist

- [X] Added a changelog entry

### Authors
- @scannillo 
- @sestevens 
