### PR TITLE
Checkout with vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Breaking Changes
   * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
   * Remove `BTTokenizationService`
-* Add `offerPayLater` to `BTPayPalRequest`
+* Add `offerPayLater` and `requestBillingAgreement` to `BTPayPalRequest`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Breaking Changes
   * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
   * Remove `BTTokenizationService`
+* Add `offerPayLater` to `BTPayPalRequest`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
@@ -22,10 +22,9 @@
 
     [sender setTitle:NSLocalizedString(@"Processing...", nil) forState:UIControlStateDisabled];
     [sender setEnabled:NO];
-    self.apiClient = [[BTAPIClient alloc] initWithAuthorization:@"sandbox_hcsh8ntd_t54vmb9mkw84cdtx"];
     BTPayPalDriver *driver = [[BTPayPalDriver alloc] initWithAPIClient:self.apiClient];
     driver.appSwitchDelegate = self;
-    BTPayPalRequest *request = [[BTPayPalRequest alloc] initWithAmount:@"124.30"];
+    BTPayPalRequest *request = [[BTPayPalRequest alloc] initWithAmount:@"4.30"];
     request.activeWindow = self.view.window;
     [driver requestOneTimePayment:request completion:^(BTPayPalAccountNonce * _Nullable payPalAccount, NSError * _Nullable error) {
         [sender setEnabled:YES];

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
@@ -22,10 +22,10 @@
 
     [sender setTitle:NSLocalizedString(@"Processing...", nil) forState:UIControlStateDisabled];
     [sender setEnabled:NO];
-
+    self.apiClient = [[BTAPIClient alloc] initWithAuthorization:@"sandbox_hcsh8ntd_t54vmb9mkw84cdtx"];
     BTPayPalDriver *driver = [[BTPayPalDriver alloc] initWithAPIClient:self.apiClient];
     driver.appSwitchDelegate = self;
-    BTPayPalRequest *request = [[BTPayPalRequest alloc] initWithAmount:@"4.30"];
+    BTPayPalRequest *request = [[BTPayPalRequest alloc] initWithAmount:@"124.30"];
     request.activeWindow = self.view.window;
     [driver requestOneTimePayment:request completion:^(BTPayPalAccountNonce * _Nullable payPalAccount, NSError * _Nullable error) {
         [sender setEnabled:YES];

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
@@ -22,6 +22,7 @@
 
     [sender setTitle:NSLocalizedString(@"Processing...", nil) forState:UIControlStateDisabled];
     [sender setEnabled:NO];
+
     BTPayPalDriver *driver = [[BTPayPalDriver alloc] initWithAPIClient:self.apiClient];
     driver.appSwitchDelegate = self;
     BTPayPalRequest *request = [[BTPayPalRequest alloc] initWithAmount:@"4.30"];

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -158,6 +158,8 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
         parameters[@"offer_paypal_credit"] = @(request.offerCredit);
 
+        parameters[@"offer_pay_later"] = @(request.offerPayLater);
+
         experienceProfile[@"no_shipping"] = @(!request.isShippingAddressRequired);
 
         experienceProfile[@"brand_name"] = request.displayName ?: [configuration.json[@"paypal"][@"displayName"] asString];
@@ -618,6 +620,12 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
     if ((paymentType == BTPayPalPaymentTypeCheckout || paymentType == BTPayPalPaymentTypeBillingAgreement) && self.payPalRequest.offerCredit) {
         NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.credit.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
+
+        [self.apiClient sendAnalyticsEvent:eventName];
+    }
+
+    if (paymentType == BTPayPalPaymentTypeCheckout && self.payPalRequest.offerPayLater) {
+        NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.paylater.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
 
         [self.apiClient sendAnalyticsEvent:eventName];
     }

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -152,6 +152,14 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
             if (request.amount != nil) {
                 parameters[@"amount"] = request.amount;
             }
+            if (request.requestBillingAgreement) {
+                parameters[@"request_billing_agreement"] = @(request.requestBillingAgreement);
+                if (request.billingAgreementDescription.length > 0) {
+                    NSMutableDictionary *billingAgreementDetails = [NSMutableDictionary dictionary];
+                    billingAgreementDetails[@"description"] = request.billingAgreementDescription;
+                    parameters[@"billing_agreement_details"] = billingAgreementDetails;
+                }
+            }
         } else if (request.billingAgreementDescription.length > 0) {
             parameters[@"description"] = request.billingAgreementDescription;
         }

--- a/Sources/BraintreePayPal/BTPayPalRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalRequest.m
@@ -12,6 +12,7 @@
     if (self) {
         _shippingAddressRequired = NO;
         _offerCredit = NO;
+        _offerPayLater = NO;
         _shippingAddressEditable = NO;
         _intent = BTPayPalRequestIntentAuthorize;
         _userAction = BTPayPalRequestUserActionDefault;

--- a/Sources/BraintreePayPal/BTPayPalRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalRequest.m
@@ -14,6 +14,7 @@
         _offerCredit = NO;
         _offerPayLater = NO;
         _shippingAddressEditable = NO;
+        _requestBillingAgreement = NO;
         _intent = BTPayPalRequestIntentAuthorize;
         _userAction = BTPayPalRequestUserActionDefault;
         _landingPageType = BTPayPalRequestLandingPageTypeDefault;

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic, nullable, strong) BTPostalAddress *shippingAddressOverride;
 
 /**
- Optional: Display a custom description to the user for a billing agreement.
+ Optional: Display a custom description to the user during billing agreement flows or when `requestBillingAgreement` is `true`.
 */
 @property (nonatomic, nullable, copy) NSString *billingAgreementDescription;
 
@@ -189,6 +189,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
  @note If your app supports multitasking, you must set this property to ensure that the ASWebAuthentication session is presented on the correct window.
  */
 @property (nonatomic, nullable, strong) UIWindow *activeWindow;
+
+/**
+ Optional: If `true`, the customer will be prompted to consent to a billing agreement during PayPal Checkout flows.
+ */
+@property (nonatomic) BOOL requestBillingAgreement;
 
 @end
 

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -169,7 +169,7 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic) BOOL offerCredit;
 
 /**
- Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false.
+ Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
  */
 @property (nonatomic) BOOL offerPayLater;
 

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -169,6 +169,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic) BOOL offerCredit;
 
 /**
+ Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false.
+ */
+@property (nonatomic) BOOL offerPayLater;
+
+/**
  Optional: A non-default merchant account to use for tokenization.
 */
 @property (nonatomic, nullable, copy) NSString *merchantAccountId;

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
@@ -363,6 +363,7 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
             return
         }
         XCTAssertEqual(lastPostParameters["offer_paypal_credit"] as? Bool, false)
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, false)
         XCTAssertEqual(experienceProfile["address_override"] as? Bool, true)
         XCTAssertEqual(lastPostParameters["line1"] as? String, "1234 Fake St.")
         XCTAssertEqual(lastPostParameters["line2"] as? String, "Apt. 0")
@@ -395,6 +396,7 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
             return
         }
         XCTAssertEqual(lastPostParameters["offer_paypal_credit"] as? Bool, false)
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, false)
         XCTAssertEqual(experienceProfile["address_override"] as? Bool, true)
         XCTAssertEqual(lastPostParameters["line1"] as? String, "1234 Fake St.")
         XCTAssertNil(lastPostParameters["line2"])

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
@@ -735,6 +735,33 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
         XCTAssertTrue(delegate.appContextDidReturnCalled)
     }
 
+    func testCheckout_postWithRequestBillingAgreement_withDescription() {
+        let request = BTPayPalRequest(amount: "1")
+        request.currencyCode = "GBP"
+        request.requestBillingAgreement = true
+        request.billingAgreementDescription = "ABC payments"
+
+        payPalDriver.requestOneTimePayment(request) { _,_  in }
+
+        XCTAssertNotNil(payPalDriver.authenticationSession)
+        XCTAssertTrue(payPalDriver.isAuthenticationSessionStarted)
+
+        // Ensure the payment resource had the correct parameters
+        XCTAssertEqual("v1/paypal_hermes/create_payment_resource", mockAPIClient.lastPOSTPath)
+        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(lastPostParameters["request_billing_agreement"] as? Bool, true)
+
+        guard let billingAgreementDetails = lastPostParameters["billing_agreement_details"] as? [String:Any] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(billingAgreementDetails["description"] as? String, "ABC payments")
+    }
+
     // MARK: - Tokenization
 
     func testTokenizedPayPalAccount_containsPayerInfo() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Checkout_Tests.swift
@@ -552,6 +552,30 @@ class BTPayPalDriver_Checkout_Tests: XCTestCase {
         XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-single-payment.webswitch.credit.offered.started"))
     }
 
+    func testCheckout_whenPayPalPayLaterOffered_performsSwitchCorrectly() {
+        let request = BTPayPalRequest(amount: "1")
+        request.currencyCode = "GBP"
+        request.offerPayLater = true
+
+        payPalDriver.requestOneTimePayment(request) { _,_  in }
+
+        XCTAssertNotNil(payPalDriver.authenticationSession)
+        XCTAssertTrue(payPalDriver.isAuthenticationSessionStarted)
+
+        // Ensure the payment resource had the correct parameters
+        XCTAssertEqual("v1/paypal_hermes/create_payment_resource", mockAPIClient.lastPOSTPath)
+        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(lastPostParameters["offer_pay_later"] as? Bool, true)
+
+        // Make sure analytics event was sent when switch occurred
+        let postedAnalyticsEvents = mockAPIClient.postedAnalyticsEvents
+
+        XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-single-payment.webswitch.paylater.offered.started"))
+    }
+
     func testCheckout_whenPayPalPaymentCreationSuccessful_performsAppSwitch() {
         let request = BTPayPalRequest(amount: "1")
         payPalDriver.requestOneTimePayment(request) { _,_  -> Void in }


### PR DESCRIPTION
### Summary of changes
- Add `requestBillingAgreement` to `BTPayPalRequest`
- Update usage of `billingAgreementDescription` on `BTPayPalRequest`. Opted to reuse this property when using `requestBillingAgreement` and updated the description, rather than making another property that does the same thing.

### Checklist

- [x] Added a changelog entry

### Authors
- @demerino 