### PR TITLE
Add BTVenmoRequest

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		8018090A24A4C89C00FC8BD3 /* BTPayPalIDToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B9D0D32347EB770005F8D4 /* BTPayPalIDToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80581A8C25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */; };
 		80581B1D2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */; };
+		80A79DD625CA04CB00A9E9A2 /* BTVenmoRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A79DD425CA04CB00A9E9A2 /* BTVenmoRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		80A79DD725CA04CB00A9E9A2 /* BTVenmoRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 80A79DD525CA04CB00A9E9A2 /* BTVenmoRequest.m */; };
 		80BB0C86241937A5003C8BA9 /* BTURLUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 80BB0C84241937A5003C8BA9 /* BTURLUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80BB0C87241937A5003C8BA9 /* BTURLUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 80BB0C85241937A5003C8BA9 /* BTURLUtils.m */; };
 		80DBE69523A931A600373230 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DBE69423A931A600373230 /* Helpers.swift */; };
@@ -847,6 +849,8 @@
 		80A1EE3D2236AAC600F6218B /* BTThreeDSecureAdditionalInformation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAdditionalInformation_Tests.swift; sourceTree = "<group>"; };
 		80A1EE3F2236B04F00F6218B /* BTThreeDSecureAdditionalInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTThreeDSecureAdditionalInformation.h; sourceTree = "<group>"; };
 		80A5B69AC895DC704C6286A4 /* Pods_Tests_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		80A79DD425CA04CB00A9E9A2 /* BTVenmoRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTVenmoRequest.h; sourceTree = "<group>"; };
+		80A79DD525CA04CB00A9E9A2 /* BTVenmoRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTVenmoRequest.m; sourceTree = "<group>"; };
 		80BB0C84241937A5003C8BA9 /* BTURLUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTURLUtils.h; sourceTree = "<group>"; };
 		80BB0C85241937A5003C8BA9 /* BTURLUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTURLUtils.m; sourceTree = "<group>"; };
 		80DBE69423A931A600373230 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -1568,6 +1572,7 @@
 				A7B1C1451B66D94600ED063C /* BTConfiguration+Venmo.h */,
 				A7F96D061B6043B7005A4A09 /* BTVenmoAccountNonce.h */,
 				A7C889FA1B5F0C00007A0E9C /* BTVenmoDriver.h */,
+				80A79DD425CA04CB00A9E9A2 /* BTVenmoRequest.h */,
 			);
 			path = BraintreeVenmo;
 			sourceTree = "<group>";
@@ -1907,6 +1912,7 @@
 				A7F96D0D1B604C1C005A4A09 /* BTVenmoAppSwitchReturnURL.m */,
 				A77AA2B51B61936A00217B73 /* BTVenmoDriver_Internal.h */,
 				A7C889FB1B5F0C00007A0E9C /* BTVenmoDriver.m */,
+				80A79DD525CA04CB00A9E9A2 /* BTVenmoRequest.m */,
 				41777D471B8D028C0026F987 /* Public */,
 			);
 			path = BraintreeVenmo;
@@ -2252,6 +2258,7 @@
 				A77AA2AA1B618CFB00217B73 /* BraintreeVenmo.h in Headers */,
 				03D294FF1BE835C8004F90DA /* BTVenmoAccountNonce_Internal.h in Headers */,
 				A77AA2B61B61936A00217B73 /* BTVenmoDriver_Internal.h in Headers */,
+				80A79DD625CA04CB00A9E9A2 /* BTVenmoRequest.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3349,6 +3356,7 @@
 				A77AA2A71B618CFB00217B73 /* BTVenmoAppSwitchRequestURL.m in Sources */,
 				A77AA2AC1B618CFB00217B73 /* BTVenmoDriver.m in Sources */,
 				A77AA2A91B618CFB00217B73 /* BTVenmoAppSwitchReturnURL.m in Sources */,
+				80A79DD725CA04CB00A9E9A2 /* BTVenmoRequest.m in Sources */,
 				A77AA2AE1B618CFB00217B73 /* BTVenmoAccountNonce.m in Sources */,
 				A7B1C1481B66D94600ED063C /* BTConfiguration+Venmo.m in Sources */,
 			);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
   * Make `shippingMethod` property on `BTThreeDSecureRequest` an enum instead of a string
   * Remove `BTTokenizationService`
   * Make `BTPaymentMethodNonceParser` private
+  * Replace `BTVenmoDriver.authorizeAccount` methods with `BTVenmoDriver.tokenizeVenmoAccount`
 * Fix memory leak in `BTPayPalDriver`
 * Add `offerPayLater` to `BTPayPalRequest`
+* Add `BTVenmoRequest`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -116,8 +116,8 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         
         button.setTitle("Processing...", for: .disabled)
         button.isEnabled = false
-        
-        venmoDriver.authorizeAccountAndVault(false) { (nonce, error) in
+
+        venmoDriver.tokenizeVenmoAccount(with: BTVenmoRequest()) { (nonce, error) in
             button.isEnabled = true
             
             if let e = error {

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -27,7 +27,8 @@
 
 - (void)tappedCustomVenmo {
     self.progressBlock(@"Tapped Venmo - initiating Venmo auth");
-    [self.venmoDriver authorizeAccountAndVault:NO completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
+    BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] init];
+    [self.venmoDriver tokenizeVenmoAccountWithVenmoRequest:venmoRequest completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
         if (venmoAccount) {
             self.progressBlock(@"Got a nonce 💎!");
             NSLog(@"%@", [venmoAccount debugDescription]);

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -91,18 +91,15 @@ static BTVenmoDriver *appSwitchedDriver;
 
 #pragma mark - Tokenization
 
-- (void)authorizeAccountWithCompletion:(void (^)(BTVenmoAccountNonce *venmoAccount, NSError *error))completionBlock {
-    [self authorizeAccountAndVault:NO completion:completionBlock];
-}
+- (void)tokenizeVenmoAccountWithVenmoRequest:(BTVenmoRequest *)venmoRequest completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
+    if (!venmoRequest) {
+        NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
+                                             code:BTVenmoDriverErrorTypeIntegration
+                                         userInfo:@{NSLocalizedDescriptionKey: @"BTVenmoDriver failed because BTVenmoRequest is nil."}];
+        completionBlock(nil, error);
+        return;
+    }
 
-- (void)authorizeAccountAndVault:(BOOL)vault completion:(void (^)(BTVenmoAccountNonce *venmoAccount, NSError *error))completionBlock {
-    [self authorizeAccountWithProfileID:nil vault:vault completion:completionBlock];
-}
-
-- (void)authorizeAccountWithProfileID:(NSString *)profileId
-                                vault:(BOOL)vault
-                           completion:(void (^)(BTVenmoAccountNonce *venmoAccount, NSError *error))completionBlock
-{
     if (!self.apiClient) {
         NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
                                              code:BTVenmoDriverErrorTypeIntegration
@@ -138,7 +135,7 @@ static BTVenmoDriver *appSwitchedDriver;
         metadata.source = BTClientMetadataSourceVenmoApp;
         NSString *bundleDisplayName = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 
-        NSString *venmoProfileId = profileId ?: configuration.venmoMerchantID;
+        NSString *venmoProfileId = venmoRequest.profileID ?: configuration.venmoMerchantID;
         NSURL *appSwitchURL = [BTVenmoAppSwitchRequestURL appSwitchURLForMerchantID:venmoProfileId
                                                                         accessToken:configuration.venmoAccessToken
                                                                     returnURLScheme:self.returnURLScheme
@@ -158,7 +155,7 @@ static BTVenmoDriver *appSwitchedDriver;
         [self informDelegateAppContextWillSwitch];
 
         [self.application openURL:appSwitchURL options:[NSDictionary dictionary] completionHandler:^(BOOL success) {
-            [self invokedOpenURLSuccessfully:success shouldVault:vault completion:completionBlock];
+            [self invokedOpenURLSuccessfully:success shouldVault:venmoRequest.vault completion:completionBlock];
         }];
     }];
 }

--- a/Sources/BraintreeVenmo/BTVenmoRequest.m
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.m
@@ -1,0 +1,9 @@
+#ifdef COCOAPODS
+#import <Braintree/BTVenmoRequest.h>
+#else
+#import <BraintreeVenmo/BTVenmoRequest.h>
+#endif
+
+@implementation BTVenmoRequest
+
+@end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoDriver.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoDriver.h
@@ -1,7 +1,9 @@
 #if __has_include(<Braintree/BraintreeVenmo.h>)
 #import <Braintree/BraintreeCore.h>
+#import <Braintree/BTVenmoRequest.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>
+#import <BraintreeVenmo/BTVenmoRequest.h>
 #endif
 
 @class BTVenmoAccountNonce;
@@ -62,23 +64,12 @@ typedef NS_ENUM(NSInteger, BTVenmoDriverErrorType) {
 /**
  Initiates Venmo login via app switch, which returns a BTVenmoAccountNonce when successful.
 
- @param vault Whether to automatically vault the Venmo Account. Vaulting will only occur if a client token with a customer_id is being used.
+ @param venmoRequest A Venmo request.
  @param completionBlock This completion will be invoked when app switch is complete or an error occurs.
     On success, you will receive an instance of `BTVenmoAccountNonce`; on failure, an error; on user
     cancellation, you will receive `nil` for both parameters.
 */
-- (void)authorizeAccountAndVault:(BOOL)vault completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock;
-
-/**
- Initiates Venmo login via app switch, which returns a BTVenmoAccountNonce when successful.
-
- @param profileId The Venmo profile ID to be used during payment authorization. Customers will see the business name and logo associated with this Venmo profile, and it will show up in the Venmo app as a "Connected Merchant". Venmo profile IDs can be found in the Braintree Control Panel. Passing `nil` will use the default Venmo profile.
- @param vault Whether to automatically vault the Venmo Account. Vaulting will only occur if a client token with a customer_id is being used.
- @param completionBlock This completion will be invoked when app switch is complete or an error occurs.
- On success, you will receive an instance of `BTVenmoAccountNonce`; on failure, an error; on user
- cancellation, you will receive `nil` for both parameters.
- */
-- (void)authorizeAccountWithProfileID:(nullable NSString *)profileId vault:(BOOL)vault completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock NS_SWIFT_NAME(authorizeAccount(profileID:vault:completion:));
+- (void)tokenizeVenmoAccountWithVenmoRequest:(BTVenmoRequest *)venmoRequest completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock;
 
 /**
  Returns true if the proper Venmo app is installed and configured correctly, returns false otherwise.

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A BTVenmoRequest specifies options that contribute to the Venmo flow
+*/
+@interface BTVenmoRequest : NSObject
+
+/**
+ The Venmo profile ID to be used during payment authorization. Customers will see the business name and logo associated with this Venmo profile, and it will show up in the Venmo app as a "Connected Merchant". Venmo profile IDs can be found in the Braintree Control Panel. Leaving this `nil` will use the default Venmo profile.
+ */
+@property (nonatomic, nullable, copy) NSString *profileID;
+
+/**
+ Whether to automatically vault the Venmo Account. Vaulting will only occur if a client token with a customer_id is being used. Defaults to false.
+ */
+@property (nonatomic) BOOL vault;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BraintreeVenmo.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BraintreeVenmo.h
@@ -11,9 +11,11 @@ FOUNDATION_EXPORT const unsigned char BraintreeVenmoVersionString[];
 #import <Braintree/BTConfiguration+Venmo.h>
 #import <Braintree/BTVenmoDriver.h>
 #import <Braintree/BTVenmoAccountNonce.h>
+#import <Braintree/BTVenmoRequest.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeVenmo/BTConfiguration+Venmo.h>
 #import <BraintreeVenmo/BTVenmoDriver.h>
 #import <BraintreeVenmo/BTVenmoAccountNonce.h>
+#import <BraintreeVenmo/BTVenmoRequest.h>
 #endif

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -7,6 +7,7 @@ import BraintreeCore.Private
 class BTVenmoDriver_Tests: XCTestCase {
     var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
     var observers : [NSObjectProtocol] = []
+    var venmoRequest: BTVenmoRequest = BTVenmoRequest()
 
     override func setUp() {
         super.setUp()
@@ -25,12 +26,12 @@ class BTVenmoDriver_Tests: XCTestCase {
         super.tearDown()
     }
 
-    func testAuthorizeAccount_whenAPIClientIsNil_callsBackWithError() {
+    func testTokenizeVenmoAccount_whenAPIClientIsNil_callsBackWithError() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         venmoDriver.apiClient = nil
 
         let expectation = self.expectation(description: "Callback invoked with error")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(venmoAccount)
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTVenmoDriverErrorDomain)
@@ -41,13 +42,13 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 10, handler: nil)
     }
 
-    func testAuthorizeAccount_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
+    func testTokenizeVenmoAccount_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "", code: 0, userInfo: nil)
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
 
         let expectation = self.expectation(description: "Tokenize fails with error")
-        venmoDriver.authorizeAccountAndVault(false)  { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest)  { (venmoAccount, error) -> Void in
             XCTAssertEqual(error! as NSError, self.mockAPIClient.cannedConfigurationResponseError!)
             expectation.fulfill()
         }
@@ -55,13 +56,13 @@ class BTVenmoDriver_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_whenVenmoConfigurationDisabled_callsBackWithError() {
+    func testTokenizeVenmoAccount_whenVenmoConfigurationDisabled_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
 
         let expectation = self.expectation(description: "tokenization callback")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTVenmoDriverErrorDomain)
             XCTAssertEqual(error.code, BTVenmoDriverErrorType.disabled.rawValue)
@@ -70,13 +71,13 @@ class BTVenmoDriver_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_whenVenmoConfigurationMissing_callsBackWithError() {
+    func testTokenizeVenmoAccount_whenVenmoConfigurationMissing_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
 
         let expectation = self.expectation(description: "tokenization callback")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTVenmoDriverErrorDomain)
             XCTAssertEqual(error.code, BTVenmoDriverErrorType.disabled.rawValue)
@@ -101,7 +102,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "authorization callback")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTVenmoDriverErrorDomain)
             XCTAssertEqual(error.code, BTVenmoDriverErrorType.appNotAvailable.rawValue)
@@ -120,7 +121,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.application = fakeApplication
         venmoDriver.bundle = FakeBundle()
 
-        venmoDriver.authorizeAccountAndVault(false) { _,_  -> Void in }
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _,_  -> Void in }
 
         XCTAssertTrue(fakeApplication.openURLWasCalled)
         XCTAssertEqual(fakeApplication.lastOpenURL!.scheme, "com.venmo.touch.v2")
@@ -129,7 +130,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         XCTAssertNotNil(fakeApplication.lastOpenURL!.absoluteString.range(of: "sandbox"));
     }
     
-    func testAuthorizeAccount_beforeAppSwitch_informsDelegate() {
+    func testTokenizeVenmoAccount_beforeAppSwitch_informsDelegate() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         let delegate = MockAppSwitchDelegate(willPerform: expectation(description: "willPerform called"), didPerform: expectation(description: "didPerform called"))
         delegate.appContextWillSwitchExpectation =  self.expectation(description: "Delegate received appContextWillSwitch")
@@ -139,21 +140,21 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.application = fakeApplication
         venmoDriver.bundle = FakeBundle()
 
-        venmoDriver.authorizeAccountAndVault(false) { _,_  -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _,_  -> Void in
             XCTAssertEqual(delegate.lastAppSwitcher as? BTVenmoDriver, venmoDriver)
         }
 
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_whenUsingTokenizationKeyAndAppSwitchSucceeds_tokenizesVenmoAccount() {
+    func testTokenizeVenmoAccount_whenUsingTokenizationKeyAndAppSwitchSucceeds_tokenizesVenmoAccount() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
         venmoDriver.application = FakeApplication()
         venmoDriver.bundle = FakeBundle()
 
         let expectation = self.expectation(description: "Callback")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             guard let venmoAccount = venmoAccount else {
                 XCTFail("Received an error: \(String(describing: error))")
                 return
@@ -169,7 +170,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
-    func testAuthorizeAccount_whenUsingClientTokenAndAppSwitchSucceeds_tokenizesVenmoAccount() {
+    func testTokenizeVenmoAccount_whenUsingClientTokenAndAppSwitchSucceeds_tokenizesVenmoAccount() {
         // Test setup sets up mockAPIClient with a tokenization key, we want a client token
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.token(withVersion: 2))
@@ -179,7 +180,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.bundle = FakeBundle()
         
         let expectation = self.expectation(description: "Callback")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             guard let venmoAccount = venmoAccount else {
                 XCTFail("Received an error: \(String(describing: error))")
                 return
@@ -195,7 +196,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_whenAppSwitchSucceeds_makesDelegateCallbacks() {
+    func testTokenizeVenmoAccount_whenAppSwitchSucceeds_makesDelegateCallbacks() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         let delegate = MockAppSwitchDelegate(willPerform: self.expectation(description: "willPerform called"), didPerform: self.expectation(description: "didPerform called"))
         delegate.appContextWillSwitchExpectation =  self.expectation(description: "Delegate received appContextWillSwitch")
@@ -205,7 +206,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.bundle = FakeBundle()
 
         let expectation = self.expectation(description: "Callback")
-        venmoDriver.authorizeAccountAndVault(false) { _,_  -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _,_  -> Void in
             XCTAssertEqual(delegate.lastAppSwitcher as? BTVenmoDriver, venmoDriver)
             expectation.fulfill()
         }
@@ -214,7 +215,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_whenAppSwitchSucceeds_postsNotifications() {
+    func testTokenizeVenmoAccount_whenAppSwitchSucceeds_postsNotifications() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         let delegate = MockAppSwitchDelegate(willPerform: expectation(description: "willPerform called"), didPerform: expectation(description: "didPerform called"))
         venmoDriver.appSwitchDelegate = delegate
@@ -237,7 +238,7 @@ class BTVenmoDriver_Tests: XCTestCase {
             didAppSwitchNotificationExpectation.fulfill()
         })
 
-        venmoDriver.authorizeAccountAndVault(false) { _,_  -> Void in }
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _,_  -> Void in }
 
         let appContextDidReturnNotificationExpectation = expectation(description: "appContextDidReturn notification received")
         observers.append(NotificationCenter.default.addObserver(forName: NSNotification.Name.BTAppContextDidReturn, object: nil, queue: nil) { (notification) -> Void in
@@ -254,14 +255,14 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
-    func testAuthorizeAccount_whenAppSwitchFails_callsBackWithError() {
+    func testTokenizeVenmoAccount_whenAppSwitchFails_callsBackWithError() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
         venmoDriver.application = FakeApplication()
         venmoDriver.bundle = FakeBundle()
 
         let expectation = self.expectation(description: "Callback invoked")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(venmoAccount)
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, "com.braintreepayments.BTVenmoAppSwitchReturnURLErrorDomain")
@@ -272,7 +273,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_vaultTrue_setsShouldVaultProperty() {
+    func testTokenizeVenmoAccount_vaultTrue_setsShouldVaultProperty() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
         venmoDriver.application = FakeApplication()
@@ -280,7 +281,9 @@ class BTVenmoDriver_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "Callback invoked")
 
-        venmoDriver.authorizeAccountAndVault(true) { (venmoAccount, error) -> Void in
+        venmoRequest.vault = true
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertTrue(venmoDriver.shouldVault)
             expectation.fulfill()
         }
@@ -289,7 +292,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testAuthorizeAccount_vaultFalse_setsVaultToFalse() {
+    func testTokenizeVenmoAccount_vaultFalse_setsVaultToFalse() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
         venmoDriver.application = FakeApplication()
@@ -297,7 +300,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         
         let expectation = self.expectation(description: "Callback invoked")
         
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertFalse(venmoDriver.shouldVault)
             expectation.fulfill()
         }
@@ -306,7 +309,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
-    func testAuthorizeAccount_vaultTrue_callsBackWithNonce() {
+    func testTokenizeVenmoAccount_vaultTrue_callsBackWithNonce() {
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.validClientToken)
         mockAPIClient.cannedResponseBody = BTJSON(value: [
@@ -329,8 +332,10 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.bundle = FakeBundle()
         
         let expectation = self.expectation(description: "Callback invoked")
-        
-        venmoDriver.authorizeAccountAndVault(true) { (venmoAccount, error) -> Void in
+
+        venmoRequest.vault = true
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(error)
             
             XCTAssertEqual(venmoAccount?.username, "venmojoe")
@@ -344,7 +349,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
-    func testAuthorizeAccount_vaultTrue_sendsSucessAnalyticsEvent() {
+    func testTokenizeVenmoAccount_vaultTrue_sendsSucessAnalyticsEvent() {
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.validClientToken)
         mockAPIClient.cannedResponseBody = BTJSON(value: [
@@ -367,7 +372,9 @@ class BTVenmoDriver_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "Callback invoked")
 
-        venmoDriver.authorizeAccountAndVault(true) { (venmoAccount, error) -> Void in
+        venmoRequest.vault = true
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(error)
 
             XCTAssertEqual(venmoAccount?.username, "venmojoe")
@@ -383,7 +390,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.vault.success")
     }
 
-    func testAuthorizeAccount_vaultTrue_sendsFailureAnalyticsEvent() {
+    func testTokenizeVenmoAccount_vaultTrue_sendsFailureAnalyticsEvent() {
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.validClientToken)
         mockAPIClient.cannedResponseError = NSError(domain: "Fake Error", code: 400, userInfo: nil)
@@ -393,8 +400,10 @@ class BTVenmoDriver_Tests: XCTestCase {
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
         
         let expectation = self.expectation(description: "Callback invoked")
-        
-        venmoDriver.authorizeAccountAndVault(true) { (venmoAccount, error) -> Void in
+
+        venmoRequest.vault = true
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -405,14 +414,14 @@ class BTVenmoDriver_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.vault.failure")
     }
 
-    func testAuthorizeAccount_whenAppSwitchCancelled_callsBackWithNoError() {
+    func testTokenizeVenmoAccount_whenAppSwitchCancelled_callsBackWithNoError() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         venmoDriver.application = FakeApplication()
         venmoDriver.bundle = FakeBundle()
         BTAppSwitch.sharedInstance().returnURLScheme = "scheme"
 
         let expectation = self.expectation(description: "Callback invoked")
-        venmoDriver.authorizeAccountAndVault(false) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(venmoAccount)
             XCTAssertNil(error)
             expectation.fulfill()
@@ -429,7 +438,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.application = fakeApplication
         venmoDriver.bundle = FakeBundle()
 
-        venmoDriver.authorizeAccount(profileID: nil, vault: false) { (_, _) in }
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (_, _) in }
 
         XCTAssertTrue(fakeApplication.openURLWasCalled)
         XCTAssertEqual(fakeApplication.lastOpenURL!.scheme, "com.venmo.touch.v2")
@@ -444,7 +453,9 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.application = fakeApplication
         venmoDriver.bundle = FakeBundle()
 
-        venmoDriver.authorizeAccount(profileID: "second_venmo_merchant_id", vault: false) { (_, _) in }
+        venmoRequest.profileID = "second_venmo_merchant_id"
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (_, _) in }
 
         XCTAssertTrue(fakeApplication.openURLWasCalled)
         XCTAssertEqual(fakeApplication.lastOpenURL!.scheme, "com.venmo.touch.v2")

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -581,8 +581,10 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.bundle = FakeBundle()
 
         let expectation = self.expectation(description: "Callback invoked")
+        let venmoRequest = BTVenmoRequest()
+        venmoRequest.vault = true
 
-        venmoDriver.authorizeAccountAndVault(true) { (venmoAccount, error) -> Void in
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccount, error) -> Void in
             XCTAssertNil(error)
 
             XCTAssertEqual(venmoAccount?.username, "venmotim")

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -119,3 +119,21 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
     return false
 }
 ```
+
+## Venmo
+
+The `authorizeAccount` methods on `BTVenmoDriver` have been replaced with a `tokenizeVenmoAccount` method.
+
+```
+let venmoRequest = BTVenmoRequest()
+venmoRequest.profileID = "my-profile-id"
+venmoRequest.vault = true
+
+venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccountNonce, error) -> Void in
+  if (error != nil) {
+    // handle error
+  }
+
+  // transact with nonce on server
+}
+```


### PR DESCRIPTION
### Summary of changes

- Addresses feedback in PR #595 
- Adds `BTVenmoRequest`
- Replaces methods on `BTVenmoDriver` that required separate `vault` and `profileID` params to accept a single `BTVenmoRequest` 
- Update V5_MIGRATION_GUIDE.md

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo @sestevens 
