### PR TITLE
SPM Analytics Metadata

### DIFF
--- a/Sources/BraintreeCore/BTAnalyticsMetadata.m
+++ b/Sources/BraintreeCore/BTAnalyticsMetadata.m
@@ -2,14 +2,6 @@
 #import "Braintree-Version.h"
 #import "BTKeychain.h"
 
-#if __has_include(<Braintree/BraintreePaymentFlow.h>) // CocoaPods
-#import <Braintree/BTLogger_Internal.h>
-#elif SWIFT_PACKAGE // SPM
-#import "../BraintreeCore/BTLogger_Internal.h"
-#else // Carthage
-#import <BraintreeCore/BTLogger_Internal.h>
-#endif
-
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
@@ -97,13 +89,10 @@
 
 - (NSString *)iosPackageManager {
 #ifdef COCOAPODS
-    [[BTLogger sharedLogger] critical:@"Analytics found CocoaPods]"];
     return @"CocoaPods";
 #elif SWIFT_PACKAGE
-    [[BTLogger sharedLogger] critical:@"Analytics found SPM]"];
     return @"Swift Package Manager";
 #else
-    [[BTLogger sharedLogger] critical:@"Analytics found Carthage/Other]"];
     return @"Carthage or Other";
 #endif
 }

--- a/Sources/BraintreeCore/BTAnalyticsMetadata.m
+++ b/Sources/BraintreeCore/BTAnalyticsMetadata.m
@@ -2,6 +2,14 @@
 #import "Braintree-Version.h"
 #import "BTKeychain.h"
 
+#if __has_include(<Braintree/BraintreePaymentFlow.h>) // CocoaPods
+#import <Braintree/BTLogger_Internal.h>
+#elif SWIFT_PACKAGE // SPM
+#import "../BraintreeCore/BTLogger_Internal.h"
+#else // Carthage
+#import <BraintreeCore/BTLogger_Internal.h>
+#endif
+
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
@@ -26,8 +34,7 @@
     [self setObject:[m iosBaseSDK] forKey:@"iosBaseSDK" inDictionary:data];
     [self setObject:[m iosDeploymentTarget] forKey:@"iosDeploymentTarget" inDictionary:data];
     [self setObject:[m iosIdentifierForVendor] forKey:@"iosIdentifierForVendor" inDictionary:data];
-    [self setObject:@([m iosIsCocoapods]) forKey:@"iosIsCocoapods" inDictionary:data];
-    [self setObject:@([m iosIsSwiftPackageManager]) forKey:@"iosIsSwiftPackageManager" inDictionary:data];
+    [self setObject:[m iosPackageManager] forKey:@"iosPackageManager" inDictionary:data];
     [self setObject:[m deviceAppGeneratedPersistentUuid] forKey:@"deviceAppGeneratedPersistentUuid" inDictionary:data];
     [self setObject:@([m isSimulator]) forKey:@"isSimulator" inDictionary:data];
     [self setObject:[m deviceScreenOrientation] forKey:@"deviceScreenOrientation" inDictionary:data];
@@ -88,6 +95,19 @@
     return UIDevice.currentDevice.identifierForVendor.UUIDString;
 }
 
+- (NSString *)iosPackageManager {
+#ifdef COCOAPODS
+    [[BTLogger sharedLogger] critical:@"Analytics found CocoaPods]"];
+    return @"CocoaPods";
+#elif SWIFT_PACKAGE
+    [[BTLogger sharedLogger] critical:@"Analytics found SPM]"];
+    return @"Swift Package Manager";
+#else
+    [[BTLogger sharedLogger] critical:@"Analytics found Carthage/Other]"];
+    return @"Carthage or Other";
+#endif
+}
+
 - (NSString *)iosDeploymentTarget {
     NSString *rawVersionString = NSBundle.mainBundle.infoDictionary[@"MinimumOSVersion"];
     NSArray<NSString *> *rawVersionArray = [rawVersionString componentsSeparatedByString:@"."];
@@ -110,22 +130,6 @@
 
 - (NSString *)iosSystemName {
     return UIDevice.currentDevice.systemName;
-}
-
-- (BOOL)iosIsCocoapods {
-#ifdef COCOAPODS
-    return YES;
-#else
-    return NO;
-#endif
-}
-
-- (BOOL)iosIsSwiftPackageManager {
-#ifdef SWIFT_PACKAGE
-    return YES;
-#else
-    return NO;
-#endif
 }
 
 - (NSString *)deviceAppGeneratedPersistentUuid {

--- a/Sources/BraintreeCore/BTAnalyticsMetadata.m
+++ b/Sources/BraintreeCore/BTAnalyticsMetadata.m
@@ -27,6 +27,7 @@
     [self setObject:[m iosDeploymentTarget] forKey:@"iosDeploymentTarget" inDictionary:data];
     [self setObject:[m iosIdentifierForVendor] forKey:@"iosIdentifierForVendor" inDictionary:data];
     [self setObject:@([m iosIsCocoapods]) forKey:@"iosIsCocoapods" inDictionary:data];
+    [self setObject:@([m iosIsSwiftPackageManager]) forKey:@"iosIsSwiftPackageManager" inDictionary:data];
     [self setObject:[m deviceAppGeneratedPersistentUuid] forKey:@"deviceAppGeneratedPersistentUuid" inDictionary:data];
     [self setObject:@([m isSimulator]) forKey:@"isSimulator" inDictionary:data];
     [self setObject:[m deviceScreenOrientation] forKey:@"deviceScreenOrientation" inDictionary:data];
@@ -113,6 +114,14 @@
 
 - (BOOL)iosIsCocoapods {
 #ifdef COCOAPODS
+    return YES;
+#else
+    return NO;
+#endif
+}
+
+- (BOOL)iosIsSwiftPackageManager {
+#ifdef SWIFT_PACKAGE
     return YES;
 #else
     return NO;

--- a/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
@@ -109,6 +109,11 @@ describe(@"metadata", ^{
             expect([BTAnalyticsMetadata metadata][@"iosIsCocoapods"]).to.beKindOf([NSNumber class]);
         });
     });
+    describe(@"iosIsSwiftPackageManager", ^{
+        it(@"is present", ^{
+            expect([BTAnalyticsMetadata metadata][@"iosIsSwiftPackageManager"]).to.beKindOf([NSNumber class]);
+        });
+    });
     describe(@"isSimulator", ^{
         it(@"returns true for ios simulators", ^{
             expect([BTAnalyticsMetadata metadata][@"isSimulator"]).to.beTruthy();

--- a/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
@@ -104,14 +104,9 @@ describe(@"metadata", ^{
             [mock stopMocking];
         });
     });
-    describe(@"iosIsCocoaPods", ^{
-        it(@"is present", ^{
-            expect([BTAnalyticsMetadata metadata][@"iosIsCocoapods"]).to.beKindOf([NSNumber class]);
-        });
-    });
-    describe(@"iosIsSwiftPackageManager", ^{
-        it(@"is present", ^{
-            expect([BTAnalyticsMetadata metadata][@"iosIsSwiftPackageManager"]).to.beKindOf([NSNumber class]);
+    describe(@"iosPackageManager", ^{
+        it(@"returns some string value", ^{
+            expect([BTAnalyticsMetadata metadata][@"iosPackageManager"]).to.beTruthy();
         });
     });
     describe(@"isSimulator", ^{

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -22,7 +22,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.nonce = "fake-card-nonce"
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.versionRequested = .version2
-        threeDSecureRequest.dfReferenceId = "df-reference-id"
+        threeDSecureRequest.dfReferenceID = "df-reference-id"
         threeDSecureRequest.accountType = .credit
         threeDSecureRequest.challengeRequested = true
         threeDSecureRequest.exemptionRequested = true


### PR DESCRIPTION
### Summary
Add Analytics metadata for if Swift Package Manager is used.

### Note
It would be nice to have an `iosPackageManager` field that returns a string `CocoaPods`, `Swift Package Manager`, or `Carthage`. However, there is no way to differentiate between a Carthage integration & a manual integration. 

We could leave as-is, or instead have an `iosPackageManager` field with the options of:
- `CocoaPods`
- `Swift Package Manager`
- `Carthage or Manual integration`

### Checklist

- ~Added a changelog entry~