### PR TITLE
Clean up BTDataCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   * Replace `BTVenmoDriver.authorizeAccount` methods with `BTVenmoDriver.tokenizeVenmoAccount`
   * Remove `BTDataCollectorDelegate`
   * Remove `BTDataCollector.collectCardFraudData()`
+  * Remove `BTDataCollectorKountErrorDomain`
 * Fix memory leak in `BTPayPalDriver`
 * Add `offerPayLater` to `BTPayPalRequest`
 * Add `environment` to `BTConfiguration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
     * `BTVenmoDriver.authorizeAccount(profileID:vault:completion:)`
   * Remove `initWithNumber` and `initWithParameters` initializers from `BTCard`
   * Replace `BTVenmoDriver.authorizeAccount` methods with `BTVenmoDriver.tokenizeVenmoAccount`
+  * Remove `BTDataCollectorDelegate`
+  * Remove `BTDataCollector.collectCardFraudData()`
 * Fix memory leak in `BTPayPalDriver`
 * Add `offerPayLater` to `BTPayPalRequest`
 * Add `environment` to `BTConfiguration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@
     * `BTVenmoDriver.authorizeAccount(profileID:vault:completion:)`
   * Remove `initWithNumber` and `initWithParameters` initializers from `BTCard`
   * Replace `BTVenmoDriver.authorizeAccount` methods with `BTVenmoDriver.tokenizeVenmoAccount`
-  * Remove `BTDataCollectorDelegate`
-  * Remove `BTDataCollector.collectCardFraudData()`
-  * Remove `BTDataCollectorKountErrorDomain`
+  * BraintreeDataCollector
+    * Remove `BTDataCollectorDelegate`
+    * Remove `BTDataCollector.collectCardFraudData()`
+    * Remove `BTDataCollectorKountErrorDomain`
 * Fix memory leak in `BTPayPalDriver`
 * Add `offerPayLater` to `BTPayPalRequest`
 * Add `environment` to `BTConfiguration`

--- a/Demo/Application/Features/Fraud Protection - BTDataCollector/BraintreeDemoBTDataCollectorViewController.m
+++ b/Demo/Application/Features/Fraud Protection - BTDataCollector/BraintreeDemoBTDataCollectorViewController.m
@@ -3,7 +3,7 @@
 @import PayPalDataCollector;
 @import CoreLocation;
 
-@interface BraintreeDemoBTDataCollectorViewController () <BTDataCollectorDelegate>
+@interface BraintreeDemoBTDataCollectorViewController ()
 
 /// Retain BTDataCollector for entire lifecycle of view controller
 @property (nonatomic, strong) BTDataCollector *dataCollector;
@@ -34,12 +34,6 @@
     [collectButton addTarget:self
                       action:@selector(tappedCollect)
             forControlEvents:UIControlEventTouchUpInside];
-    
-    UIButton *collectKountButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [collectKountButton setTitle:NSLocalizedString(@"Collect Kount Data", nil) forState:UIControlStateNormal];
-    [collectKountButton addTarget:self
-                           action:@selector(tappedCollectKount)
-                 forControlEvents:UIControlEventTouchUpInside];
 
     UIButton *collectPayPalButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [collectPayPalButton setTitle:NSLocalizedString(@"Collect PayPal Data", nil) forState:UIControlStateNormal];
@@ -52,7 +46,6 @@
     self.dataLabel.numberOfLines = 0;
 
     UIStackView *stackView = [[UIStackView alloc] initWithArrangedSubviews:@[collectButton,
-                                                                             collectKountButton,
                                                                              collectPayPalButton,
                                                                              self.dataLabel]];
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -77,20 +70,13 @@
     ]];
     
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
-    self.dataCollector.delegate = self;
 }
 
 - (IBAction)tappedCollect {
     self.progressBlock(@"Started collecting all data...");
     [self.dataCollector collectDeviceData:^(NSString * _Nonnull deviceData) {
         self.dataLabel.text = deviceData;
-    }];
-}
-
-- (IBAction)tappedCollectKount {
-    self.progressBlock(@"Started collecting Kount data...");
-    [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {
-        self.dataLabel.text = deviceData;
+        self.progressBlock(@"Collected all device data!");
     }];
 }
 

--- a/IntegrationTests/BraintreeDataCollector_IntegrationTests.m
+++ b/IntegrationTests/BraintreeDataCollector_IntegrationTests.m
@@ -34,29 +34,4 @@
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
 
-- (void)testCollectCardFraudData_alsoReturnsPayPalFraudData {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Callback invoked"];
-    [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {
-        XCTAssertTrue([deviceData containsString:@"correlation_id"]);
-        XCTAssertTrue([deviceData containsString:@"device_session_id"]);
-        XCTAssertTrue([deviceData containsString:@"fraud_merchant_id"]);
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:10 handler:nil];
-}
-
-// Test is failing because Kount is no longer async and doesn't return errors
-- (void)pendCollectCardFraudData_whenMerchantIDIsInvalid_invokesErrorCallback {
-    [self.dataCollector setFraudMerchantID:@"-1"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Error callback invoked"];
-    
-    [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {
-        NSLog(@"%@", deviceData);
-        //XCTAssertEqualObjects(error.localizedDescription, @"Merchant ID formatted incorrectly.");
-        //XCTAssertEqual(error.code, (NSInteger)KDataCollectorErrorCodeBadParameter);
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:10 handler:nil];
-}
-
 @end

--- a/IntegrationTests/BraintreeDataCollector_IntegrationTests.m
+++ b/IntegrationTests/BraintreeDataCollector_IntegrationTests.m
@@ -34,50 +34,6 @@
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
 
-- (void)testCollectDeviceDataWithCallback_returnsAllFraudData {
-    BTAPIClient *apiClient = [[BTAPIClient alloc] initWithAuthorization:SANDBOX_TOKENIZATION_KEY];
-    self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:apiClient];
-    id delegate = OCMProtocolMock(@protocol(BTDataCollectorDelegate));
-    self.dataCollector.delegate = delegate;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Delegate received completion callback"];
-    OCMStub([delegate dataCollectorDidComplete:self.dataCollector]).andDo(^(__unused NSInvocation *invocation) {
-        [expectation fulfill];
-    });
-
-    XCTestExpectation *callbackExpectation = [self expectationWithDescription:@"Callback invoked"];
-    [self.dataCollector collectDeviceData:^(NSString * _Nonnull deviceData) {
-        XCTAssertTrue([deviceData containsString:@"correlation_id"]);
-        XCTAssertTrue([deviceData containsString:@"device_session_id"]);
-        XCTAssertTrue([deviceData containsString:@"fraud_merchant_id"]);
-        [callbackExpectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:10 handler:nil];
-}
-
-- (void)testCollectCardFraudDataWithCallback_alsoReturnsPayPalFraudData {
-    BTAPIClient *apiClient = [[BTAPIClient alloc] initWithAuthorization:SANDBOX_TOKENIZATION_KEY];
-    self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:apiClient];
-
-    id delegate = OCMProtocolMock(@protocol(BTDataCollectorDelegate));
-    self.dataCollector.delegate = delegate;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Delegate received completion callback"];
-    OCMStub([delegate dataCollectorDidComplete:self.dataCollector]).andDo(^(__unused NSInvocation *invocation) {
-        [expectation fulfill];
-    });
-
-    XCTestExpectation *callbackExpectation = [self expectationWithDescription:@"Callback invoked"];
-    [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {
-        XCTAssertTrue([deviceData containsString:@"correlation_id"]);
-        XCTAssertTrue([deviceData containsString:@"device_session_id"]);
-        XCTAssertTrue([deviceData containsString:@"fraud_merchant_id"]);
-        [callbackExpectation fulfill];
-    }];
-    
-
-    [self waitForExpectationsWithTimeout:10 handler:nil];
-}
-
 - (void)testCollectCardFraudData_alsoReturnsPayPalFraudData {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback invoked"];
     [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -81,9 +81,6 @@ static Class PayPalDataCollectorClass;
 
 #pragma mark - Public methods
 
-
-#pragma mark - Helper methods
-
 - (void)collectDeviceData:(void (^)(NSString * _Nonnull))completion {
     [self.apiClient fetchOrReturnRemoteConfiguration:^(BTConfiguration * _Nullable configuration, NSError * _Nullable __unused _) {
         NSMutableDictionary *dataDictionary = [NSMutableDictionary new];
@@ -130,6 +127,8 @@ static Class PayPalDataCollectorClass;
         });
     }];
 }
+
+#pragma mark - Helper methods
 
 + (NSString *)generatePayPalClientMetadataID {
 #pragma clang diagnostic push

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -35,8 +35,6 @@ typedef NS_ENUM(NSInteger, BTDataCollectorEnvironment) {
 
 static Class PayPalDataCollectorClass;
 
-NSString * const BTDataCollectorKountErrorDomain = @"com.braintreepayments.BTDataCollectorKountErrorDomain";
-
 #pragma mark - Initialization and setup
 
 + (void)load {

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 @class BTAPIClient;
 
-@protocol BTDataCollectorDelegate;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -14,12 +12,6 @@ extern NSString * const BTDataCollectorKountErrorDomain;
  Braintree's advanced fraud protection solution
 */
 @interface BTDataCollector : NSObject
-
-/**
- Set a BTDataCollectorDelegate to receive notifications about collector events.
- @see BTDataCollectorDelegate protocol declaration
-*/
-@property (nonatomic, weak) id<BTDataCollectorDelegate> delegate;
 
 /**
  Initializes a `BTDataCollector` instance with a BTAPIClient.
@@ -40,22 +32,6 @@ extern NSString * const BTDataCollectorKountErrorDomain;
 */
 - (void)collectDeviceData:(void (^)(NSString *deviceData))completion;
 
-/**
- Collects device data for Kount.
-
- This should be used when the user is paying with a card.
-
- For lifecycle events such as a completion callback, use BTDataCollectorDelegate. Although you do not need
- to wait for the completion callback before performing the transaction, the data will be most effective if you do.
- Normal response time is less than 1 second, and it should never take more than 10 seconds.
-
- We recommend that you call this method as early as possible, e.g. at app launch. If that's too early,
- calling it e.g. when the customer initiates checkout should also be fine.
-
- @param completion A completion block callback that returns a deviceData string that should be passed in to server-side calls, such as `Transaction.sale` This JSON serialized string contains the merchant ID and session ID.
-*/
-- (void)collectCardFraudData:(void (^)(NSString *deviceData))completion;
-
 #pragma mark - Direct Integrations
 
 /**
@@ -66,39 +42,6 @@ extern NSString * const BTDataCollectorKountErrorDomain;
  @param fraudMerchantID The fraudMerchantID you have established with your Braintree account manager.
 */
 - (void)setFraudMerchantID:(NSString *)fraudMerchantID;
-
-@end
-
-/**
- Provides status updates from a BTDataCollector instance. At this time, updates will only be sent for card fraud data (from Kount).
-*/
-@protocol BTDataCollectorDelegate <NSObject>
-
-/**
- The collector finished successfully.
-
- Use this delegate method if, due to fraud, you want to wait
- until collection completes before performing a transaction.
-
- This method is required because there's no reason to implement BTDataCollectorDelegate without this method.
-*/
-- (void)dataCollectorDidComplete:(BTDataCollector *)dataCollector;
-
-@optional
-
-/**
- The collector has started.
-*/
-- (void)dataCollectorDidStart:(BTDataCollector *)dataCollector;
-
-/**
- An error occurred.
-
- @param error Triggering error. If the error domain is BTDataCollectorKountErrorDomain, then the
-              errorCode is a Kount error code. See error.userInfo[NSLocalizedFailureReasonErrorKey]
-              for the cause of the failure.
-*/
-- (void)dataCollector:(BTDataCollector *)dataCollector didFailWithError:(NSError *)error;
 
 @end
 

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
@@ -4,11 +4,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Domain for Kount errors.
- */
-extern NSString * const BTDataCollectorKountErrorDomain;
-
-/**
  Braintree's advanced fraud protection solution
 */
 @interface BTDataCollector : NSObject

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -29,7 +29,7 @@ class BTDataCollector_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testCollectDeviceData_whenMerchantHasKountConfiguration_collectsAllData() {
+    func testCollectDeviceData_whenMerchantConfiguredForKount_collectsAllData() {
         let config = [
             "environment": "development" as AnyObject,
             "kount": [
@@ -51,7 +51,7 @@ class BTDataCollector_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testCollectDeviceData_whenMerchantHasKountConfiguration_setsMerchantIDOnKount() {
+    func testCollectDeviceData_whenMerchantConfiguredForKount_setsMerchantIDOnKount() {
         let config = [
             "environment": "sandbox",
             "kount": [
@@ -74,7 +74,7 @@ class BTDataCollector_Tests: XCTestCase {
         XCTAssertEqual(KEnvironment.test, stubKount.environment)
     }
 
-    func testCollectDeviceData_doesNotCollectKountDataIfDisabledInConfiguration() {
+    func testCollectDeviceData_whenMerchantNotConfiguredForKount_doesNotCollectKountData() {
         let config = [
             "environment": "development",
             "kount": [

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -22,7 +22,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.nonce = "fake-card-nonce"
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.versionRequested = .version2
-        threeDSecureRequest.dfReferenceId = "df-reference-id"
+        threeDSecureRequest.dfReferenceID = "df-reference-id"
         threeDSecureRequest.accountType = .credit
         threeDSecureRequest.challengeRequested = true
         threeDSecureRequest.exemptionRequested = true

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -171,3 +171,9 @@ venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccountNonce, error
   // transact with nonce on server
 }
 ```
+
+## BraintreeDataCollector
+
+v5 removes the `BTDataCollector.collectCardFraudData()` method. You should instead use `BTDataCollector.collectDeviceData()` which will collect Kount data if your merchant account is properly setup for a Kount integration.
+
+v5 also removes the `BTDataCollectorDelegate`. You should call `collectDeviceData()` as early as possible, e.g. at app launch. If that's too early, calling it when the customer initiates checkout is also fine.

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -172,7 +172,7 @@ venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccountNonce, error
 }
 ```
 
-## BraintreeDataCollector
+## Data Collector
 
 v5 removes the `BTDataCollector.collectCardFraudData()` method. You should instead use `BTDataCollector.collectDeviceData()` which will collect Kount data if your merchant account is properly setup for a Kount integration.
 


### PR DESCRIPTION
### Summary

- Addresses comments in #595 
- Android (and JS to my understanding) doesn't have an equivalent of `BTDataCollectorDelegate` for merchants to hook into notifications for when Kount started, succeeded, or errored.
- We can remove `collectCardFraudData` in favor of `collectDeviceData`, since both methods collected all data (Kount & PayPal). This also matches Android.

### Changes

- Remove `BTDataCollectorDelegate`
- Remove `BTDataCollector.collectCardFraudData()` method
- Remove `BTDataCollectorKountErrorDomain`

### Checklist

- [X] Added a changelog entry

### Authors

- @scannillo
