### PR TITLE
Remove bt_int_type from PayPal checkout URL

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -242,9 +242,6 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 - (void)performSwitchRequest:(NSURL *)appSwitchURL paymentType:(BTPayPalPaymentType)paymentType completion:(void (^)(BTPayPalAccountNonce *, NSError *))completionBlock {
     NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:appSwitchURL resolvingAgainstBaseURL:NO];
 
-    NSString *queryForAuthSession = [urlComponents.query stringByAppendingString:@"&bt_int_type=2"];
-    urlComponents.query = queryForAuthSession;
-
     self.authenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:urlComponents.URL
                                                                   callbackURLScheme:BTPayPalCallbackURLScheme
                                                                   completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {


### PR DESCRIPTION
### Summary of changes

- Addresses feedback in #595 
- JS and Android do not include this `bt_int_type` param on the PayPal checkout URLs. It was used a few years ago for some A/B testing with `SFSafariAuthenticationSession`, and is no longer used in other BT repos. (Confirmed by @crookedneighbor).

### Checklist

- ~Added a changelog entry~
