### PR TITLE
update bundler @ 2.2.9, drops supports for Ruby versions < 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,4 +114,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.3
+   2.2.9


### PR DESCRIPTION
### Summary of changes

- we noticed we haven't been using the [newest major version](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html) of bundler, so this PR updates the Gemfile. Biggest change is that bundler v2 drops support for ruby versions lower than 2.3.0.

### Checklist

- We don't think this needs a CHANGELOG entry, but if folks feel otherwise let us know.

### Authors
> @scannillo 
> @hollabaq86 
