### PR TITLE
PayPal Checkout with Vault (Take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,10 @@
 * Add `BTVenmoRequest`
 * PayPal
   * Fix memory leak in `BTPayPalDriver`
-  * Add `offerPayLater` to `BTPayPalRequest`
   * Add `BTPayPalCheckoutRequest`
   * Add `BTPayPalVaultRequest`
   * Add `tokenizePayPalAccount` method to `BTPayPalDriver`
+  * Add `offerPayLater` and `requestBillingAgreement` to `BTPayPalCheckoutRequest`
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.m
@@ -46,6 +46,14 @@
         parameters[@"currency_iso_code"] = currencyCode;
     }
 
+    if (self.requestBillingAgreement) {
+        parameters[@"request_billing_agreement"] = @(self.requestBillingAgreement);
+    }
+
+    if (self.requestBillingAgreement && self.billingAgreementDescription) {
+        parameters[@"billing_agreement_details"] = @{@"description": self.billingAgreementDescription};
+    }
+
     if (self.shippingAddressOverride) {
         parameters[@"line1"] = self.shippingAddressOverride.streetAddress;
         parameters[@"line2"] = self.shippingAddressOverride.extendedAddress;

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalCheckoutRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalCheckoutRequest.h
@@ -65,6 +65,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestIntent) {
  */
 @property (nonatomic) BOOL offerPayLater;
 
+/**
+ Optional: If set to true, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
+ */
+@property (nonatomic) BOOL requestBillingAgreement;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -129,6 +129,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic, nullable, copy) NSArray<BTPayPalLineItem *> *lineItems;
 
 /**
+ Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set requestBillingAgreement to true on your BTPayPalCheckoutRequest.
+*/
+@property (nonatomic, nullable, copy) NSString *billingAgreementDescription;
+
+/**
  Optional: The window used to present the ASWebAuthenticationSession.
 
  @note If your app supports multitasking, you must set this property to ensure that the ASWebAuthenticationSession is presented on the correct window.

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalVaultRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalVaultRequest.h
@@ -8,11 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BTPayPalVaultRequest : BTPayPalRequest
 
-/**
- Optional: Display a custom description to the user for a billing agreement.
-*/
-@property (nonatomic, nullable, copy) NSString *billingAgreementDescription;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -63,6 +63,8 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         request.intent = .sale
         request.offerPayLater = true
         request.currencyCode = "currency-code"
+        request.requestBillingAgreement = true
+        request.billingAgreementDescription = "description"
 
         let shippingAddress = BTPostalAddress()
         shippingAddress.streetAddress = "123 Main"
@@ -88,6 +90,14 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(parameters["postal_code"] as? String, "11111")
         XCTAssertEqual(parameters["country_code"] as? String, "US")
         XCTAssertEqual(parameters["recipient_name"] as? String, "Recipient")
+        XCTAssertEqual(parameters["request_billing_agreement"] as? Bool, true)
+
+        guard let billingAgreementDetails = parameters["billing_agreement_details"] as? [String : String] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(billingAgreementDetails["description"], "description")
     }
 
     func testParametersWithConfiguration_returnsMinimumParams() {
@@ -114,5 +124,15 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         let parameters = request.parameters(with: configuration)
 
         XCTAssertEqual(parameters["currency_iso_code"] as? String, "currency-code")
+    }
+
+    func testParametersWithConfiguration_whenRequestBillingAgreementIsFalse_andBillingAgreementDescriptionIsSet_doesNotReturnDescription() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.billingAgreementDescription = "description"
+
+        let parameters = request.parameters(with: configuration)
+
+        XCTAssertNil(parameters["request_billing_agreement"])
+        XCTAssertNil(parameters["billing_agreement_details"])
     }
 }


### PR DESCRIPTION
### Replaces #599 

### Summary of changes

- Add `requestBillingAgreement` to `BTPayPalCheckoutRequest`
- Move `billingAgreementDescription` from `BTPayPalVaultRequest` to `BTPayPalRequest`

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
