### PR TITLE
Update v5 changelog to include links to betas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
   * Add `offerPayLater` and `requestBillingAgreement` to `BTPayPalCheckoutRequest`
 * Update CardinalMobile.framework to v2.2.5
 
-**Note:** Includes all changes in [5.0.0-beta2](##500-beta2-2021-01-20) and [5.0.0-beta1](##500-beta1-2020-12-01)
+**Note:** Includes all changes in [5.0.0-beta2](#500-beta2-2021-01-20) and [5.0.0-beta1](#500-beta1-2020-12-01)
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
   * Add `offerPayLater` and `requestBillingAgreement` to `BTPayPalCheckoutRequest`
 * Update CardinalMobile.framework to v2.2.5
 
-**Note:** Includes all changes in [5.0.0-beta2](#5.0.0-beta2) and [5.0.0-beta1](#5.0.0-beta1)
+**Note:** Includes all changes in [5.0.0-beta2](##500-beta2-2021-01-20) and [5.0.0-beta1](##500-beta1-2020-12-01)
 
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   * Add `offerPayLater` and `requestBillingAgreement` to `BTPayPalCheckoutRequest`
 * Update CardinalMobile.framework to v2.2.5
 
+**Note:** Includes all changes in [5.0.0-beta2](#5.0.0-beta2) and [5.0.0-beta1](#5.0.0-beta1)
+
 ## 5.0.0-beta2 (2021-01-20)
 * Add SPM support for `BraintreeDataCollector` and `BraintreeThreeDSecure`
 * Add SPM libraries for `KountDataCollector` and `PPRiskMagnes` to workaround Xcode bug (addresses #576)


### PR DESCRIPTION


### Summary of changes

- Add links to v5 betas at the end of the v5 CHANGELOG entry so that it's clear that everything in the betas is included in v5.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
