### PR TITLE
Update Release Script and Podspec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           git add .
           git commit -m 'Bump version to ${{ github.event.inputs.version }}'
           git tag ${{ github.event.inputs.version }} -a -m 'Release ${{ github.event.inputs.version }}'
-          git push
+          git push origin tag ${{ github.event.inputs.version }}
 
       # Save changelog entries to a file
       - name: Extract changelog entries

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -11,11 +11,9 @@ Pod::Spec.new do |s|
   DESC
   s.homepage         = "https://www.braintreepayments.com/how-braintree-works"
   s.documentation_url = "https://developers.braintreepayments.com/ios/start/hello-client"
-  s.screenshots      = "https://raw.githubusercontent.com/braintree/braintree_ios/master/Docs/screenshot.png"
   s.license          = "MIT"
   s.author           = { "Braintree" => "code@getbraintree.com" }
   s.source           = { :git => "https://github.com/braintree/braintree_ios.git", :tag => s.version.to_s }
-  s.social_media_url = "https://twitter.com/braintree"
 
   s.platform         = :ios, "12.0"
   s.requires_arc     = true


### PR DESCRIPTION


### Summary of changes

- Fix `git push` step so that it also pushes the tag for the new version
- Remove unneeded links from Braintree.podspec, since they were causing warnings during `pod lib lint`:

```
    - WARN  | url: The URL (https://raw.githubusercontent.com/braintree/braintree_ios/master/Docs/screenshot.png) is not reachable.
    - WARN  | screenshot: The screenshot https://raw.githubusercontent.com/braintree/braintree_ios/master/Docs/screenshot.png is not a valid image.
    - WARN  | url: The URL (https://twitter.com/braintree) is not reachable.
```

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
