### PR TITLE
Update unit tests to use MockAPIClient

### DIFF
--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -11,10 +11,11 @@ class BTDataCollector_Tests: XCTestCase {
                 "kountMerchantId": "500000"
             ]
         ] as [String : Any]
-        
-        let apiClient = clientThatReturnsConfiguration(config as [String : AnyObject])
-        
-        let dataCollector = BTDataCollector(apiClient: apiClient)
+
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
+
+        let dataCollector = BTDataCollector(apiClient: mockAPIClient)
         dataCollector.setFraudMerchantID("500001")
         let expectation = self.expectation(description: "Returns fraud data")
         
@@ -36,8 +37,11 @@ class BTDataCollector_Tests: XCTestCase {
                 "kountMerchantId": "500000"
             ]
         ] as [String : Any]
-        let apiClient = clientThatReturnsConfiguration(config as [String : AnyObject])
-        let dataCollector = BTDataCollector(apiClient: apiClient)
+        
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
+
+        let dataCollector = BTDataCollector(apiClient: mockAPIClient)
 
         let expectation = self.expectation(description: "Returns fraud data")
         dataCollector.collectDeviceData { deviceData in
@@ -58,8 +62,11 @@ class BTDataCollector_Tests: XCTestCase {
                 "kountMerchantId": "500000"
             ]
         ] as [String : Any]
-        let apiClient = clientThatReturnsConfiguration(config as [String : AnyObject])
-        let dataCollector = BTDataCollector(apiClient: apiClient)
+
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
+
+        let dataCollector = BTDataCollector(apiClient: mockAPIClient)
         let stubKount = FakeDeviceCollectorSDK()
         dataCollector.kount = stubKount
 
@@ -81,9 +88,11 @@ class BTDataCollector_Tests: XCTestCase {
                 "kountMerchantId": nil
             ]
         ] as [String : Any]
-        let apiClient = clientThatReturnsConfiguration(config as [String : AnyObject])
-        
-        let dataCollector = BTDataCollector(apiClient: apiClient)
+
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
+
+        let dataCollector = BTDataCollector(apiClient: mockAPIClient)
         let expectation = self.expectation(description: "Returns fraud data")
         dataCollector.collectDeviceData { deviceData in
             let json = BTJSON(data: deviceData.data(using: String.Encoding.utf8)!)
@@ -95,17 +104,6 @@ class BTDataCollector_Tests: XCTestCase {
         
         waitForExpectations(timeout: 2, handler: nil)
     }
-}
-
-func clientThatReturnsConfiguration(_ configuration: [String:AnyObject]) -> BTAPIClient {
-    let apiClient = BTAPIClient(authorization: "development_tokenization_key", sendAnalyticsEvent: false)!
-    let fakeHttp = FakeHTTP.fakeHTTP()
-    let cannedConfig = BTJSON(value: configuration)
-    fakeHttp.cannedConfiguration = cannedConfig
-    fakeHttp.cannedStatusCode = 200
-    apiClient.configurationHTTP = fakeHttp
-    
-    return apiClient
 }
 
 class FakeDeviceCollectorSDK: KDataCollector {

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -5,9 +5,11 @@ public class MockAPIClient : BTAPIClient {
     public var lastPOSTPath = ""
     public var lastPOSTParameters = [:] as [AnyHashable: Any]?
     public var lastPOSTAPIClientHTTPType: BTAPIClientHTTPType?
-    var lastGETPath = ""
-    var lastGETParameters = [:] as [String : String]?
-    var lastGETAPIClientHTTPType: BTAPIClientHTTPType?
+
+    public var lastGETPath = ""
+    public var lastGETParameters = [:] as [String : String]?
+    public var lastGETAPIClientHTTPType: BTAPIClientHTTPType?
+
     public var postedAnalyticsEvents : [String] = []
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -486,26 +486,7 @@ class BTVenmoDriver_Tests: XCTestCase {
 
     // Note: testing of handleReturnURL is done implicitly while testing authorizeAccountWithCompletion
 
-    // MARK: - Drop-in
-
-    /// Helper
-    func client(_ configurationDictionary: Dictionary<String, String>) -> BTAPIClient {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let fakeHttp = FakeHTTP.fakeHTTP()
-        fakeHttp.cannedResponse = BTJSON(value: configurationDictionary)
-        fakeHttp.cannedStatusCode = 200
-        apiClient.configurationHTTP = fakeHttp
-        return apiClient
-    }
-    
-    func clientWithJson(_ configurationJson: BTJSON) -> BTAPIClient {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let fakeHttp = FakeHTTP.fakeHTTP()
-        fakeHttp.cannedResponse = configurationJson
-        fakeHttp.cannedStatusCode = 200
-        apiClient.configurationHTTP = fakeHttp
-        return apiClient
-    }
+    // MARK: - openVenmoAppPageInAppStore
 
     func testGotoVenmoInAppStore_opensVenmoAppStoreURL_andSendsAnalyticsEvent() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)


### PR DESCRIPTION


### Summary of changes

I noticed that a lot of the unit tests that randomly fail (especially in CI) are using `BTAPIClient` with a mock `BTHTTP` when they could be using `MockAPIClient`. Since `BTAPIClient` kicks off a configuration request in the initializer, I have a hunch that there could be a race condition that causes tests to sporadically fail.

This PR updates unit tests to use `MockAPIClient` where possible. It doesn't address the sporadic failures in the unit tests for `BTAPIClient` itself.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
