### PR TITLE
Update GH Actions Test and Build Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,38 +1,49 @@
 name: Build
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
     name: CocoaPods
     runs-on: macOS-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
-        run: pod lib lint --allow-warnings
+        run: pod lib lint
   carthage:
     name: Carthage
     runs-on: macOS-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Remove SPMTest
-        run: rm -rf SampleApps/SPMTest && git add . && git commit -m 'Remove SPMTest app to avoid Carthage timeout'
-      - name: Run carthage build
-        run: carthage build --no-skip-current
+        run: |
+          git checkout $GITHUB_HEAD_REF
+          rm -rf SampleApps/SPMTest
+          git add SampleApps/SPMTest
+          git commit -m 'Remove SPMTest app to avoid Carthage timeout'
+      - name: Use current branch
+        run: |
+          echo 'git "file://'$PWD'" "'$GITHUB_HEAD_REF'"' > SampleApps/CarthageTest/Cartfile
+      - name: Run carthage update
+        run: cd SampleApps/CarthageTest && carthage update
+      - name: Build CarthageTest
+        run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
     name: SPM
     runs-on: macOS-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,7 @@ jobs:
           git add SampleApps/SPMTest
           git commit -m 'Remove SPMTest app to avoid Carthage timeout'
       - name: Use current branch
-        run: |
-          echo 'git "file://'$PWD'" "'$GITHUB_HEAD_REF'"' > SampleApps/CarthageTest/Cartfile
+        run: echo 'git "file://'$PWD'" "'$GITHUB_HEAD_REF'"' > SampleApps/CarthageTest/Cartfile
       - name: Run carthage update
         run: cd SampleApps/CarthageTest && carthage update
       - name: Build CarthageTest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,14 @@
 name: Tests
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   unit_test_job:
     name: Unit
     runs-on: macOS-latest
     steps:
-      # Checks out a copy of your repository
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
@@ -18,11 +17,10 @@ jobs:
     name: UI
     runs-on: macOS-latest
     steps:
-      # Checks out a copy of your repository
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
@@ -31,11 +29,10 @@ jobs:
     name: Integration
     runs-on: macOS-latest
     steps:
-      # Checks out a copy of your repository
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests


### PR DESCRIPTION

### Summary of changes

- Use actions/checkout@v2 instead of v1
- Use Xcode 12.4 instead of 12.3
- Update Carthage check to build the CarthageTest demo app. This is a more thorough check since it pulls down our dependencies (CardinalMobile and PPRiskMagnes).
- Remove `--allow-warnings` flag from `pod lib lint` so that it fails if there are warnings
- Allow Test and Build workflows to be run manually as well as on pull requests. This way we can run them manually prior to releasing.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
