### PR TITLE
Release script - exit early if changelog doesn't have an unreleased section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       # Check for unreleased section in changelog
       - name: Check for unreleased section in changelog
-        run: grep "## unreleased" CHANGELOG.md || echo "::error::No unreleased section found in CHANGELOG"
+        run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)
 
       # Update the version number
       - name: Update version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Use Xcode 12.4
         run: sudo xcode-select -switch /Applications/Xcode_12.4.app
 
+      # Check for unreleased section in changelog
+      - name: Check for unreleased section in changelog
+        run: grep "## unreleased" CHANGELOG.md || echo "::error::No unreleased section found in CHANGELOG"
+
       # Update the version number
       - name: Update version
         run: |


### PR DESCRIPTION


### Summary of changes

- The release script depends on there being a CHANGELOG section with the header `## unreleased`. Let's fail early if that's not found.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
