### PR TITLE
Use full links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Welcome to Braintree's iOS SDK. This library will help you accept card and alternative payments in your iOS app.
 
-v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 migration guide](/V5_MIGRATION.md).
+v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/master/V5_MIGRATION.md).
 
 **The Braintree iOS SDK requires Xcode 12+**. It permits a Deployment Target of iOS 12.0 or higher.
 
@@ -28,7 +28,7 @@ We recommend using [Swift Package Manager](https://swift.org/package-manager/), 
 ### Swift Package Manager
 _This feature is only available in v5._
 
-See our [Swift Package Manager guide](/SWIFT_PACKAGE_MANAGER.md) for instructions on integrating with SPM.
+See our [Swift Package Manager guide](https://github.com/braintree/braintree_ios/blob/master/SWIFT_PACKAGE_MANAGER.md) for instructions on integrating with SPM.
 
 ### CocoaPods
 ```
@@ -70,7 +70,7 @@ A demo app is included in the project. To run it, run `pod install` and then ope
 
 ## Contributing
 
-We welcome PRs to this repo. See our [development doc](DEVELOPMENT.md).
+We welcome PRs to this repo. See our [development doc](https://github.com/braintree/braintree_ios/blob/master/DEVELOPMENT.md).
 
 ## Feedback
 
@@ -87,8 +87,8 @@ Here are a few ways to get in touch:
 * [Read the Braintree docs](https://developers.braintreepayments.com/ios/sdk/client)
 * [Check out the reference docs](https://braintree.github.io/braintree_ios/)
 * Find a bug? [Open an issue](https://github.com/braintree/braintree_ios/issues)
-* Want to contribute? [Check out contributing guidelines](CONTRIBUTING.md) and [submit a pull request](https://help.github.com/articles/creating-a-pull-request).
+* Want to contribute? [Check out contributing guidelines](https://github.com/braintree/braintree_ios/blob/master/CONTRIBUTING.md) and [submit a pull request](https://help.github.com/articles/creating-a-pull-request).
 
 ### License
 
-The Braintree iOS SDK is open source and available under the MIT license. See the [LICENSE](LICENSE) file for more info.
+The Braintree iOS SDK is open source and available under the MIT license. See the [LICENSE](https://github.com/braintree/braintree_ios/blob/master/LICENSE) file for more info.


### PR DESCRIPTION


### Summary of changes

Use full links in README so that they work when the README is displayed in our [reference docs](https://braintree.github.io/braintree_ios/) and on [CocoaPods](https://cocoapods.org/pods/Braintree).

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
