### PR TITLE
Allow multiple versions of the reference docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Use Xcode 12.4
         run: sudo xcode-select -switch /Applications/Xcode_12.4.app
 
@@ -108,11 +110,12 @@ jobs:
             --author Braintree \
             --author_url http://braintreepayments.com \
             --github_url https://github.com/braintree/braintree_ios \
-            --github-file-prefix https://github.com/braintree/braintree_ios/tree/#{current_version} \
+            --github-file-prefix https://github.com/braintree/braintree_ios/tree/${{ github.event.inputs.version }} \
             --theme fullwidth \
-            --output docs_output
+            --output ${{ github.event.inputs.version }}
         run: |
-          git add docs_output
-          git commit -m "Publish docs to github pages"
-          git subtree split --prefix docs_output -b gh-pages
-          git push -f origin gh-pages:gh-pages
+          git checkout gh-pages
+          ls -sfn ${{ github.event.inputs.version }} current
+          git add current ${{ github.event.inputs.version }}
+          git commit -m "Publish ${{ github.event.inputs.version }} docs to github pages"
+          git push

--- a/Rakefile
+++ b/Rakefile
@@ -286,7 +286,7 @@ def jazzy_command
       --github_url https://github.com/braintree/braintree_ios
       --github-file-prefix https://github.com/braintree/braintree_ios/tree/#{current_version}
       --theme fullwidth
-      --output docs_output
+      --output #{current_version}
   ].join(' ')
 end
 
@@ -317,7 +317,7 @@ def sourcekitten_swift_command
 end
 
 desc "Generate documentation via jazzy and push to GH"
-task :docs_publish => %w[docs:generate docs:publish docs:clean]
+task :docs_publish => %w[docs:generate docs:publish]
 
 namespace :docs do
 
@@ -334,24 +334,17 @@ namespace :docs do
     run(sourcekitten_swift_command)
     run(sourcekitten_objc_command)
     run(jazzy_command)
-    puts "Generated HTML documentation at docs_output"
+    run! "rm swiftDoc.json && rm objcDoc.json"
+    puts "Generated HTML documentation"
   end
 
   task :publish do
-    run "git branch -D gh-pages"
-    run! "git add docs_output"
-    run! "git commit -m 'Publish docs to github pages'"
-    puts "Generating git subtree, this will take a moment..."
-    run! "git subtree split --prefix docs_output -b gh-pages"
-    run! "git push -f #{PUBLIC_REMOTE_NAME} gh-pages:gh-pages"
+    run! "git checkout gh-pages"
+    run! "ln -sfn #{current_version} current" # update symlink to current version
+    run! "git add current #{current_version}"
+    run! "git commit -m 'Publish #{current_version} docs to github pages'"
+    run! "git push"
+    run! "git checkout -"
+    puts "Published docs to github pages"
   end
-
-  task :clean do
-    run! "git reset HEAD~"
-    run! "git branch -D gh-pages"
-    puts "Published docs to gh-pages branch"
-    run! "rm -rf docs_output"
-    run! "rm swiftDoc.json && rm objcDoc.json"
-  end
-
 end


### PR DESCRIPTION

### Summary of changes

- Update Rakefile and release.yml steps for publishing reference docs to allow multiple version to exist at once

I went ahead and published docs for [4.37.0](https://braintree.github.io/braintree_ios/4.37.0/), so they now live alongside the docs for [5.0.0](https://braintree.github.io/braintree_ios/5.0.0/). Ideally, there would be a drop-down allowing you to toggle between versions, but currently you have to change the version in the URL.

[Related PR in iOS Drop-in](https://github.com/braintree/braintree-ios-drop-in/pull/273)

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
