### PR TITLE
Add Elo support to Apple Pay Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+# unreleased
+* Add support for `PKPaymentNetworkElo` to Apple Pay configuration
+
 ## 5.0.1 (2021-03-01)
 * SPM
   * Remove `KountDataCollector` binary dependency from `BraintreeDataCollector` target (fixes #624)

--- a/Sources/BraintreeApplePay/BTConfiguration+ApplePay.m
+++ b/Sources/BraintreeApplePay/BTConfiguration+ApplePay.m
@@ -43,6 +43,10 @@
             [supportedNetworks addObject:PKPaymentNetworkDiscover];
         } else if ([gatewaySupportedNetwork localizedCaseInsensitiveCompare:@"maestro"] == NSOrderedSame) {
             [supportedNetworks addObject:PKPaymentNetworkMaestro];
+        } else if ([gatewaySupportedNetwork localizedCaseInsensitiveCompare:@"elo"] == NSOrderedSame) {
+            if (@available(iOS 12.1.1, *)) {
+                [supportedNetworks addObject:PKPaymentNetworkElo];
+            }
         }
     }
     return [supportedNetworks copy];

--- a/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
@@ -79,6 +79,16 @@ class BTConfiguration_ApplePay_Tests : XCTestCase {
         XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.maestro])
     }
 
+    @available(iOS 12.1.1, *)
+    func testApplePaySupportedNetworks_whenSupportedNetworksIncludesElo_returnsSupportedNetworks() {
+        let configurationJSON = BTJSON(value: [
+            "applePay": [ "supportedNetworks": ["elo"] ]
+            ])
+        let configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.elo])
+    }
+
     func testApplePaySupportedNetworks_doesNotPassesThroughUnknownValuesFromConfiguration() {
         let configurationJSON = BTJSON(value: [
             "applePay": [ "supportedNetworks": ["ChinaUnionPay", "Interac", "PrivateLabel"] ]


### PR DESCRIPTION
### Summary of changes
- Add support for `PKPaymentNetworkElo` when using the gateway configuration for Apple Pay
- Elo support was added in iOS `12.1.1` but we support down to `12.0` so there is an availability check
> extern PKPaymentNetwork const PKPaymentNetworkElo API_AVAILABLE(macos(11.0), ios(12.1.1), watchos(5.1.2));


### Checklist

- [x] Added a changelog entry

### Authors
- @demerino 
