### PR TITLE
Fix potential crash on missing `legacyCode` GraphQL param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Fix potential crash if `legacyCode` param missing from GraphQL error response
+
 ## 5.1.0 (2021-03-08)
 * Local Payment Methods
   * Add `bic` (Bank Identification Code) to `BTLocalPaymentRequest`

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -189,11 +189,14 @@ static NSString *BraintreeVersion = @"2018-03-06";
     NSString *field = [inputPath firstObject];
 
     if (inputPath.count == 1) {
-        [errors addObject:@{
-                            @"field": field,
-                            @"message": errorJSON[@"message"],
-                            @"code": errorJSON[@"extensions"][@"legacyCode"]
-                            }];
+        NSMutableDictionary *errorsBody = [NSMutableDictionary new];
+        [errorsBody setObject:field forKey:@"field"];
+        [errorsBody setObject:errorJSON[@"message"] forKey:@"message"];
+        if (errorJSON[@"extensions"][@"legacyCode"]) { // prevent crash if missing from GraphQL response
+            [errorsBody setObject:errorJSON[@"extensions"][@"legacyCode"] forKey:@"code"];
+        }
+
+        [errors addObject:errorsBody];
         return;
     }
 

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -451,6 +451,51 @@
     }
 }
 
+- (void)testErrorResponse_whenErrorIsMissingLegacyCode_doesNotSetCodeNumber {
+    id stubGraphQLErrorResponse = @{
+                                    @"data": @{@"tokenizeCreditCard": NSNull.null},
+                                    @"errors": @[
+                                            @{
+                                                @"message": @"Expiration month is invalid",
+                                                @"path": @[@"tokenizeCreditCard"],
+                                                @"extensions": @{
+                                                        @"errorType": @"user_error",
+                                                        @"inputPath": @[@"input", @"creditCard", @"expirationMonth"]
+                                                        }
+                                                }
+                                            ],
+                                    @"extensions": @{@"requestId": @"de1f7c67-4861-455f-89bb-1d208915f270"}
+                                    };
+    id expectedErrorBody = @{
+                                 @"error": @{@"message": @"Input is invalid"},
+                                 @"fieldErrors": @[
+                                         @{
+                                             @"field": @"creditCard",
+                                             @"fieldErrors": @[
+                                                     @{
+                                                         @"field": @"expirationMonth",
+                                                         @"message": @"Expiration month is invalid"
+                                                         }
+                                                     ]
+                                             }
+                                         ]
+                                 };
+
+    [HTTPStubs stubRequestsPassingTest:^BOOL(__unused NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^HTTPStubsResponse *(__unused NSURLRequest *request) {
+        return [HTTPStubsResponse responseWithData:[NSJSONSerialization dataWithJSONObject:stubGraphQLErrorResponse options:NSJSONWritingPrettyPrinted error:NULL] statusCode:200 headers:@{@"Content-Type": @"application/json"}];
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback invoked"];
+    [http POST:@"" completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
+        XCTAssertEqualObjects(body.asDictionary, expectedErrorBody);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
 - (void)testNetworkError_returnsError {
     [HTTPStubs stubRequestsPassingTest:^BOOL(__unused NSURLRequest *request) {
         return YES;

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -464,7 +464,6 @@
                                                         }
                                                 }
                                             ],
-                                    @"extensions": @{@"requestId": @"de1f7c67-4861-455f-89bb-1d208915f270"}
                                     };
     id expectedErrorBody = @{
                                  @"error": @{@"message": @"Input is invalid"},


### PR DESCRIPTION
### Why

- I was experiencing an app crash when I was testing removing a vaulted payment method in Drop In. This happened because I was able to trigger a VALIDATION error in attempting to delete a payment method belonging to the incorrect customerID.
- Most features in GraphQL that correspond to a GW behavior include a `legacyCode` in their response. Others, such as delete payment method, don't have a corresponding error code in the GW to warrant including a `legacyCode`.

### Changes

- This PR adds a check for if `errorJSON[@"extensions"][@"legacyCode"]` exists before setting the `code` value.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo