### PR TITLE
Add offerCredit to BTPayPalVaultRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Fix potential crash if `legacyCode` param missing from GraphQL error response
+* PayPal
+  * Add `offerCredit` to `BTPayPalVaultRequest`
 
 ## 5.1.0 (2021-03-08)
 * Local Payment Methods

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -459,6 +459,12 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
         [self.apiClient sendAnalyticsEvent:eventName];
     }
+
+    if ([self.payPalRequest isKindOfClass:BTPayPalVaultRequest.class] && ((BTPayPalVaultRequest *)self.payPalRequest).offerCredit) {
+        NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.credit.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
+
+        [self.apiClient sendAnalyticsEvent:eventName];
+    }
 }
 
 - (void)sendAnalyticsEventIfCreditFinancingInNonce:(BTPayPalAccountNonce *)payPalAccountNonce forPaymentType:(BTPayPalPaymentType)paymentType {

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.m
@@ -23,6 +23,8 @@
         parameters[@"description"] = self.billingAgreementDescription;
     }
 
+    parameters[@"offer_paypal_credit"] = @(self.offerCredit);
+
     if (self.shippingAddressOverride) {
         NSMutableDictionary *shippingAddressParams = [NSMutableDictionary dictionary];
         shippingAddressParams[@"line1"] = self.shippingAddressOverride.streetAddress;

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalVaultRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalVaultRequest.h
@@ -11,6 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface BTPayPalVaultRequest : BTPayPalRequest
 
+/**
+ Optional: Offers PayPal Credit if the customer qualifies. Defaults to false.
+ */
+@property (nonatomic) BOOL offerCredit;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Tests.swift
@@ -258,6 +258,29 @@ class BTPayPalDriver_Tests: XCTestCase {
         XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-single-payment.webswitch.paylater.offered.started"))
     }
 
+    func testTokenizePayPalAccount_whenPayPalCreditOffered_performsSwitchCorrectly() {
+        let request = BTPayPalVaultRequest()
+        request.offerCredit = true
+
+        payPalDriver.tokenizePayPalAccount(with: request) { _,_  in }
+
+        XCTAssertNotNil(payPalDriver.authenticationSession)
+        XCTAssertTrue(payPalDriver.isAuthenticationSessionStarted)
+
+        // Ensure the payment resource had the correct parameters
+        XCTAssertEqual("v1/paypal_hermes/setup_billing_agreement", mockAPIClient.lastPOSTPath)
+        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(lastPostParameters["offer_paypal_credit"] as? Bool, true)
+
+        // Make sure analytics event was sent when switch occurred
+        let postedAnalyticsEvents = mockAPIClient.postedAnalyticsEvents
+
+        XCTAssertTrue(postedAnalyticsEvents.contains("ios.paypal-ba.webswitch.credit.offered.started"))
+    }
+
     func testTokenizePayPalAccount_whenPayPalPaymentCreationSuccessful_performsAppSwitch() {
         let request = BTPayPalCheckoutRequest(amount: "1")
         payPalDriver.tokenizePayPalAccount(with: request) { _,_  -> Void in }

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -47,10 +47,12 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         shippingAddress.recipientName = "Recipient"
         request.shippingAddressOverride = shippingAddress
         request.isShippingAddressEditable = true
+        request.offerCredit = true
 
         let parameters = request.parameters(with: configuration)
 
         XCTAssertEqual(parameters["description"] as? String, "desc")
+        XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)
 
         guard let shippingParams = parameters["shipping_address"] as? [String:String] else { XCTFail(); return }
 

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -185,7 +185,7 @@ payPalDriver.tokenizePayPalAccount(with: request) { nonce, error in
 
 If your app supports multi-tasking, you must set the `BTPayPalRequest.activeWindow` property to ensure that the PayPal flow launches from the correct window.
 
-The `offerCredit` property has been removed in favor of `offerPayLater`.
+For PayPal Checkout flows, the `offerCredit` property has been removed in favor of `offerPayLater`.
 
 #### Other Changes
 


### PR DESCRIPTION


### Summary of changes

- Add `offerCredit` to `BTPayPalVaultRequest`. This field was initially removed from v5 in favor of `offerPayLater`, but since this field only applies to PayPal Checkout flows, `offerCredit` is still needed on PayPal Vault flows.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
