### PR TITLE
Venmo UI Tests w/ MockVenmo app

### DIFF
--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -36,7 +36,7 @@
         } else if (error) {
             self.progressBlock(error.localizedDescription);
         } else {
-            self.progressBlock(@"Canceled 🔰");
+            self.progressBlock(@"Cancelled 🔰");
         }
     }];
 }

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -36,7 +36,7 @@
         } else if (error) {
             self.progressBlock(error.localizedDescription);
         } else {
-            self.progressBlock(@"Cancelled 🔰");
+            self.progressBlock(@"Canceled 🔰");
         }
     }];
 }

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -3,14 +3,22 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		08222B07C311489F90D08D41 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */; };
 		42456E3E25474B620018374E /* BTUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42456E3C25474B620018374E /* BTUITest.swift */; };
 		42456E3F25474B620018374E /* DateGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42456E3D25474B620018374E /* DateGenerator.swift */; };
-		428D119725A3A834003D8552 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 428D119625A3A834003D8552 /* PPRiskMagnes.xcframework */; };
+		42C574AE25FA66F9008B3681 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574AD25FA66F9008B3681 /* AppDelegate.swift */; };
+		42C574B025FA66F9008B3681 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574AF25FA66F9008B3681 /* SceneDelegate.swift */; };
+		42C574B225FA66F9008B3681 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574B125FA66F9008B3681 /* ViewController.swift */; };
+		42C574B525FA66F9008B3681 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B325FA66F9008B3681 /* Main.storyboard */; };
+		42C574B725FA66FB008B3681 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B625FA66FB008B3681 /* Assets.xcassets */; };
+		42C574BA25FA66FB008B3681 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B825FA66FB008B3681 /* LaunchScreen.storyboard */; };
+		42C574D025FA6A00008B3681 /* PPRiskMagnes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */; };
+		42C574D125FA6A00008B3681 /* PPRiskMagnes.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574D425FA6CAC008B3681 /* AppSwitcher.swift */; };
 		42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */; };
 		42D47A152554679D0012BAF1 /* BraintreeDemoSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */; };
 		803D64F5256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */; };
@@ -137,6 +145,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		42C574C125FA673B008B3681 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A0988E4124DB43DC0095EEEE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 42C574AA25FA66F9008B3681;
+			remoteInfo = MockVenmo;
+		};
 		A9B5ABE324EB2A2200A4E1C8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A0988E4124DB43DC0095EEEE /* Project object */;
@@ -160,6 +175,7 @@
 				803D64FE256DAF9A00ACE692 /* BraintreeDataCollector.framework in Embed Frameworks */,
 				803D64FC256DAF9A00ACE692 /* BraintreeCore.framework in Embed Frameworks */,
 				803D6504256DAF9A00ACE692 /* BraintreeThreeDSecure.framework in Embed Frameworks */,
+				42C574D125FA6A00008B3681 /* PPRiskMagnes.framework in Embed Frameworks */,
 				803D6500256DAF9A00ACE692 /* BraintreePaymentFlow.framework in Embed Frameworks */,
 				803D6506256DAF9A00ACE692 /* BraintreeUnionPay.framework in Embed Frameworks */,
 				A9C11A9924DB542900AE207A /* CardinalMobile.framework in Embed Frameworks */,
@@ -175,6 +191,16 @@
 		42456E3C25474B620018374E /* BTUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTUITest.swift; sourceTree = "<group>"; };
 		42456E3D25474B620018374E /* DateGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateGenerator.swift; sourceTree = "<group>"; };
 		428D119625A3A834003D8552 /* PPRiskMagnes.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PPRiskMagnes.xcframework; path = ../Frameworks/PPRiskMagnes.xcframework; sourceTree = "<group>"; };
+		42C574AB25FA66F9008B3681 /* MockVenmo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MockVenmo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		42C574AD25FA66F9008B3681 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		42C574AF25FA66F9008B3681 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		42C574B125FA66F9008B3681 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		42C574B425FA66F9008B3681 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		42C574B625FA66FB008B3681 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		42C574B925FA66FB008B3681 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		42C574BB25FA66FB008B3681 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PPRiskMagnes.framework; path = ../Frameworks/PPRiskMagnes.framework; sourceTree = "<group>"; };
+		42C574D425FA6CAC008B3681 /* AppSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcher.swift; sourceTree = "<group>"; };
 		42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmericanExpress_UITests.swift; sourceTree = "<group>"; };
 		42D47A132554679D0012BAF1 /* BraintreeDemoSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoSceneDelegate.h; sourceTree = "<group>"; };
 		42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoSceneDelegate.m; sourceTree = "<group>"; };
@@ -393,6 +419,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		42C574A825FA66F9008B3681 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A0988E4624DB43DC0095EEEE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -400,8 +433,8 @@
 				803D64FB256DAF9A00ACE692 /* BraintreeCore.framework in Frameworks */,
 				803D64F5256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Frameworks */,
 				803D6501256DAF9A00ACE692 /* BraintreePayPal.framework in Frameworks */,
-				428D119725A3A834003D8552 /* PPRiskMagnes.xcframework in Frameworks */,
 				803D64FD256DAF9A00ACE692 /* BraintreeDataCollector.framework in Frameworks */,
+				42C574D025FA6A00008B3681 /* PPRiskMagnes.framework in Frameworks */,
 				803D64F7256DAF9A00ACE692 /* BraintreeApplePay.framework in Frameworks */,
 				803D6509256DAF9A00ACE692 /* PayPalDataCollector.framework in Frameworks */,
 				803D6507256DAF9A00ACE692 /* BraintreeVenmo.framework in Frameworks */,
@@ -433,6 +466,21 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		42C574AC25FA66F9008B3681 /* MockVenmo */ = {
+			isa = PBXGroup;
+			children = (
+				42C574AD25FA66F9008B3681 /* AppDelegate.swift */,
+				42C574AF25FA66F9008B3681 /* SceneDelegate.swift */,
+				42C574D425FA6CAC008B3681 /* AppSwitcher.swift */,
+				42C574B125FA66F9008B3681 /* ViewController.swift */,
+				42C574B325FA66F9008B3681 /* Main.storyboard */,
+				42C574B625FA66FB008B3681 /* Assets.xcassets */,
+				42C574B825FA66FB008B3681 /* LaunchScreen.storyboard */,
+				42C574BB25FA66FB008B3681 /* Info.plist */,
+			);
+			path = MockVenmo;
+			sourceTree = "<group>";
+		};
 		42C5BDD425A4CE2E00E8FF40 /* American Express UI Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -453,6 +501,7 @@
 			isa = PBXGroup;
 			children = (
 				A9C4E08024EC2A70002F6FF2 /* Application */,
+				42C574AC25FA66F9008B3681 /* MockVenmo */,
 				A0988FFB24DB44D60095EEEE /* Frameworks */,
 				F1D1FED7D4B39E9B6D0FCC73 /* Pods */,
 				A0988E4A24DB43DC0095EEEE /* Products */,
@@ -465,6 +514,7 @@
 			children = (
 				A0988E4924DB43DC0095EEEE /* Demo.app */,
 				A9B5ABDE24EB2A2200A4E1C8 /* UITests.xctest */,
+				42C574AB25FA66F9008B3681 /* MockVenmo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -892,6 +942,7 @@
 		A0988FFB24DB44D60095EEEE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */,
 				803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */,
 				803D64EB256DAF9A00ACE692 /* BraintreeApplePay.framework */,
 				803D64EC256DAF9A00ACE692 /* BraintreeCard.framework */,
@@ -968,6 +1019,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		42C574AA25FA66F9008B3681 /* MockVenmo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 42C574BE25FA66FB008B3681 /* Build configuration list for PBXNativeTarget "MockVenmo" */;
+			buildPhases = (
+				42C574A725FA66F9008B3681 /* Sources */,
+				42C574A825FA66F9008B3681 /* Frameworks */,
+				42C574A925FA66F9008B3681 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MockVenmo;
+			productName = MockVenmo;
+			productReference = 42C574AB25FA66F9008B3681 /* MockVenmo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		A0988E4824DB43DC0095EEEE /* Demo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A0988E6224DB43DF0095EEEE /* Build configuration list for PBXNativeTarget "Demo" */;
@@ -999,6 +1067,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				42C574C225FA673B008B3681 /* PBXTargetDependency */,
 				A9B5ABE424EB2A2200A4E1C8 /* PBXTargetDependency */,
 			);
 			name = UITests;
@@ -1012,10 +1081,13 @@
 		A0988E4124DB43DC0095EEEE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1160;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = braintree;
 				TargetAttributes = {
+					42C574AA25FA66F9008B3681 = {
+						CreatedOnToolsVersion = 12.4;
+					};
 					A0988E4824DB43DC0095EEEE = {
 						CreatedOnToolsVersion = 11.5;
 					};
@@ -1060,11 +1132,22 @@
 			targets = (
 				A0988E4824DB43DC0095EEEE /* Demo */,
 				A9B5ABDD24EB2A2200A4E1C8 /* UITests */,
+				42C574AA25FA66F9008B3681 /* MockVenmo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		42C574A925FA66F9008B3681 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42C574BA25FA66FB008B3681 /* LaunchScreen.storyboard in Resources */,
+				42C574B725FA66FB008B3681 /* Assets.xcassets in Resources */,
+				42C574B525FA66F9008B3681 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A0988E4724DB43DC0095EEEE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1143,6 +1226,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		42C574A725FA66F9008B3681 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42C574B225FA66F9008B3681 /* ViewController.swift in Sources */,
+				42C574AE25FA66F9008B3681 /* AppDelegate.swift in Sources */,
+				42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */,
+				42C574B025FA66F9008B3681 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A0988E4524DB43DC0095EEEE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1242,6 +1336,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		42C574C225FA673B008B3681 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 42C574AA25FA66F9008B3681 /* MockVenmo */;
+			targetProxy = 42C574C125FA673B008B3681 /* PBXContainerItemProxy */;
+		};
 		A9B5ABE424EB2A2200A4E1C8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A0988E4824DB43DC0095EEEE /* Demo */;
@@ -1250,6 +1349,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		42C574B325FA66F9008B3681 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				42C574B425FA66F9008B3681 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		42C574B825FA66FB008B3681 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				42C574B925FA66FB008B3681 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 		A0988F3824DB44B10095EEEE /* UI.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1297,6 +1412,49 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		42C574BC25FA66FB008B3681 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 43253H4X22;
+				INFOPLIST_FILE = MockVenmo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.MockVenmo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		42C574BD25FA66FB008B3681 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 43253H4X22;
+				INFOPLIST_FILE = MockVenmo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.MockVenmo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		A0988E6024DB43DF0095EEEE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1520,6 +1678,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		42C574BE25FA66FB008B3681 /* Build configuration list for PBXNativeTarget "MockVenmo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				42C574BC25FA66FB008B3681 /* Debug */,
+				42C574BD25FA66FB008B3681 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A0988E4424DB43DC0095EEEE /* Build configuration list for PBXProject "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -3,11 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		08222B07C311489F90D08D41 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */; };
+		423B451025FFB5E500EF563F /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 428D119625A3A834003D8552 /* PPRiskMagnes.xcframework */; };
+		423B451125FFB5E500EF563F /* PPRiskMagnes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 428D119625A3A834003D8552 /* PPRiskMagnes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		42456E3E25474B620018374E /* BTUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42456E3C25474B620018374E /* BTUITest.swift */; };
 		42456E3F25474B620018374E /* DateGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42456E3D25474B620018374E /* DateGenerator.swift */; };
 		42C574AE25FA66F9008B3681 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574AD25FA66F9008B3681 /* AppDelegate.swift */; };
@@ -16,8 +18,6 @@
 		42C574B525FA66F9008B3681 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B325FA66F9008B3681 /* Main.storyboard */; };
 		42C574B725FA66FB008B3681 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B625FA66FB008B3681 /* Assets.xcassets */; };
 		42C574BA25FA66FB008B3681 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B825FA66FB008B3681 /* LaunchScreen.storyboard */; };
-		42C574D025FA6A00008B3681 /* PPRiskMagnes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */; };
-		42C574D125FA6A00008B3681 /* PPRiskMagnes.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574D425FA6CAC008B3681 /* AppSwitcher.swift */; };
 		42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */; };
 		42D47A152554679D0012BAF1 /* BraintreeDemoSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */; };
@@ -173,9 +173,9 @@
 				803D650A256DAF9A00ACE692 /* PayPalDataCollector.framework in Embed Frameworks */,
 				803D64FA256DAF9A00ACE692 /* BraintreeCard.framework in Embed Frameworks */,
 				803D64FE256DAF9A00ACE692 /* BraintreeDataCollector.framework in Embed Frameworks */,
+				423B451125FFB5E500EF563F /* PPRiskMagnes.xcframework in Embed Frameworks */,
 				803D64FC256DAF9A00ACE692 /* BraintreeCore.framework in Embed Frameworks */,
 				803D6504256DAF9A00ACE692 /* BraintreeThreeDSecure.framework in Embed Frameworks */,
-				42C574D125FA6A00008B3681 /* PPRiskMagnes.framework in Embed Frameworks */,
 				803D6500256DAF9A00ACE692 /* BraintreePaymentFlow.framework in Embed Frameworks */,
 				803D6506256DAF9A00ACE692 /* BraintreeUnionPay.framework in Embed Frameworks */,
 				A9C11A9924DB542900AE207A /* CardinalMobile.framework in Embed Frameworks */,
@@ -199,7 +199,6 @@
 		42C574B625FA66FB008B3681 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		42C574B925FA66FB008B3681 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		42C574BB25FA66FB008B3681 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PPRiskMagnes.framework; path = ../Frameworks/PPRiskMagnes.framework; sourceTree = "<group>"; };
 		42C574D425FA6CAC008B3681 /* AppSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcher.swift; sourceTree = "<group>"; };
 		42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmericanExpress_UITests.swift; sourceTree = "<group>"; };
 		42D47A132554679D0012BAF1 /* BraintreeDemoSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoSceneDelegate.h; sourceTree = "<group>"; };
@@ -433,8 +432,8 @@
 				803D64FB256DAF9A00ACE692 /* BraintreeCore.framework in Frameworks */,
 				803D64F5256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Frameworks */,
 				803D6501256DAF9A00ACE692 /* BraintreePayPal.framework in Frameworks */,
+				423B451025FFB5E500EF563F /* PPRiskMagnes.xcframework in Frameworks */,
 				803D64FD256DAF9A00ACE692 /* BraintreeDataCollector.framework in Frameworks */,
-				42C574D025FA6A00008B3681 /* PPRiskMagnes.framework in Frameworks */,
 				803D64F7256DAF9A00ACE692 /* BraintreeApplePay.framework in Frameworks */,
 				803D6509256DAF9A00ACE692 /* PayPalDataCollector.framework in Frameworks */,
 				803D6507256DAF9A00ACE692 /* BraintreeVenmo.framework in Frameworks */,
@@ -942,7 +941,6 @@
 		A0988FFB24DB44D60095EEEE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				42C574CF25FA6A00008B3681 /* PPRiskMagnes.framework */,
 				803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */,
 				803D64EB256DAF9A00ACE692 /* BraintreeApplePay.framework */,
 				803D64EC256DAF9A00ACE692 /* BraintreeCard.framework */,

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/MockVenmo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/MockVenmo.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "42C574AA25FA66F9008B3681"
+               BuildableName = "MockVenmo.app"
+               BlueprintName = "MockVenmo"
+               ReferencedContainer = "container:Demo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "42C574AA25FA66F9008B3681"
+            BuildableName = "MockVenmo.app"
+            BlueprintName = "MockVenmo"
+            ReferencedContainer = "container:Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "42C574AA25FA66F9008B3681"
+            BuildableName = "MockVenmo.app"
+            BlueprintName = "MockVenmo"
+            ReferencedContainer = "container:Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Demo/MockVenmo/AppDelegate.swift
+++ b/Demo/MockVenmo/AppDelegate.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Demo/MockVenmo/AppSwitcher.swift
+++ b/Demo/MockVenmo/AppSwitcher.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+class AppSwitcher {
+
+    static var openVenmoURL: URL?
+
+    static var successURL: URL? {
+        var successComponents = openVenmoURL
+            .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false)})?
+            .queryItems?
+            .first(where: { $0.name == "x-success" })?
+            .value
+            .flatMap({ URLComponents(string: $0) })
+
+        successComponents?.queryItems = [
+            URLQueryItem(name: "x-source", value: "Venmo"),
+            URLQueryItem(name: "username", value: "@fake-venmo-username"),
+            URLQueryItem(name: "paymentMethodNonce", value: "fake-venmo-account-nonce")
+        ]
+
+        return successComponents?.url
+    }
+
+    static var errorURL: URL? {
+        var errorComponents = openVenmoURL
+            .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false)})?
+            .queryItems?
+            .first(where: { $0.name == "x-error" })?
+            .value
+            .flatMap({ URLComponents(string: $0) })
+
+        errorComponents?.queryItems = [
+            URLQueryItem(name: "errorMessage", value: "An error occurred during the Venmo flow"),
+            URLQueryItem(name: "errorCode", value: "123")
+        ]
+
+        return errorComponents?.url
+    }
+
+    static var cancelURL: URL? {
+        return openVenmoURL
+            .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false)})?
+            .queryItems?
+            .first(where: { $0.name == "x-cancel" })?
+            .value
+            .flatMap({ URL(string: $0) })
+    }
+}

--- a/Demo/MockVenmo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Demo/MockVenmo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/MockVenmo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demo/MockVenmo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/MockVenmo/Assets.xcassets/Contents.json
+++ b/Demo/MockVenmo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/MockVenmo/Base.lproj/LaunchScreen.storyboard
+++ b/Demo/MockVenmo/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Demo/MockVenmo/Base.lproj/Main.storyboard
+++ b/Demo/MockVenmo/Base.lproj/Main.storyboard
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SZM-Ya-npP">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Mock Venmo-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="MockVenmo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="DU8-s0-e71">
+                                <rect key="frame" x="158" y="394" width="98" height="108"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IAG-ty-79I">
+                                        <rect key="frame" x="0.0" y="0.0" width="98" height="39"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                        <state key="normal" title="SUCCESS"/>
+                                        <connections>
+                                            <action selector="didTapSuccess:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8EF-wh-Sou"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oCF-fe-kF3">
+                                        <rect key="frame" x="0.0" y="69" width="98" height="39"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                        <state key="normal" title="ERROR"/>
+                                        <connections>
+                                            <action selector="didTapError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eng-kb-nWu"/>
+                                            <action selector="didTapSuccess:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Kzl-me-tfH"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="DU8-s0-e71" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Fkn-p6-SIg"/>
+                            <constraint firstItem="DU8-s0-e71" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Rtd-pX-A7j"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Mock Venmo" id="4c8-0s-Z3t">
+                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="sA7-WW-Ufg">
+                            <connections>
+                                <action selector="didTapCancel:" destination="BYZ-38-t0r" id="6iU-jq-s7r"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1050.7246376811595" y="134.59821428571428"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="cxV-QH-mdu">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="SZM-Ya-npP" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="qu2-ye-XN0">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="cAJ-Dr-yYD"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SaS-3k-WAT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="140.57971014492756" y="134.59821428571428"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Demo/MockVenmo/Info.plist
+++ b/Demo/MockVenmo/Info.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.venmo.touch.v2</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Demo/MockVenmo/SceneDelegate.swift
+++ b/Demo/MockVenmo/SceneDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        AppSwitcher.openVenmoURL = URLContexts.first?.url
+    }
+}
+

--- a/Demo/MockVenmo/ViewController.swift
+++ b/Demo/MockVenmo/ViewController.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class ViewController: UIViewController {
+
+    @IBAction func didTapSuccess(_ sender: UIButton) {
+        guard let successURL = AppSwitcher.successURL else { return }
+        UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
+    }
+
+    @IBAction func didTapError(_ sender: UIButton) {
+        guard let errorURL = AppSwitcher.errorURL else { return }
+        UIApplication.shared.open(errorURL, options: [:], completionHandler: nil)
+    }
+
+    @IBAction func didTapCancel(_ sender: UIBarButtonItem) {
+        guard let cancelURL = AppSwitcher.cancelURL else { return }
+        UIApplication.shared.open(cancelURL, options: [:], completionHandler: nil)
+    }
+}

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -2,24 +2,52 @@ import XCTest
 
 class Venmo_UITests: XCTestCase {
 
-    var app: XCUIApplication!
+    var demoApp: XCUIApplication!
+    var mockVenmo: XCUIApplication!
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-ClientToken")
-        app.launchArguments.append("-Integration:BraintreeDemoCustomVenmoButtonViewController")
-        app.launch()
 
-        waitForElementToAppear(app.buttons["Venmo (custom button)"])
+        mockVenmo = XCUIApplication(bundleIdentifier: "com.braintreepayments.MockVenmo")
+        mockVenmo.activate()
+
+        demoApp = XCUIApplication(bundleIdentifier: "com.braintreepayments.Demo")
+        demoApp.launchArguments.append("-EnvironmentSandbox")
+        demoApp.launchArguments.append("-ClientToken")
+        demoApp.launchArguments.append("-Integration:BraintreeDemoCustomVenmoButtonViewController")
+        demoApp.launch()
+
+        waitForElementToAppear(demoApp.buttons["Venmo (custom button)"])
     }
 
-    func testTokenizeVenmo_returnsErrorWhenVenmoAppNotInstalled() {
-        app.buttons["Venmo (custom button)"].tap()
-        sleep(2)
+    func testTokenizeVenmo_whenSignInSuccessful_returnsNonce() {
+        demoApp.buttons["Venmo (custom button)"].tap()
 
-        XCTAssertTrue(app.buttons["The Venmo app is not installed on this device, or it is not configured or available for app switch."].exists);
+        waitForElementToAppear(mockVenmo.buttons["SUCCESS"])
+        mockVenmo.buttons["SUCCESS"].tap()
+
+        waitForElementToAppear(demoApp.buttons["Got a nonce. Tap to make a transaction."])
+        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].exists);
+    }
+
+    func testTokenizeVenmo_whenErrorOccurs_returnsError() {
+        demoApp.buttons["Venmo (custom button)"].tap()
+
+        waitForElementToAppear(mockVenmo.buttons["ERROR"])
+        mockVenmo.buttons["ERROR"].tap()
+
+        waitForElementToAppear(demoApp.buttons["An error occurred during the Venmo flow"])
+        XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].exists);
+    }
+
+    func testTokenizeVenmo_whenUserCancels_returnsCancel() {
+        demoApp.buttons["Venmo (custom button)"].tap()
+
+        waitForElementToAppear(mockVenmo.buttons["Cancel"])
+        mockVenmo.buttons["Cancel"].tap()
+
+        waitForElementToAppear(demoApp.buttons["Cancelled 🔰"])
+        XCTAssertTrue(demoApp.buttons["Cancelled 🔰"].exists);
     }
 }

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -47,7 +47,7 @@ class Venmo_UITests: XCTestCase {
         waitForElementToAppear(mockVenmo.buttons["Cancel"])
         mockVenmo.buttons["Cancel"].tap()
 
-        waitForElementToAppear(demoApp.buttons["Cancelled 🔰"])
-        XCTAssertTrue(demoApp.buttons["Cancelled 🔰"].exists);
+        waitForElementToAppear(demoApp.buttons["Canceled 🔰"])
+        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].exists);
     }
 }


### PR DESCRIPTION

### Summary of changes

- Add UI tests for the Venmo flow using a dummy app that stands in for the real Venmo app. This won't protect us against changes on the Venmo side that could break this flow, but it'll ensure that we catch any changes to our SDK or the iOS SDK that could break this flow.
- I also updated the demo app to use `PPRiskMagnes.framework` instead of `PPRiskMagnes.xcframework`, which fixes the issue with not being able to run the demo app on a device.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
