### PR TITLE
Update PayPal terms used in demo app

### DIFF
--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -17,7 +17,7 @@
 			<string>BraintreeDemoCardTokenizationViewController</string>
 			<key>Titles</key>
 			<array>
-				<string>PayPal - Billing Agreement</string>
+				<string>PayPal - Vault</string>
 				<string>PayPal - One-Time Payment</string>
 				<string>PayPal - Pay Later</string>
 				<string>Credit Card Tokenization</string>
@@ -32,7 +32,7 @@
 			</array>
 			<key>Values</key>
 			<array>
-				<string>BraintreeDemoPayPalBillingAgreementViewController</string>
+				<string>BraintreeDemoPayPalVaultViewController</string>
 				<string>BraintreeDemoPayPalOneTimePaymentViewController</string>
 				<string>BraintreeDemoPayPalPayLaterViewController</string>
 				<string>BraintreeDemoCardTokenizationViewController</string>

--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -18,7 +18,7 @@
 			<key>Titles</key>
 			<array>
 				<string>PayPal - Vault</string>
-				<string>PayPal - One-Time Payment</string>
+				<string>PayPal - Checkout</string>
 				<string>PayPal - Pay Later</string>
 				<string>Credit Card Tokenization</string>
 				<string>Venmo - Custom Button</string>
@@ -33,7 +33,7 @@
 			<key>Values</key>
 			<array>
 				<string>BraintreeDemoPayPalVaultViewController</string>
-				<string>BraintreeDemoPayPalOneTimePaymentViewController</string>
+				<string>BraintreeDemoPayPalCheckoutViewController</string>
 				<string>BraintreeDemoPayPalPayLaterViewController</string>
 				<string>BraintreeDemoCardTokenizationViewController</string>
 				<string>BraintreeDemoCustomVenmoButtonViewController</string>

--- a/Demo/Application/Features/PayPal - Billing Agreement/BraintreeDemoPayPalBillingAgreementViewController.h
+++ b/Demo/Application/Features/PayPal - Billing Agreement/BraintreeDemoPayPalBillingAgreementViewController.h
@@ -1,5 +1,0 @@
-#import "BraintreeDemoPaymentButtonBaseViewController.h"
-
-@interface BraintreeDemoPayPalBillingAgreementViewController : BraintreeDemoPaymentButtonBaseViewController
-
-@end

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.h
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.h
@@ -1,0 +1,5 @@
+#import "BraintreeDemoPaymentButtonBaseViewController.h"
+
+@interface BraintreeDemoPayPalCheckoutViewController : BraintreeDemoPaymentButtonBaseViewController
+
+@end

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.m
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.m
@@ -1,20 +1,20 @@
-#import "BraintreeDemoPayPalOneTimePaymentViewController.h"
+#import "BraintreeDemoPayPalCheckoutViewController.h"
 @import BraintreePayPal;
 
-@implementation BraintreeDemoPayPalOneTimePaymentViewController
+@implementation BraintreeDemoPayPalCheckoutViewController
 
 - (UIView *)createPaymentButton {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    [button setTitle:NSLocalizedString(@"PayPal one-time payment", nil) forState:UIControlStateNormal];
+    [button setTitle:NSLocalizedString(@"PayPal Checkout", nil) forState:UIControlStateNormal];
     [button setTitleColor:[UIColor blueColor] forState:UIControlStateNormal];
     [button setTitleColor:[UIColor colorWithRed:50.0/255 green:50.0/255 blue:255.0/255 alpha:1.0] forState:UIControlStateHighlighted];
     [button setTitleColor:[UIColor lightGrayColor] forState:UIControlStateDisabled];
-    [button addTarget:self action:@selector(tappedPayPalOneTimePayment:) forControlEvents:UIControlEventTouchUpInside];
+    [button addTarget:self action:@selector(tappedPayPalCheckout:) forControlEvents:UIControlEventTouchUpInside];
     return button;
 }
 
-- (void)tappedPayPalOneTimePayment:(UIButton *)sender {
-    self.progressBlock(@"Tapped PayPal - initiating one-time payment using BTPayPalDriver");
+- (void)tappedPayPalCheckout:(UIButton *)sender {
+    self.progressBlock(@"Tapped PayPal - checkout using BTPayPalDriver");
 
     [sender setTitle:NSLocalizedString(@"Processing...", nil) forState:UIControlStateDisabled];
     [sender setEnabled:NO];

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.h
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.h
@@ -1,5 +1,0 @@
-#import "BraintreeDemoPaymentButtonBaseViewController.h"
-
-@interface BraintreeDemoPayPalOneTimePaymentViewController : BraintreeDemoPaymentButtonBaseViewController
-
-@end

--- a/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.h
+++ b/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.h
@@ -1,0 +1,5 @@
+#import "BraintreeDemoPaymentButtonBaseViewController.h"
+
+@interface BraintreeDemoPayPalVaultViewController : BraintreeDemoPaymentButtonBaseViewController
+
+@end

--- a/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.m
+++ b/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.m
@@ -1,20 +1,20 @@
-#import "BraintreeDemoPayPalBillingAgreementViewController.h"
+#import "BraintreeDemoPayPalVaultViewController.h"
 @import BraintreePayPal;
 
-@implementation BraintreeDemoPayPalBillingAgreementViewController
+@implementation BraintreeDemoPayPalVaultViewController
 
 - (UIView *)createPaymentButton {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    [button setTitle:NSLocalizedString(@"Billing Agreement with PayPal", nil) forState:UIControlStateNormal];
+    [button setTitle:NSLocalizedString(@"PayPal Vault", nil) forState:UIControlStateNormal];
     [button setTitleColor:[UIColor blueColor] forState:UIControlStateNormal];
     [button setTitleColor:[UIColor colorWithRed:50.0/255 green:50.0/255 blue:255.0/255 alpha:1.0] forState:UIControlStateHighlighted];
     [button setTitleColor:[UIColor lightGrayColor] forState:UIControlStateDisabled];
-    [button addTarget:self action:@selector(tappedPayPalCheckout:) forControlEvents:UIControlEventTouchUpInside];
+    [button addTarget:self action:@selector(tappedPayPalVault:) forControlEvents:UIControlEventTouchUpInside];
     return button;
 }
 
-- (void)tappedPayPalCheckout:(UIButton *)sender {
-    self.progressBlock(@"Tapped PayPal - initiating checkout using BTPayPalDriver");
+- (void)tappedPayPalVault:(UIButton *)sender {
+    self.progressBlock(@"Tapped PayPal - vault using BTPayPalDriver");
     [sender setTitle:NSLocalizedString(@"Processing...", nil) forState:UIControlStateDisabled];
     [sender setEnabled:NO];
 

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -4,8 +4,8 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
     private let preferredPaymentMethods: BTPreferredPaymentMethods
     private let paypalDriver: BTPayPalDriver
     private let venmoDriver: BTVenmoDriver
-    private let checkoutButton = UIButton(type: .system)
-    private let vaultButton = UIButton(type: .system)
+    private let payPalCheckoutButton = UIButton(type: .system)
+    private let payPalVaultButton = UIButton(type: .system)
     private let venmoButton = UIButton(type: .system)
     
     override init?(authorization: String!) {
@@ -26,17 +26,17 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         preferredPaymentMethodsButton.addTarget(self, action: #selector(preferredPaymentMethodsButtonTapped(_:)), for: .touchUpInside)
         view.addSubview(preferredPaymentMethodsButton)
         
-        checkoutButton.setTitle("PayPal Checkout", for: .normal)
-        checkoutButton.translatesAutoresizingMaskIntoConstraints = false
-        checkoutButton.addTarget(self, action: #selector(checkoutButtonTapped(_:)), for: .touchUpInside)
-        checkoutButton.isEnabled = false
-        view.addSubview(checkoutButton)
+        payPalCheckoutButton.setTitle("PayPal Checkout", for: .normal)
+        payPalCheckoutButton.translatesAutoresizingMaskIntoConstraints = false
+        payPalCheckoutButton.addTarget(self, action: #selector(payPalCheckoutButtonTapped(_:)), for: .touchUpInside)
+        payPalCheckoutButton.isEnabled = false
+        view.addSubview(payPalCheckoutButton)
         
-        vaultButton.setTitle("PayPal Vault", for: .normal)
-        vaultButton.translatesAutoresizingMaskIntoConstraints = false
-        vaultButton.addTarget(self, action: #selector(vaultButtonTapped(_:)), for: .touchUpInside)
-        vaultButton.isEnabled = false
-        view.addSubview(vaultButton)
+        payPalVaultButton.setTitle("PayPal Vault", for: .normal)
+        payPalVaultButton.translatesAutoresizingMaskIntoConstraints = false
+        payPalVaultButton.addTarget(self, action: #selector(payPalVaultButtonTapped(_:)), for: .touchUpInside)
+        payPalVaultButton.isEnabled = false
+        view.addSubview(payPalVaultButton)
         
         venmoButton.setTitle("Venmo", for: .normal)
         venmoButton.translatesAutoresizingMaskIntoConstraints = false
@@ -46,10 +46,10 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         
         view.addConstraints([preferredPaymentMethodsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              preferredPaymentMethodsButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                             vaultButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                             vaultButton.bottomAnchor.constraint(equalTo: checkoutButton.bottomAnchor, constant: -40),
-                             checkoutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                             checkoutButton.bottomAnchor.constraint(equalTo: venmoButton.bottomAnchor, constant: -40),
+                             payPalVaultButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                             payPalVaultButton.bottomAnchor.constraint(equalTo: payPalCheckoutButton.bottomAnchor, constant: -40),
+                             payPalCheckoutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                             payPalCheckoutButton.bottomAnchor.constraint(equalTo: venmoButton.bottomAnchor, constant: -40),
                              venmoButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              venmoButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -40)])
     }
@@ -62,13 +62,13 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         self.progressBlock("Fetching preferred payment methods...")
         preferredPaymentMethods.fetch { (result) in
             self.progressBlock("PayPal Preferred: \(result.isPayPalPreferred)\nVenmo Preferred: \(result.isVenmoPreferred)")
-            self.checkoutButton.isEnabled = result.isPayPalPreferred
-            self.vaultButton.isEnabled = result.isPayPalPreferred
+            self.payPalCheckoutButton.isEnabled = result.isPayPalPreferred
+            self.payPalVaultButton.isEnabled = result.isPayPalPreferred
             self.venmoButton.isEnabled = result.isVenmoPreferred
         }
     }
     
-    @objc func checkoutButtonTapped(_ button: UIButton) {
+    @objc func payPalCheckoutButtonTapped(_ button: UIButton) {
         self.progressBlock("Tapped PayPal Checkout")
         
         button.setTitle("Processing...", for: .disabled)
@@ -88,7 +88,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         }
     }
     
-    @objc func vaultButtonTapped(_ button: UIButton) {
+    @objc func payPalVaultButtonTapped(_ button: UIButton) {
         self.progressBlock("Tapped PayPal Vault")
         
         button.setTitle("Processing...", for: .disabled)

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -5,7 +5,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
     private let paypalDriver: BTPayPalDriver
     private let venmoDriver: BTVenmoDriver
     private let oneTimePaymentButton = UIButton(type: .system)
-    private let billingAgreementButton = UIButton(type: .system)
+    private let vaultButton = UIButton(type: .system)
     private let venmoButton = UIButton(type: .system)
     
     override init?(authorization: String!) {
@@ -32,11 +32,11 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         oneTimePaymentButton.isEnabled = false
         view.addSubview(oneTimePaymentButton)
         
-        billingAgreementButton.setTitle("PayPal Billing Agreement", for: .normal)
-        billingAgreementButton.translatesAutoresizingMaskIntoConstraints = false
-        billingAgreementButton.addTarget(self, action: #selector(billingAgreementButtonTapped(_:)), for: .touchUpInside)
-        billingAgreementButton.isEnabled = false
-        view.addSubview(billingAgreementButton)
+        vaultButton.setTitle("PayPal Vault", for: .normal)
+        vaultButton.translatesAutoresizingMaskIntoConstraints = false
+        vaultButton.addTarget(self, action: #selector(vaultButtonTapped(_:)), for: .touchUpInside)
+        vaultButton.isEnabled = false
+        view.addSubview(vaultButton)
         
         venmoButton.setTitle("Venmo", for: .normal)
         venmoButton.translatesAutoresizingMaskIntoConstraints = false
@@ -46,8 +46,8 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         
         view.addConstraints([preferredPaymentMethodsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              preferredPaymentMethodsButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                             billingAgreementButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                             billingAgreementButton.bottomAnchor.constraint(equalTo: oneTimePaymentButton.bottomAnchor, constant: -40),
+                             vaultButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                             vaultButton.bottomAnchor.constraint(equalTo: oneTimePaymentButton.bottomAnchor, constant: -40),
                              oneTimePaymentButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              oneTimePaymentButton.bottomAnchor.constraint(equalTo: venmoButton.bottomAnchor, constant: -40),
                              venmoButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -63,7 +63,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         preferredPaymentMethods.fetch { (result) in
             self.progressBlock("PayPal Preferred: \(result.isPayPalPreferred)\nVenmo Preferred: \(result.isVenmoPreferred)")
             self.oneTimePaymentButton.isEnabled = result.isPayPalPreferred
-            self.billingAgreementButton.isEnabled = result.isPayPalPreferred
+            self.vaultButton.isEnabled = result.isPayPalPreferred
             self.venmoButton.isEnabled = result.isVenmoPreferred
         }
     }
@@ -88,8 +88,8 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         }
     }
     
-    @objc func billingAgreementButtonTapped(_ button: UIButton) {
-        self.progressBlock("Tapped PayPal Billing Agreement")
+    @objc func vaultButtonTapped(_ button: UIButton) {
+        self.progressBlock("Tapped PayPal Vault")
         
         button.setTitle("Processing...", for: .disabled)
         button.isEnabled = false

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -4,7 +4,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
     private let preferredPaymentMethods: BTPreferredPaymentMethods
     private let paypalDriver: BTPayPalDriver
     private let venmoDriver: BTVenmoDriver
-    private let oneTimePaymentButton = UIButton(type: .system)
+    private let checkoutButton = UIButton(type: .system)
     private let vaultButton = UIButton(type: .system)
     private let venmoButton = UIButton(type: .system)
     
@@ -26,11 +26,11 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         preferredPaymentMethodsButton.addTarget(self, action: #selector(preferredPaymentMethodsButtonTapped(_:)), for: .touchUpInside)
         view.addSubview(preferredPaymentMethodsButton)
         
-        oneTimePaymentButton.setTitle("PayPal One-Time Payment", for: .normal)
-        oneTimePaymentButton.translatesAutoresizingMaskIntoConstraints = false
-        oneTimePaymentButton.addTarget(self, action: #selector(oneTimePaymentButtonTapped(_:)), for: .touchUpInside)
-        oneTimePaymentButton.isEnabled = false
-        view.addSubview(oneTimePaymentButton)
+        checkoutButton.setTitle("PayPal Checkout", for: .normal)
+        checkoutButton.translatesAutoresizingMaskIntoConstraints = false
+        checkoutButton.addTarget(self, action: #selector(checkoutButtonTapped(_:)), for: .touchUpInside)
+        checkoutButton.isEnabled = false
+        view.addSubview(checkoutButton)
         
         vaultButton.setTitle("PayPal Vault", for: .normal)
         vaultButton.translatesAutoresizingMaskIntoConstraints = false
@@ -47,9 +47,9 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         view.addConstraints([preferredPaymentMethodsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              preferredPaymentMethodsButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                              vaultButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                             vaultButton.bottomAnchor.constraint(equalTo: oneTimePaymentButton.bottomAnchor, constant: -40),
-                             oneTimePaymentButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                             oneTimePaymentButton.bottomAnchor.constraint(equalTo: venmoButton.bottomAnchor, constant: -40),
+                             vaultButton.bottomAnchor.constraint(equalTo: checkoutButton.bottomAnchor, constant: -40),
+                             checkoutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                             checkoutButton.bottomAnchor.constraint(equalTo: venmoButton.bottomAnchor, constant: -40),
                              venmoButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                              venmoButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -40)])
     }
@@ -62,14 +62,14 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         self.progressBlock("Fetching preferred payment methods...")
         preferredPaymentMethods.fetch { (result) in
             self.progressBlock("PayPal Preferred: \(result.isPayPalPreferred)\nVenmo Preferred: \(result.isVenmoPreferred)")
-            self.oneTimePaymentButton.isEnabled = result.isPayPalPreferred
+            self.checkoutButton.isEnabled = result.isPayPalPreferred
             self.vaultButton.isEnabled = result.isPayPalPreferred
             self.venmoButton.isEnabled = result.isVenmoPreferred
         }
     }
     
-    @objc func oneTimePaymentButtonTapped(_ button: UIButton) {
-        self.progressBlock("Tapped PayPal One-Time Payment")
+    @objc func checkoutButtonTapped(_ button: UIButton) {
+        self.progressBlock("Tapped PayPal Checkout")
         
         button.setTitle("Processing...", for: .disabled)
         button.isEnabled = false

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -131,7 +131,7 @@
 		A0988FEE24DB44B20095EEEE /* BraintreeDemoCardTokenizationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F6E24DB44B10095EEEE /* BraintreeDemoCardTokenizationViewController.m */; };
 		A0988FF024DB44B20095EEEE /* BraintreeDemoApplePayPassKitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F7424DB44B10095EEEE /* BraintreeDemoApplePayPassKitViewController.m */; };
 		A0988FF224DB44B20095EEEE /* BraintreeDemoThreeDSecurePaymentFlowViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F7A24DB44B10095EEEE /* BraintreeDemoThreeDSecurePaymentFlowViewController.m */; };
-		A0988FF324DB44B20095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.m */; };
+		A0988FF324DB44B20095EEEE /* BraintreeDemoPayPalVaultViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalVaultViewController.m */; };
 		A0988FF424DB44B20095EEEE /* BraintreeDemoAmexViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F7F24DB44B10095EEEE /* BraintreeDemoAmexViewController.m */; };
 		A0988FF524DB44B20095EEEE /* BraintreeDemoCustomVenmoButtonViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F8324DB44B10095EEEE /* BraintreeDemoCustomVenmoButtonViewController.m */; };
 		A0988FF724DB44B20095EEEE /* BraintreeDemoUnionPayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F8824DB44B10095EEEE /* BraintreeDemoUnionPayViewController.m */; };
@@ -139,7 +139,7 @@
 		A0988FFA24DB44B20095EEEE /* BraintreeDemoMerchantAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0988F9024DB44B20095EEEE /* BraintreeDemoMerchantAPIClient.swift */; };
 		A9B5ABEE24EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5ABE924EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift */; };
 		A9C4E07924EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */; };
-		A9C4E07B24EC290F002F6FF2 /* PayPal_BillingAgreement_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07A24EC290F002F6FF2 /* PayPal_BillingAgreement_UITests.swift */; };
+		A9C4E07B24EC290F002F6FF2 /* PayPal_Vault_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */; };
 		A9C4E07D24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07C24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift */; };
 		A9C4E07F24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07E24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift */; };
 /* End PBXBuildFile section */
@@ -396,8 +396,8 @@
 		A0988F7424DB44B10095EEEE /* BraintreeDemoApplePayPassKitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoApplePayPassKitViewController.m; sourceTree = "<group>"; };
 		A0988F7924DB44B10095EEEE /* BraintreeDemoThreeDSecurePaymentFlowViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoThreeDSecurePaymentFlowViewController.h; sourceTree = "<group>"; };
 		A0988F7A24DB44B10095EEEE /* BraintreeDemoThreeDSecurePaymentFlowViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoThreeDSecurePaymentFlowViewController.m; sourceTree = "<group>"; };
-		A0988F7C24DB44B10095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoPayPalBillingAgreementViewController.h; sourceTree = "<group>"; };
-		A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoPayPalBillingAgreementViewController.m; sourceTree = "<group>"; };
+		A0988F7C24DB44B10095EEEE /* BraintreeDemoPayPalVaultViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoPayPalVaultViewController.h; sourceTree = "<group>"; };
+		A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalVaultViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoPayPalVaultViewController.m; sourceTree = "<group>"; };
 		A0988F7F24DB44B10095EEEE /* BraintreeDemoAmexViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoAmexViewController.m; sourceTree = "<group>"; };
 		A0988F8024DB44B10095EEEE /* BraintreeDemoAmexViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoAmexViewController.h; sourceTree = "<group>"; };
 		A0988F8224DB44B10095EEEE /* BraintreeDemoCustomVenmoButtonViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoCustomVenmoButtonViewController.h; sourceTree = "<group>"; };
@@ -411,7 +411,7 @@
 		A9B5ABE224EB2A2200A4E1C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A9B5ABE924EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_V1_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_OneTimePayment_UITests.swift; sourceTree = "<group>"; };
-		A9C4E07A24EC290F002F6FF2 /* PayPal_BillingAgreement_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_BillingAgreement_UITests.swift; sourceTree = "<group>"; };
+		A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_Vault_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07C24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_V2_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07E24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_UITests_Extensions.swift; sourceTree = "<group>"; };
 		C8E5BAD1DA81AAD310B19786 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
@@ -812,7 +812,7 @@
 				A0988F6B24DB44B10095EEEE /* Credit Card Tokenization */,
 				A0988F5C24DB44B10095EEEE /* Fraud Protection - BTDataCollector */,
 				A0988F6224DB44B10095EEEE /* Ideal */,
-				A0988F7B24DB44B10095EEEE /* PayPal - Billing Agreement */,
+				A0988F7B24DB44B10095EEEE /* PayPal - Vault */,
 				A0988F5F24DB44B10095EEEE /* PayPal - Checkout */,
 				A0988F6824DB44B10095EEEE /* PayPal - Pay Later */,
 				A0988F5A24DB44B10095EEEE /* Preferred Payment Methods */,
@@ -894,13 +894,13 @@
 			path = "3D Secure";
 			sourceTree = "<group>";
 		};
-		A0988F7B24DB44B10095EEEE /* PayPal - Billing Agreement */ = {
+		A0988F7B24DB44B10095EEEE /* PayPal - Vault */ = {
 			isa = PBXGroup;
 			children = (
-				A0988F7C24DB44B10095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.h */,
-				A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.m */,
+				A0988F7C24DB44B10095EEEE /* BraintreeDemoPayPalVaultViewController.h */,
+				A0988F7D24DB44B10095EEEE /* BraintreeDemoPayPalVaultViewController.m */,
 			);
-			path = "PayPal - Billing Agreement";
+			path = "PayPal - Vault";
 			sourceTree = "<group>";
 		};
 		A0988F7E24DB44B10095EEEE /* Amex */ = {
@@ -975,7 +975,7 @@
 		A9C4E07624EC2889002F6FF2 /* PayPal UI Tests */ = {
 			isa = PBXGroup;
 			children = (
-				A9C4E07A24EC290F002F6FF2 /* PayPal_BillingAgreement_UITests.swift */,
+				A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */,
 				A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */,
 			);
 			path = "PayPal UI Tests";
@@ -1246,7 +1246,7 @@
 				A0988F9524DB44B20095EEEE /* BraintreeDemoBaseViewController.m in Sources */,
 				A0988FBA24DB44B20095EEEE /* BTUICoinbaseMonogramCardView.m in Sources */,
 				A0988FD624DB44B20095EEEE /* BTUIFormField.m in Sources */,
-				A0988FF324DB44B20095EEEE /* BraintreeDemoPayPalBillingAgreementViewController.m in Sources */,
+				A0988FF324DB44B20095EEEE /* BraintreeDemoPayPalVaultViewController.m in Sources */,
 				A0988F9B24DB44B20095EEEE /* BTUICardType.m in Sources */,
 				A0988F9924DB44B20095EEEE /* BTUIUtil.m in Sources */,
 				A0988F9C24DB44B20095EEEE /* BTUICardExpirationValidator.m in Sources */,
@@ -1323,7 +1323,7 @@
 				42456E3F25474B620018374E /* DateGenerator.swift in Sources */,
 				A9C4E07924EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift in Sources */,
 				80581A5F2553170000006F53 /* Venmo_UITests.swift in Sources */,
-				A9C4E07B24EC290F002F6FF2 /* PayPal_BillingAgreement_UITests.swift in Sources */,
+				A9C4E07B24EC290F002F6FF2 /* PayPal_Vault_UITests.swift in Sources */,
 				A9C4E07D24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift in Sources */,
 				42456E3E25474B620018374E /* BTUITest.swift in Sources */,
 				42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */,

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -124,7 +124,7 @@
 		A0988FE624DB44B20095EEEE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F5824DB44B10095EEEE /* main.m */; };
 		A0988FE724DB44B20095EEEE /* BraintreeDemoPreferredPaymentMethodsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0988F5B24DB44B10095EEEE /* BraintreeDemoPreferredPaymentMethodsViewController.swift */; };
 		A0988FE824DB44B20095EEEE /* BraintreeDemoBTDataCollectorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F5D24DB44B10095EEEE /* BraintreeDemoBTDataCollectorViewController.m */; };
-		A0988FE924DB44B20095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.m */; };
+		A0988FE924DB44B20095EEEE /* BraintreeDemoPayPalCheckoutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalCheckoutViewController.m */; };
 		A0988FEA24DB44B20095EEEE /* BraintreeDemoIdealViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F6424DB44B10095EEEE /* BraintreeDemoIdealViewController.m */; };
 		A0988FEC24DB44B20095EEEE /* BraintreeDemoPayPalPayLaterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0988F6924DB44B10095EEEE /* BraintreeDemoPayPalPayLaterViewController.m */; };
 		A0988FED24DB44B20095EEEE /* BraintreeDemoCardTokenizationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A0988F6D24DB44B10095EEEE /* BraintreeDemoCardTokenizationViewController.xib */; };
@@ -138,7 +138,7 @@
 		A0988FF924DB44B20095EEEE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A0988F8D24DB44B10095EEEE /* Images.xcassets */; };
 		A0988FFA24DB44B20095EEEE /* BraintreeDemoMerchantAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0988F9024DB44B20095EEEE /* BraintreeDemoMerchantAPIClient.swift */; };
 		A9B5ABEE24EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5ABE924EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift */; };
-		A9C4E07924EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */; };
+		A9C4E07924EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07824EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift */; };
 		A9C4E07B24EC290F002F6FF2 /* PayPal_Vault_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */; };
 		A9C4E07D24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07C24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift */; };
 		A9C4E07F24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C4E07E24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift */; };
@@ -383,8 +383,8 @@
 		A0988F5B24DB44B10095EEEE /* BraintreeDemoPreferredPaymentMethodsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraintreeDemoPreferredPaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		A0988F5D24DB44B10095EEEE /* BraintreeDemoBTDataCollectorViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoBTDataCollectorViewController.m; sourceTree = "<group>"; };
 		A0988F5E24DB44B10095EEEE /* BraintreeDemoBTDataCollectorViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoBTDataCollectorViewController.h; sourceTree = "<group>"; };
-		A0988F6024DB44B10095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoPayPalOneTimePaymentViewController.h; sourceTree = "<group>"; };
-		A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoPayPalOneTimePaymentViewController.m; sourceTree = "<group>"; };
+		A0988F6024DB44B10095EEEE /* BraintreeDemoPayPalCheckoutViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoPayPalCheckoutViewController.h; sourceTree = "<group>"; };
+		A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalCheckoutViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoPayPalCheckoutViewController.m; sourceTree = "<group>"; };
 		A0988F6324DB44B10095EEEE /* BraintreeDemoIdealViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoIdealViewController.h; sourceTree = "<group>"; };
 		A0988F6424DB44B10095EEEE /* BraintreeDemoIdealViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoIdealViewController.m; sourceTree = "<group>"; };
 		A0988F6924DB44B10095EEEE /* BraintreeDemoPayPalPayLaterViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoPayPalPayLaterViewController.m; sourceTree = "<group>"; };
@@ -410,7 +410,7 @@
 		A9B5ABDE24EB2A2200A4E1C8 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9B5ABE224EB2A2200A4E1C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A9B5ABE924EB2A3200A4E1C8 /* ThreeDSecure_V1_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_V1_UITests.swift; sourceTree = "<group>"; };
-		A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_OneTimePayment_UITests.swift; sourceTree = "<group>"; };
+		A9C4E07824EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_Checkout_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPal_Vault_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07C24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_V2_UITests.swift; sourceTree = "<group>"; };
 		A9C4E07E24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecure_UITests_Extensions.swift; sourceTree = "<group>"; };
@@ -842,8 +842,8 @@
 		A0988F5F24DB44B10095EEEE /* PayPal - Checkout */ = {
 			isa = PBXGroup;
 			children = (
-				A0988F6024DB44B10095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.h */,
-				A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.m */,
+				A0988F6024DB44B10095EEEE /* BraintreeDemoPayPalCheckoutViewController.h */,
+				A0988F6124DB44B10095EEEE /* BraintreeDemoPayPalCheckoutViewController.m */,
 			);
 			path = "PayPal - Checkout";
 			sourceTree = "<group>";
@@ -976,7 +976,7 @@
 			isa = PBXGroup;
 			children = (
 				A9C4E07A24EC290F002F6FF2 /* PayPal_Vault_UITests.swift */,
-				A9C4E07824EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift */,
+				A9C4E07824EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift */,
 			);
 			path = "PayPal UI Tests";
 			sourceTree = "<group>";
@@ -1305,7 +1305,7 @@
 				A0988FBC24DB44B20095EEEE /* BTUICVVFrontVectorArtView.m in Sources */,
 				A0988FCA24DB44B20095EEEE /* BTUIPayPalCompactButton.m in Sources */,
 				A0988FAD24DB44B20095EEEE /* BTUICardNumberField.m in Sources */,
-				A0988FE924DB44B20095EEEE /* BraintreeDemoPayPalOneTimePaymentViewController.m in Sources */,
+				A0988FE924DB44B20095EEEE /* BraintreeDemoPayPalCheckoutViewController.m in Sources */,
 				A0988FD324DB44B20095EEEE /* BTUITextField.m in Sources */,
 				A0988FCF24DB44B20095EEEE /* BTUIHorizontalButtonStackCollectionViewFlowLayout.m in Sources */,
 				A0988FBF24DB44B20095EEEE /* BTUIUnionPayVectorArtView.m in Sources */,
@@ -1321,7 +1321,7 @@
 			files = (
 				A9C4E07F24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift in Sources */,
 				42456E3F25474B620018374E /* DateGenerator.swift in Sources */,
-				A9C4E07924EC28F7002F6FF2 /* PayPal_OneTimePayment_UITests.swift in Sources */,
+				A9C4E07924EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift in Sources */,
 				80581A5F2553170000006F53 /* Venmo_UITests.swift in Sources */,
 				A9C4E07B24EC290F002F6FF2 /* PayPal_Vault_UITests.swift in Sources */,
 				A9C4E07D24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift in Sources */,

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -5,7 +5,7 @@
 
 import XCTest
 
-class PayPal_OneTimePayment_UITests: XCTestCase {
+class PayPal_Checkout_UITests: XCTestCase {
     var app: XCUIApplication!
 
     override func setUp() {
@@ -14,11 +14,11 @@ class PayPal_OneTimePayment_UITests: XCTestCase {
         app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
         app.launchArguments.append("-TokenizationKey")
-        app.launchArguments.append("-Integration:BraintreeDemoPayPalOneTimePaymentViewController")
+        app.launchArguments.append("-Integration:BraintreeDemoPayPalCheckoutViewController")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["PayPal one-time payment"])
-        app.buttons["PayPal one-time payment"].tap()
+        self.waitForElementToBeHittable(app.buttons["PayPal Checkout"])
+        app.buttons["PayPal Checkout"].tap()
         sleep(2)
 
         // Tap "Continue" on alert
@@ -33,7 +33,7 @@ class PayPal_OneTimePayment_UITests: XCTestCase {
         sleep(1)
     }
 
-    func testPayPal_oneTimePayment_receivesNonce() {
+    func testPayPal_checkout_receivesNonce() {
         let webviewElementsQuery = app.webViews.element.otherElements
 
         self.waitForElementToAppear(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
@@ -45,24 +45,24 @@ class PayPal_OneTimePayment_UITests: XCTestCase {
         XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].exists);
     }
 
-    func testPayPal_oneTimePayment_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
+    func testPayPal_checkout_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
         let webviewElementsQuery = app.webViews.element.otherElements
 
         self.waitForElementToAppear(webviewElementsQuery.links["Cancel Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal one-time payment"])
+        self.waitForElementToAppear(app.buttons["PayPal Checkout"])
 
         XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
     }
 
-    func testPayPal_oneTimePayment_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
+    func testPayPal_checkout_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
         self.waitForElementToAppear(app.buttons["Cancel"])
 
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal one-time payment"])
+        self.waitForElementToAppear(app.buttons["PayPal Checkout"])
 
         XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
     }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -5,7 +5,7 @@
 
 import XCTest
 
-class PayPal_BillingAgreement_UITests: XCTestCase {
+class PayPal_Vault_UITests: XCTestCase {
     var app: XCUIApplication!
 
     override func setUp() {
@@ -14,11 +14,11 @@ class PayPal_BillingAgreement_UITests: XCTestCase {
         app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
         app.launchArguments.append("-TokenizationKey")
-        app.launchArguments.append("-Integration:BraintreeDemoPayPalBillingAgreementViewController")
+        app.launchArguments.append("-Integration:BraintreeDemoPayPalVaultViewController")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Billing Agreement with PayPal"])
-        app.buttons["Billing Agreement with PayPal"].tap()
+        self.waitForElementToBeHittable(app.buttons["PayPal Vault"])
+        app.buttons["PayPal Vault"].tap()
         sleep(2)
 
         // Tap "Continue" on alert
@@ -33,7 +33,7 @@ class PayPal_BillingAgreement_UITests: XCTestCase {
         sleep(1)
     }
 
-    func testPayPal_billingAgreement_receivesNonce() {
+    func testPayPal_vault_receivesNonce() {
         let webviewElementsQuery = app.webViews.element.otherElements
 
         self.waitForElementToAppear(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
@@ -45,24 +45,24 @@ class PayPal_BillingAgreement_UITests: XCTestCase {
         XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].exists);
     }
 
-    func testPayPal_billingAgreement_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
+    func testPayPal_vault_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
         let webviewElementsQuery = app.webViews.element.otherElements
 
         self.waitForElementToAppear(webviewElementsQuery.links["Cancel Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Billing Agreement with PayPal"])
+        self.waitForElementToAppear(app.buttons["PayPal Vault"])
 
         XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists)
     }
 
-    func testPayPal_billingAgreement_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
+    func testPayPal_vault_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
         self.waitForElementToAppear(app.buttons["Cancel"])
 
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Billing Agreement with PayPal"])
+        self.waitForElementToAppear(app.buttons["PayPal Vault"])
 
         XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
     }

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalDriver.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalDriver.h
@@ -39,41 +39,7 @@ typedef NS_ENUM(NSInteger, BTPayPalDriverErrorType) {
 };
 
 /** 
- BTPayPalDriver enables you to obtain permission to charge your customers' PayPal accounts by presenting the PayPal website.
-
- @note To make PayPal available, you must ensure that PayPal is enabled in your Braintree control panel.
- See our [online documentation](https://developers.braintreepayments.com/ios+ruby/guides/paypal) for
- details.
-
- This class supports two basic use-cases: Vault and Checkout. Each of these involves variations on the
- user experience as well as variations on the capabilities granted to you by this authorization.
-
- The *Vault* option uses PayPal's future payments authorization, which allows your merchant account to
- charge this customer arbitrary amounts for a long period of time into the future (unless the user
- manually revokes this permission in their PayPal control panel.) This authorization flow includes
- a screen with legal language that directs the user to agree to the terms of Future Payments.
- Unfortunately, it is not currently possible to collect shipping information in the Vault flow.
-
- The *Checkout* option creates a one-time use PayPal payment on your behalf. As a result, you must
- specify the checkout details up-front, so that they can be shown to the user during the PayPal flow.
- With this flow, you must specify the estimated transaction amount, and you can collect shipping
- details. This flow omits the Future Payments agreement, and the resulting payment method cannot be
- stored in the vault. It is only possible to create one Braintree transaction with this form of user
- approval.
-
- The user experience takes full advantage of One Touch. This
- means that users may bypass the username/password entry screen when they are already logged in.
-
- Upon successful completion, you will receive a `BTPayPalAccountNonce`, which includes user-facing
- details and a payment method nonce, which you must pass to your server in order to create a transaction
- or save the authorization in the Braintree vault (not possible with Checkout).
-
- ## User Experience Details
-
- To keep your UI in sync during authentication, you may set a delegate, which will be notified
- as the PayPal driver progresses through the various steps necessary for user
- authentication.
-
+ Used to tokenize PayPal accounts.
 */
 @interface BTPayPalDriver : NSObject
 


### PR DESCRIPTION


### Summary of changes

- Update demo app:
    - Replace "PayPal Billing Agreements" with "PayPal Vault"
    - Replace "PayPal One-Time Payments" with "PayPal Checkout"
- Simplify doc string for `BTPayPalDriver`, since it's outdated. The new comment matches what we have on Android.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
