### PR TITLE
Fix spelling: cancelled --> canceled

### DIFF
--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -146,7 +146,7 @@
             [self updateCallbackCount];
             if (error) {
                 if (error.code == BTPaymentFlowDriverErrorTypeCanceled) {
-                    self.progressBlock(@"Cancelled🎲");
+                    self.progressBlock(@"Canceled 🎲");
                 } else {
                     self.progressBlock(error.localizedDescription);
                 }

--- a/Demo/Application/Features/Ideal/BraintreeDemoIdealViewController.m
+++ b/Demo/Application/Features/Ideal/BraintreeDemoIdealViewController.m
@@ -71,7 +71,7 @@
     void (^paymentFlowCompletionBlock)(BTPaymentFlowResult *, NSError *) = ^(BTPaymentFlowResult * _Nullable result, NSError * _Nullable error) {
         if (error) {
             if (error.code == BTPaymentFlowDriverErrorTypeCanceled) {
-                self.progressBlock(@"Cancelled🎲");
+                self.progressBlock(@"Canceled 🎲");
             } else {
                 self.progressBlock([NSString stringWithFormat:@"Error: %@", error]);
             }

--- a/Demo/Application/Features/PayPal - Billing Agreement/BraintreeDemoPayPalBillingAgreementViewController.m
+++ b/Demo/Application/Features/PayPal - Billing Agreement/BraintreeDemoPayPalBillingAgreementViewController.m
@@ -29,7 +29,7 @@
         } else if (tokenizedPayPalCheckout) {
             self.completionBlock(tokenizedPayPalCheckout);
         } else {
-            self.progressBlock(@"Cancelled");
+            self.progressBlock(@"Canceled");
         }
     }];
 }

--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalOneTimePaymentViewController.m
@@ -30,7 +30,7 @@
         } else if (payPalAccount) {
             self.completionBlock(payPalAccount);
         } else {
-            self.progressBlock(@"Cancelled");
+            self.progressBlock(@"Canceled");
         }
     }];
 }

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -83,7 +83,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
             } else if let n = nonce {
                 self.completionBlock(n)
             } else {
-                self.progressBlock("Cancelled")
+                self.progressBlock("Canceled")
             }
         }
     }
@@ -104,7 +104,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
             } else if let n = nonce {
                 self.completionBlock(n)
             } else {
-                self.progressBlock("Cancelled")
+                self.progressBlock("Canceled")
             }
         }
     }
@@ -123,7 +123,7 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
             } else if let n = nonce {
                 self.completionBlock(n)
             } else {
-                self.progressBlock("Cancelled")
+                self.progressBlock("Canceled")
             }
         }
     }

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V1_UITests.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V1_UITests.swift
@@ -131,7 +131,7 @@ class ThreeDSecure_V1_UITests: XCTestCase {
 
         app.buttons["Cancel"].forceTapElement()
 
-        waitForElementToAppear(app.buttons["Cancelled🎲"])
+        waitForElementToAppear(app.buttons["Canceled 🎲"])
     }
 
     func testThreeDSecurePaymentFlowV1_bypassedAuthentication() {

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -257,7 +257,7 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
                 }
             }
 
-            // User cancelled by breaking out of the PayPal browser switch flow
+            // User canceled by breaking out of the PayPal browser switch flow
             // (e.g. System "Cancel" button on permission alert or browser during ASWebAuthenticationSession)
             NSError *err = [NSError errorWithDomain:BTPayPalDriverErrorDomain
                                                code:BTPayPalDriverErrorTypeCanceled

--- a/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTPaymentFlowDriver.h
+++ b/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTPaymentFlowDriver.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, BTPaymentFlowDriverErrorType) {
 - (void)onPaymentWithURL:(NSURL * _Nullable) url error:(NSError * _Nullable)error;
 
 /**
- Use when the payment flow was cancelled.
+ Use when the payment flow was canceled.
  */
 - (void)onPaymentCancel;
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -338,7 +338,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.vault.failure")
     }
 
-    func testTokenizeVenmoAccount_whenAppSwitchCancelled_callsBackWithNoError() {
+    func testTokenizeVenmoAccount_whenAppSwitchCanceled_callsBackWithNoError() {
         let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
         venmoDriver.application = FakeApplication()
         venmoDriver.bundle = FakeBundle()


### PR DESCRIPTION


### Summary of changes

- The Braintree style guide spells canceled with one L

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
