### PR TITLE
Clarify Swift 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to Braintree's iOS SDK. This library will help you accept card and alter
 
 v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/master/V5_MIGRATION.md).
 
-**The Braintree iOS SDK permits a deployment target of iOS 12.0 or higher**. It requires the use of Xcode 12+ and Swift 5.1+.
+**The Braintree iOS SDK permits a deployment target of iOS 12.0 or higher**. It requires Xcode 12+ and Swift 5.1+.
 
 ## Supported Payment Methods
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to Braintree's iOS SDK. This library will help you accept card and alter
 
 v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/master/V5_MIGRATION.md).
 
-**The Braintree iOS SDK requires Xcode 12+**. It permits a Deployment Target of iOS 12.0 or higher.
+**The Braintree iOS SDK permits a deployment target of iOS 12.0 or higher**. It requires the use of Xcode 12+ and Swift 5.1+.
 
 ## Supported Payment Methods
 

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -19,7 +19,7 @@ _Documentation for v5 will be published to https://developers.braintreepayments.
 
 ## Supported Versions
 
-v5 supports a minimum deployment target of iOS 12+. It requires the use of Xcode 12+ and Swift 5+. If your application contains Objective-C code, the `Enable Modules` build setting must be set to `YES`.
+v5 supports a minimum deployment target of iOS 12+. It requires the use of Xcode 12+ and Swift 5.1+. If your application contains Objective-C code, the `Enable Modules` build setting must be set to `YES`.
 
 ## App Context Switching
 


### PR DESCRIPTION
### Summary of changes

 - Clarify Swift 5.1+ requirement. Swift 5 introduces ABI stability & 5.1 introduces module stability.


### Authors
@scannillo 