### PR TITLE
Update PPDataCollector doc string

### DIFF
--- a/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
+++ b/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
@@ -22,7 +22,7 @@ import Security
     /**
      Collects device data.
 
-     - Returns: A device data string that should be passed into server-side calls, such as `Transaction.sale`. This JSON serialized string contains a PayPal fraud ID.
+     - Returns: A JSON string containing a device data identifier that should be passed into server-side calls, such as `Transaction.sale`.
     */
     @objc public class func collectPayPalDeviceData() -> String {
         return "{\"correlation_id\":\"\(PPDataCollector.generateClientMetadataID())\"}"

--- a/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
+++ b/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
@@ -1,6 +1,9 @@
 import PPRiskMagnes
 import Security
 
+/**
+ Enables you to collect data about a customer's device and correlate it with a session identifier on your server.
+ */
 @objc public class PPDataCollector: NSObject {
 
     /**
@@ -17,9 +20,9 @@ import Security
     }
 
     /**
-     Collects device data for PayPal.
+     Collects device data.
 
-     - Returns: A deviceData string that should be passed into server-side calls, such as `Transaction.sale`. This JSON serialized string contains a PayPal fraud ID.
+     - Returns: A device data string that should be passed into server-side calls, such as `Transaction.sale`. This JSON serialized string contains a PayPal fraud ID.
     */
     @objc public class func collectPayPalDeviceData() -> String {
         return "{\"correlation_id\":\"\(PPDataCollector.generateClientMetadataID())\"}"

--- a/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
+++ b/Sources/PayPalDataCollector/Public/PayPalDataCollector/PPDataCollector.swift
@@ -19,8 +19,7 @@ import Security
     /**
      Collects device data for PayPal.
 
-     This should be used when the user is paying with PayPal or Venmo only.
-     - Returns: A deviceData string that should be passed into server-side calls, such as `Transaction.sale`, for PayPal transactions. This JSON serialized string contains a PayPal fraud ID.
+     - Returns: A deviceData string that should be passed into server-side calls, such as `Transaction.sale`. This JSON serialized string contains a PayPal fraud ID.
     */
     @objc public class func collectPayPalDeviceData() -> String {
         return "{\"correlation_id\":\"\(PPDataCollector.generateClientMetadataID())\"}"


### PR DESCRIPTION


### Summary of changes

- We got some feedback about a misleading doc string in `PPDataCollector`. The device data collected can be used for cards, not just PayPal and Venmo transactions, so this PR updates that comment.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
