### PR TITLE
Make Venmo Context flow opt-in

### DIFF
--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -205,7 +205,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
 #pragma mark - App switch
 
-- (void)performAppSwitch:(NSURL *)appSwitchURL  completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
+- (void)performAppSwitch:(NSURL *)appSwitchURL completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
     if (!appSwitchURL) {
         NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
                                              code:BTVenmoDriverErrorTypeInvalidRequestURL
@@ -378,4 +378,3 @@ static BTVenmoDriver *appSwitchedDriver;
 }
 
 @end
-

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -140,7 +140,7 @@ static BTVenmoDriver *appSwitchedDriver;
         BTMutableClientMetadata *metadata = [self.apiClient.metadata mutableCopy];
         metadata.source = BTClientMetadataSourceVenmoApp;
 
-        if (venmoRequest.paymentMethodUsage != BTVenmoPaymentMethodUsageNone) { // Venmo Context flow
+        if (venmoRequest.paymentMethodUsage != BTVenmoPaymentMethodUsageNone) {
             NSDictionary *params = @{
                 @"query": @"mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
                 @"variables": @{
@@ -169,12 +169,12 @@ static BTVenmoDriver *appSwitchedDriver;
             }];
         } else {
             NSURL *appSwitchURL = [BTVenmoAppSwitchRequestURL appSwitchURLForMerchantID:merchantProfileID
-                                                                     accessToken:configuration.venmoAccessToken
-                                                                 returnURLScheme:self.returnURLScheme
-                                                               bundleDisplayName:bundleDisplayName
-                                                                     environment:configuration.venmoEnvironment
-                                                                paymentContextID:nil
-                                                                        metadata:self.apiClient.metadata];
+                                                                            accessToken:configuration.venmoAccessToken
+                                                                        returnURLScheme:self.returnURLScheme
+                                                                      bundleDisplayName:bundleDisplayName
+                                                                            environment:configuration.venmoEnvironment
+                                                                       paymentContextID:nil
+                                                                               metadata:self.apiClient.metadata];
             [self performAppSwitch:appSwitchURL completion:completionBlock];
         }
     }];
@@ -206,7 +206,6 @@ static BTVenmoDriver *appSwitchedDriver;
 #pragma mark - App switch
 
 - (void)performAppSwitch:(NSURL *)appSwitchURL  completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
-
     if (!appSwitchURL) {
         NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
                                              code:BTVenmoDriverErrorTypeInvalidRequestURL

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -138,7 +138,7 @@ static BTVenmoDriver *appSwitchedDriver;
         BTMutableClientMetadata *metadata = [self.apiClient.metadata mutableCopy];
         metadata.source = BTClientMetadataSourceVenmoApp;
 
-        if (venmoRequest.paymentMethodUsage != BTVenmoPaymentMethodUsageNone) {
+        if (venmoRequest.paymentMethodUsage != BTVenmoPaymentMethodUsageUnspecified) {
             NSDictionary *params = @{
                 @"query": @"mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
                 @"variables": @{

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -132,8 +132,6 @@ static BTVenmoDriver *appSwitchedDriver;
             return;
         }
 
-        self.venmoRequest = venmoRequest;
-
         NSString *merchantProfileID = venmoRequest.profileID ?: configuration.venmoMerchantID;
         NSString *bundleDisplayName = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 
@@ -165,7 +163,7 @@ static BTVenmoDriver *appSwitchedDriver;
                                                                                 environment:configuration.venmoEnvironment
                                                                            paymentContextID:paymentContextID
                                                                                    metadata:self.apiClient.metadata];
-                [self performAppSwitch:appSwitchURL completion:completionBlock];
+                [self performAppSwitch:appSwitchURL shouldVault:venmoRequest.vault completion:completionBlock];
             }];
         } else {
             NSURL *appSwitchURL = [BTVenmoAppSwitchRequestURL appSwitchURLForMerchantID:merchantProfileID
@@ -175,7 +173,7 @@ static BTVenmoDriver *appSwitchedDriver;
                                                                             environment:configuration.venmoEnvironment
                                                                        paymentContextID:nil
                                                                                metadata:self.apiClient.metadata];
-            [self performAppSwitch:appSwitchURL completion:completionBlock];
+            [self performAppSwitch:appSwitchURL shouldVault:venmoRequest.vault completion:completionBlock];
         }
     }];
 }
@@ -205,7 +203,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
 #pragma mark - App switch
 
-- (void)performAppSwitch:(NSURL *)appSwitchURL completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
+- (void)performAppSwitch:(NSURL *)appSwitchURL shouldVault:(BOOL)vault completion:(void (^)(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error))completionBlock {
     if (!appSwitchURL) {
         NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
                                              code:BTVenmoDriverErrorTypeInvalidRequestURL
@@ -215,7 +213,7 @@ static BTVenmoDriver *appSwitchedDriver;
     }
 
     [self.application openURL:appSwitchURL options:[NSDictionary dictionary] completionHandler:^(BOOL success) {
-        [self invokedOpenURLSuccessfully:success shouldVault:self.venmoRequest.vault completion:completionBlock];
+        [self invokedOpenURLSuccessfully:success shouldVault:vault completion:completionBlock];
     }];
 }
 

--- a/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
+++ b/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
@@ -38,4 +38,9 @@
  */
 @property (nonatomic, assign) BOOL shouldVault;
 
+/**
+ Exposed for testing the payment method usage associated with this request
+*/
+@property (nonatomic, strong) BTVenmoRequest *venmoRequest;
+
 @end

--- a/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
+++ b/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
@@ -38,5 +38,4 @@
  */
 @property (nonatomic, assign) BOOL shouldVault;
 
-
 @end

--- a/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
+++ b/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
@@ -38,9 +38,5 @@
  */
 @property (nonatomic, assign) BOOL shouldVault;
 
-/**
- Exposed for testing the payment method usage associated with this request
-*/
-@property (nonatomic, strong) BTVenmoRequest *venmoRequest;
 
 @end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -34,10 +34,13 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 @property (nonatomic) BOOL vault;
 
 /**
- * If set to `.multiUse`, the resulting payment method will be authorized for future payments and can be vaulted. If set to `.singleUse`, the resulting payment method will be authorized for a one-time payment and cannot be vaulted.
+ * If set to `.multiUse`, the Venmo payment will be authorized for future payments and can be vaulted.
+ * If set to `.singleUse`, the Venmo payment will be authorized for a one-time payment and cannot be vaulted.
+ * If set to `.unspecified`, the legacy Venmo UI flow will launch. It is recommended to use `.multiUse` or `.singleUse` for the best customer experience.
  *
- * Defaults to `.none`.
+ * Defaults to `.unspecified`.
  */
+
 @property (nonatomic) BTVenmoPaymentMethodUsage paymentMethodUsage;
 
 @end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -6,10 +6,12 @@ NS_ASSUME_NONNULL_BEGIN
  Usage for the tokenized Venmo account: either multi-use or single use
  */
 typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
+    /// None
+    BTVenmoPaymentMethodUsageNone = 0,
     /// Multi-use
-    BTVenmoPaymentMethodUsageMultiUse = 0,
+    BTVenmoPaymentMethodUsageMultiUse = 1,
     /// Single use
-    BTVenmoPaymentMethodUsageSingleUse = 1
+    BTVenmoPaymentMethodUsageSingleUse = 2
 };
 
 /**
@@ -34,7 +36,7 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 /**
  * If set to `.multiUse`, the resulting payment method will be authorized for future payments and can be vaulted. If set to `.singleUse`, the resulting payment method will be authorized for a one-time payment and cannot be vaulted.
  *
- * Defaults to `.multiUse`.
+ * Defaults to `.none`.
  */
 @property (nonatomic) BTVenmoPaymentMethodUsage paymentMethodUsage;
 

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -40,7 +40,6 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
  *
  * Defaults to `.unspecified`.
  */
-
 @property (nonatomic) BTVenmoPaymentMethodUsage paymentMethodUsage;
 
 @end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -3,11 +3,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Usage for the tokenized Venmo account: either multi-use or single use
+ Usage type for the tokenized Venmo account
  */
 typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
-    /// None
-    BTVenmoPaymentMethodUsageNone = 0,
+    /// Unspecified
+    BTVenmoPaymentMethodUsageUnspecified = 0,
     /// Multi-use
     BTVenmoPaymentMethodUsageMultiUse = 1,
     /// Single use
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 /**
  * Whether to automatically vault the Venmo account on the client. For client-side vaulting, you must initialize BTAPIClient with a client token that was created with a customer ID. Also, `paymentMethodUsage` on the BTVenmoRequest must be set to `.multiUse`.
  *
- * If this property is set to false, you can still vault the Venmo account on your server, provided that `paymentMethodUsage` is set to `.multiUse`.
+ * If this property is set to false, you can still vault the Venmo account on your server, provided that `paymentMethodUsage` is not set to `.singleUse`.
  *
  * Defaults to false.
  */

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -14,4 +14,9 @@ class BTVenmoRequest_Tests: XCTestCase {
         request.paymentMethodUsage = .singleUse
         XCTAssertEqual(request.paymentMethodUsageAsString, "SINGLE_USE")
     }
+
+    func testPaymentMethodUsageAsString_whenPaymentMethodUsageIsDefault_returnsNil() {
+        let request = BTVenmoRequest()
+        XCTAssertEqual(request.paymentMethodUsageAsString, nil)
+    }
 }


### PR DESCRIPTION

### Summary of changes

- Launch the new VenmoContext flow only if the `paymentMethodUsage` property on `BTVenmoRequest` is explicitly set
    - Adds a default enum case to `BTVenmoPaymentMethodUsage` for `None`
- Reorganize methods in `BTVenmoDriver.m` to align with pragma mark descriptions

### Question
- I have an open question regarding how we should communicate this new "feature" to merchants, using this opt-in pattern. See PR comment.

### Checklist

- ~Added a changelog entry~
- [JIRA](https://engineering.paypalcorp.com/jira/browse/DTBTSDK-942)

### Authors
@scannillo
