### PR TITLE
Fix bug where `userAction` on `BTPayPalCheckoutRequest` was ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Update Kount SDK to v4.1.5
+* Fix bug where `userAction` on `BTPayPalCheckoutRequest` was ignored
 
 ## 4.37.1 (2021-04-06)
 * Update PPRiskMagnesOC to 4.0.12 (resolves potential duplicate symbols errors)

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -236,7 +236,7 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 }
 
 - (void)performSwitchRequest:(NSURL *)appSwitchURL paymentType:(BTPayPalPaymentType)paymentType completion:(void (^)(BTPayPalAccountNonce *, NSError *))completionBlock {
-    self.approvalUrl = appSwitchURL;
+    self.approvalUrl = appSwitchURL; // exposed for testing
     self.authenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:appSwitchURL
                                                                callbackURLScheme:BTPayPalCallbackURLScheme
                                                                completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -168,9 +168,9 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
             if (approvalUrl == nil) {
                 approvalUrl = [body[@"agreementSetup"][@"approvalUrl"] asURL];
             }
-            self.approvalUrl = [self decorateApprovalURL:approvalUrl forRequest:request];
+            approvalUrl = [self decorateApprovalURL:approvalUrl forRequest:request];
 
-            NSString *pairingID = [self.class tokenFromApprovalURL:self.approvalUrl];
+            NSString *pairingID = [self.class tokenFromApprovalURL:approvalUrl];
 
             self.clientMetadataID = [PPDataCollector clientMetadataID:pairingID];
 
@@ -236,11 +236,10 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 }
 
 - (void)performSwitchRequest:(NSURL *)appSwitchURL paymentType:(BTPayPalPaymentType)paymentType completion:(void (^)(BTPayPalAccountNonce *, NSError *))completionBlock {
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:appSwitchURL resolvingAgainstBaseURL:NO];
-
-    self.authenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:urlComponents.URL
-                                                                  callbackURLScheme:BTPayPalCallbackURLScheme
-                                                                  completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
+    self.approvalUrl = appSwitchURL;
+    self.authenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:appSwitchURL
+                                                               callbackURLScheme:BTPayPalCallbackURLScheme
+                                                               completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
         // Required to avoid memory leak for BTPayPalDriver
         self.authenticationSession = nil;
 


### PR DESCRIPTION

### Summary of changes

- Fix a bug where `userAction` on `BTPayPalCheckoutRequest` was ignored, which meant that the button in the PayPal web page displayed the wrong text.

The bug was that we had a local variable called `approvalURL` as well as a property, `self.approvalURL`. We added the `userAction` query param to `self.approvalURL`, but then were actually using `approvalURL` (the local variable, which didn't have the `userAction` query param) to open the web page.

The tests didn't catch this because they are checking `self.approvalURL`, which was constructed correctly (but then not actually used). Instead of setting `self.approvalURL` early on, I moved it so that it is set right before we pass the URL to `ASWebAuthenticationSession`. That way, we're testing the URL that we're actually using.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens
