### PR TITLE
Update BTJSON for Swift compatibility

### DIFF
--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -181,12 +181,14 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
     if ([jsonResponse asDictionary]) {
         mutableUserInfo[BTCustomerInputBraintreeValidationErrorsKey] = [jsonResponse asDictionary];
         
-        BTJSON *fieldError = [[jsonResponse[@"fieldErrors"] asArray] firstObject];
         NSString *errorMessage = [jsonResponse[@"error"][@"message"] asString];
         if (errorMessage) {
             mutableUserInfo[NSLocalizedDescriptionKey] = errorMessage;
         }
-        NSString *firstFieldErrorMessage = [fieldError[@"fieldErrors"] firstObject][@"message"];
+
+        BTJSON *fieldError = [jsonResponse[@"fieldErrors"] asArray].firstObject;
+        BTJSON *firstFieldError = [fieldError[@"fieldErrors"] asArray].firstObject;
+        NSString *firstFieldErrorMessage = [firstFieldError[@"message"] asString];
         if (firstFieldErrorMessage) {
             mutableUserInfo[NSLocalizedFailureReasonErrorKey] = firstFieldErrorMessage;
         }
@@ -230,7 +232,7 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
 }
 
 - (BOOL)isGraphQLEnabledForCardTokenization:(BTConfiguration *)configuration {
-    NSArray *graphQLFeatures = [configuration.json[@"graphQL"][@"features"] asArray];
+    NSArray *graphQLFeatures = [configuration.json[@"graphQL"][@"features"] asStringArray];
 
     return graphQLFeatures && [graphQLFeatures containsObject:BTCardClientGraphQLTokenizeFeature];
 }

--- a/Sources/BraintreeCore/BTAPIClient.m
+++ b/Sources/BraintreeCore/BTAPIClient.m
@@ -280,9 +280,8 @@ NSString *const BTAPIClientErrorDomain = @"com.braintreepayments.BTAPIClientErro
                              completion(nil, error);
                          } else {
                              NSMutableArray *paymentMethodNonces = [NSMutableArray array];
-                             for (NSDictionary *paymentInfo in [body[@"paymentMethods"] asArray]) {
-                                 BTJSON *paymentInfoJSON = [[BTJSON alloc] initWithValue:paymentInfo];
-                                 BTPaymentMethodNonce *paymentMethodNonce = [[BTPaymentMethodNonceParser sharedParser] parseJSON:paymentInfoJSON withParsingBlockForType:[paymentInfoJSON[@"type"] asString]];
+                             for (BTJSON *paymentInfo in [body[@"paymentMethods"] asArray]) {
+                                 BTPaymentMethodNonce *paymentMethodNonce = [[BTPaymentMethodNonceParser sharedParser] parseJSON:paymentInfo withParsingBlockForType:[paymentInfo[@"type"] asString]];
                                  if (paymentMethodNonce) {
                                      [paymentMethodNonces addObject:paymentMethodNonce];
                                  }

--- a/Sources/BraintreeCore/BTJSON.m
+++ b/Sources/BraintreeCore/BTJSON.m
@@ -139,7 +139,6 @@ NSString * const BTJSONErrorDomain = @"com.briantreepayments.BTJSONErrorDomain";
         return nil;
     }
 
-    // TODO: Check to see if other places were relying on this method not properly returning NSArray<BTJSON> type
     NSMutableArray *array = [NSMutableArray new];
     for (id element in self.value) {
         [array addObject:[[BTJSON alloc] initWithValue:element]];

--- a/Sources/BraintreeCore/BTJSON.m
+++ b/Sources/BraintreeCore/BTJSON.m
@@ -49,14 +49,14 @@ NSString * const BTJSONErrorDomain = @"com.briantreepayments.BTJSONErrorDomain";
 
 #pragma mark Subscripting
 
-- (id)objectForKeyedSubscript:(NSString *)key {
+- (BTJSON *)objectForKeyedSubscript:(NSString *)key {
     BTJSON *json = [[BTJSON alloc] initWithValue:_value];
     json.subscripts = [self.subscripts arrayByAddingObject:key];
 
     return json;
 }
 
-- (id)objectAtIndexedSubscript:(NSUInteger)idx {
+- (BTJSON *)objectAtIndexedSubscript:(NSUInteger)idx {
     BTJSON *json = [[BTJSON alloc] initWithValue:_value];
     json.subscripts = [self.subscripts arrayByAddingObject:@(idx)];
 
@@ -139,7 +139,13 @@ NSString * const BTJSONErrorDomain = @"com.briantreepayments.BTJSONErrorDomain";
         return nil;
     }
 
-    return self.value;
+    // TODO: Check to see if other places were relying on this method not properly returning NSArray<BTJSON> type
+    NSMutableArray *array = [NSMutableArray new];
+    for (id element in self.value) {
+        [array addObject:[[BTJSON alloc] initWithValue:element]];
+    }
+
+    return array;
 }
 
 - (NSDecimalNumber *)asNumber {
@@ -163,15 +169,17 @@ NSString * const BTJSONErrorDomain = @"com.briantreepayments.BTJSONErrorDomain";
 }
 
 - (NSArray<NSString *> *)asStringArray {
-    NSArray <NSString *> *array = (NSArray <NSString *> *)self.asArray;
+    if (![self.value isKindOfClass:[NSArray class]]) {
+        return nil;
+    }
 
-    for (id obj in array) {
+    for (id obj in self.value) {
         if (![obj isKindOfClass:[NSString class]]) {
             return nil;
         }
     }
 
-    return array;
+    return self.value;
 }
 
 - (NSDictionary<NSString *, BTJSON *> *)asDictionary {

--- a/Sources/BraintreeCore/BTPayPalIDToken.m
+++ b/Sources/BraintreeCore/BTPayPalIDToken.m
@@ -23,7 +23,7 @@ NSString * const BTPayPalIDTokenErrorDomain = @"com.braintreepayments.BTPayPalID
             return nil;
         }
         
-        NSArray *externalIDs = [json[@"external_id"] asArray];
+        NSArray *externalIDs = [json[@"external_id"] asStringArray];
         for (NSString *externalID in externalIDs) {
             if ([externalID hasPrefix:@"Braintree:"]) {
                 _braintreeMerchantID = [externalID componentsSeparatedByString:@":"][1];

--- a/Sources/BraintreeCore/Public/BraintreeCore/BTJSON.h
+++ b/Sources/BraintreeCore/Public/BraintreeCore/BTJSON.h
@@ -90,7 +90,7 @@ typedef NS_ENUM(NSInteger, BTJSONErrorCode) {
 
  Notably, this method will always return successfully; however, if the value is not an object, the JSON will wrap an error.
 */
-- (id)objectForKeyedSubscript:(NSString *)key;
+- (BTJSON *)objectForKeyedSubscript:(NSString *)key;
 
 /**
  Indexes into the JSON as if the current value is an array

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureResult.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureResult.m
@@ -31,7 +31,7 @@
         if ([json[@"errors"] asArray]) {
             NSDictionary *firstError = (NSDictionary *)[json[@"errors"] asArray].firstObject;
             if (firstError[@"message"]) {
-                _errorMessage = firstError[@"message"];
+                _errorMessage = [firstError[@"message"] asString];
             }
         } else {
             _errorMessage = [json[@"error"][@"message"] asString];

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_SwiftTests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_SwiftTests.swift
@@ -247,7 +247,7 @@ class BTAPIClient_SwiftTests: XCTestCase {
         apiClient.http = mockHTTP
         apiClient.configurationHTTP = mockConfigurationHTTP
 
-        XCTAssertEqual((apiClient.clientToken!.json["version"] as! BTJSON).asIntegerOrZero(), 3)
+        XCTAssertEqual((apiClient.clientToken!.json["version"]).asIntegerOrZero(), 3)
 
         let expectation = self.expectation(description: "Callback invoked")
         apiClient.fetchPaymentMethodNonces() { _,_  in

--- a/UnitTests/BraintreeCoreTests/BTBinData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTBinData_Tests.swift
@@ -21,7 +21,7 @@ class BTBinData_Tests: XCTestCase {
             ],
             "nonce": "fake-nonce",
             ])
-        let binData = BTBinData(json: json["binData"] as! BTJSON)
+        let binData = BTBinData(json: json["binData"])
 
         XCTAssertEqual(binData.prepaid, "Yes")
         XCTAssertEqual(binData.healthcare, "Yes")
@@ -38,7 +38,7 @@ class BTBinData_Tests: XCTestCase {
         let json = BTJSON(value: [
             "some": "value"
             ])
-        let binData = BTBinData(json: json["binData"] as! BTJSON)
+        let binData = BTBinData(json: json["binData"])
 
         XCTAssertEqual(binData.prepaid, "Unknown")
         XCTAssertEqual(binData.healthcare, "Unknown")

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -96,8 +96,8 @@ class BTDataCollector_Tests: XCTestCase {
         let expectation = self.expectation(description: "Returns fraud data")
         dataCollector.collectDeviceData { deviceData in
             let json = BTJSON(data: deviceData.data(using: String.Encoding.utf8)!)
-            XCTAssertNil(json["fraud_merchant_id"] as? String)
-            XCTAssertNil(json["device_session_id"] as? String)
+            XCTAssertNil(json["fraud_merchant_id"].asString())
+            XCTAssertNil(json["device_session_id"].asString())
             XCTAssert((json["correlation_id"] as AnyObject).asString()!.count > 0)
             expectation.fulfill()
         }


### PR DESCRIPTION
### Summary of changes

While adding the new module for PayPal native checkout in Swift, we came across some inconsistencies with the return types of methods on `BTJSON`. We've updated these methods so that working with `BTJSON` in Swift is more straightforward.

* Update `asArray` method to return `NSArray<BTJSON *> *`
* Update `asStringArray` method to return `NSArray<String *>`
* Update `objectForKeyedSubscript` to return `BTJSON`
* Update `objectAtIndexedSubscript` to return `BTJSON`

Once this change is released, we'll need to make a small update to iOS Drop-in: https://github.com/braintree/braintree-ios-drop-in/pull/329.

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
