### PR TITLE
Update CI to use macOS 11 and Xcode 12.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,26 +3,26 @@ on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
     name: CocoaPods
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
     name: Carthage
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -37,12 +37,12 @@ jobs:
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
     name: SPM
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
   spm_old:
     name: SPM (on Xcode 12.4)
-    runs-on: macOS-10.3
+    runs-on: macos-10.15
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,17 +49,3 @@ jobs:
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
-  spm_old:
-    name: SPM (on Xcode 12.4)
-    runs-on: macos-10.15
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,17 @@ jobs:
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
+  spm-xcode12.4:
+    name: SPM (on Xcode 12.4)
+    runs-on: macOS-10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use current branch
+        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+      - name: Run swift package resolve
+        run: cd SampleApps/SPMTest && swift package resolve
+      - name: Build & archive SPMTest
+        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
   spm_old:
     name: SPM (on Xcode 12.4)
-    runs-on: macOS-10
+    runs-on: macOS-10.3
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
-  spm-xcode12.4:
+  spm_old:
     name: SPM (on Xcode 12.4)
     runs-on: macOS-10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,36 +3,36 @@ on: [pull_request, workflow_dispatch]
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 12.5
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		427F32E025D1D62D00435294 /* BTPayPalDriver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427F32DF25D1D62D00435294 /* BTPayPalDriver_Tests.swift */; };
 		428E3307258A9F9000C744DD /* PPRiskMagnes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4255C5EB2565D62400A3CA78 /* PPRiskMagnes.framework */; platformFilter = ios; };
 		428F48E42624C9B700EC8DB4 /* BTVenmoAppSwitchRequestURL_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRequestURL_Tests.swift */; };
+		428F976626727333001042E1 /* BTMockOpenURLContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 428F976526727333001042E1 /* BTMockOpenURLContext.m */; };
 		4290C666259B9E2E00D2044C /* BTThreeDSecureV2BaseCustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 4290C660259B9E2E00D2044C /* BTThreeDSecureV2BaseCustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4290C667259B9E2E00D2044C /* BTThreeDSecureV2UICustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 4290C661259B9E2E00D2044C /* BTThreeDSecureV2UICustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4290C668259B9E2E00D2044C /* BTThreeDSecureV2LabelCustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 4290C662259B9E2E00D2044C /* BTThreeDSecureV2LabelCustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -808,6 +809,8 @@
 		427F328F25D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalVaultRequest_Tests.swift; sourceTree = "<group>"; };
 		427F32DF25D1D62D00435294 /* BTPayPalDriver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalDriver_Tests.swift; sourceTree = "<group>"; };
 		428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRequestURL_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoAppSwitchRequestURL_Tests.swift; sourceTree = "<group>"; };
+		428F976426727333001042E1 /* BTMockOpenURLContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTMockOpenURLContext.h; sourceTree = "<group>"; };
+		428F976526727333001042E1 /* BTMockOpenURLContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTMockOpenURLContext.m; sourceTree = "<group>"; };
 		4290C660259B9E2E00D2044C /* BTThreeDSecureV2BaseCustomization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTThreeDSecureV2BaseCustomization.h; sourceTree = "<group>"; };
 		4290C661259B9E2E00D2044C /* BTThreeDSecureV2UICustomization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTThreeDSecureV2UICustomization.h; sourceTree = "<group>"; };
 		4290C662259B9E2E00D2044C /* BTThreeDSecureV2LabelCustomization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTThreeDSecureV2LabelCustomization.h; sourceTree = "<group>"; };
@@ -1949,6 +1952,8 @@
 			children = (
 				A7D4630B1B4B16C100A09C46 /* BTHTTPTestProtocol.h */,
 				A7D4630C1B4B16C100A09C46 /* BTHTTPTestProtocol.m */,
+				428F976426727333001042E1 /* BTMockOpenURLContext.h */,
+				428F976526727333001042E1 /* BTMockOpenURLContext.m */,
 				42A37F1923EB65E8005A5BF7 /* PayPalIDTokenTestHelper.swift */,
 			);
 			path = Helpers;
@@ -3555,6 +3560,7 @@
 				A908436624FD8791004134CA /* BTConfiguration_Tests.swift in Sources */,
 				A908436524FD8315004134CA /* BTClientTokenSpec.m in Sources */,
 				A908436424FD82E1004134CA /* BTClientMetadataSpec.m in Sources */,
+				428F976626727333001042E1 /* BTMockOpenURLContext.m in Sources */,
 				A9E5C23424FD6FAE00EE691F /* BTAPIClient_SwiftTests.swift in Sources */,
 				A95229C424FD8EEE006F7D25 /* BTURLUtils_Tests.swift in Sources */,
 				A908436324FD82C0004134CA /* BTBinData_Tests.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Re-add `BraintreeCore` dependency to `PayPalDataCollector` for Swift Package Manager to fix archive issue (fixes #679)
+* Re-add `BraintreeCore` dependency to `PayPalDataCollector` for Swift Package Manager archive issue workaround (fixes #679)
 
 ## 5.4.0 (2021-06-07)
 * Venmo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Re-add `BraintreeCore` dependency to `PayPalDataCollector` for Swift Package Manager to fix archive issue (fixes #679)
+
 ## 5.4.0 (2021-06-07)
 * Venmo
   * Add `paymentMethodUsage` to `BTVenmoRequest`

--- a/Demo/UI Tests/Helpers/BTUITest.swift
+++ b/Demo/UI Tests/Helpers/BTUITest.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
+    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 30,  file: String = #file, line: UInt = #line) {
         let existsPredicate = NSPredicate(format: "exists == true")
         
         expectation(for: existsPredicate,
@@ -20,7 +20,7 @@ extension XCTestCase {
         }
     }
     
-    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
+    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 30,  file: String = #file, line: UInt = #line) {
         let existsPredicate = NSPredicate(format: "exists == true && hittable == true")
         
         expectation(for: existsPredicate,

--- a/Demo/UI Tests/Helpers/BTUITest.swift
+++ b/Demo/UI Tests/Helpers/BTUITest.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 30,  file: String = #file, line: UInt = #line) {
+    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
         let existsPredicate = NSPredicate(format: "exists == true")
         
         expectation(for: existsPredicate,
@@ -20,7 +20,7 @@ extension XCTestCase {
         }
     }
     
-    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 30,  file: String = #file, line: UInt = #line) {
+    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
         let existsPredicate = NSPredicate(format: "exists == true && hittable == true")
         
         expectation(for: existsPredicate,

--- a/Package.swift
+++ b/Package.swift
@@ -140,6 +140,7 @@ let package = Package(
         ),
         .target(
             name: "PayPalDataCollector",
+            dependencies: ["BraintreeCore"],
             path: "Sources/PayPalDataCollector"
         ),
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .target(
             name: "PayPalDataCollector",
-            dependencies: ["BraintreeCore"],
+//            dependencies: ["BraintreeCore"],
             path: "Sources/PayPalDataCollector"
         ),
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .target(
             name: "PayPalDataCollector",
-//            dependencies: ["BraintreeCore"],
+            dependencies: ["BraintreeCore"],
             path: "Sources/PayPalDataCollector"
         ),
         .binaryTarget(

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -56,9 +56,9 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         appSwitch.register(MockAppContextSwitchDriver.self)
         MockAppContextSwitchDriver.cannedCanHandle = true
 
-        let urlContext = MockOpenURLContext(url: URL(string: "my-url.com")!)
+        let mockURLContext = BTMockOpenURLContext(url: URL(string: "my-url.com")!).mock
 
-        let handled = BTAppContextSwitcher.handleOpenURLContext(urlContext)
+        let handled = BTAppContextSwitcher.handleOpenURLContext(mockURLContext)
 
         XCTAssertTrue(handled)
         XCTAssertEqual(MockAppContextSwitchDriver.lastCanHandleURL, URL(string: "my-url.com"))
@@ -71,9 +71,9 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         appSwitch.register(MockAppContextSwitchDriver.self)
         MockAppContextSwitchDriver.cannedCanHandle = false
 
-        let urlContext = MockOpenURLContext(url: URL(string: "fake://url")!)
+        let mockURLContext = BTMockOpenURLContext(url: URL(string: "fake://url")!).mock
 
-        let handled = BTAppContextSwitcher.handleOpenURLContext(urlContext)
+        let handled = BTAppContextSwitcher.handleOpenURLContext(mockURLContext)
 
         XCTAssertFalse(handled)
         XCTAssertNil(MockAppContextSwitchDriver.lastHandleReturnURL)
@@ -98,19 +98,5 @@ class MockAppContextSwitchDriver: BTAppContextSwitchDriver {
 
     @objc static func handleReturnURL(_ url: URL) {
         lastHandleReturnURL = url
-    }
-}
-
-@available(iOS 13.0, *)
-class MockOpenURLContext: UIOpenURLContext {
-
-    private let _url: URL
-
-    override var url: URL {
-        return _url
-    }
-
-    init(url: URL) {
-        self._url = url
     }
 }

--- a/UnitTests/BraintreeCoreTests/BraintreeCoreTests-Bridging-Header.h
+++ b/UnitTests/BraintreeCoreTests/BraintreeCoreTests-Bridging-Header.h
@@ -5,3 +5,5 @@
 #import <BraintreeCore/Braintree-Version.h>
 #import <BraintreeCore/BTAnalyticsService.h>
 #import <BraintreeCore/BTPaymentMethodNonceParser.h>
+
+#import "BTMockOpenURLContext.h"

--- a/UnitTests/BraintreeCoreTests/Helpers/BTMockOpenURLContext.h
+++ b/UnitTests/BraintreeCoreTests/Helpers/BTMockOpenURLContext.h
@@ -1,0 +1,17 @@
+@import OCMock;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** It's not possible to mock UIOpenURLContext through subclassing because its initializer is unavailable,
+ *  so we're mocking it with OCMock instead.
+ */
+API_AVAILABLE(ios(13.0))
+@interface BTMockOpenURLContext : NSObject
+
+- (instancetype)initWithURL:(NSURL *)url;
+
+@property(readonly, nonatomic) UIOpenURLContext *mock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UnitTests/BraintreeCoreTests/Helpers/BTMockOpenURLContext.m
+++ b/UnitTests/BraintreeCoreTests/Helpers/BTMockOpenURLContext.m
@@ -1,0 +1,13 @@
+#import "BTMockOpenURLContext.h"
+
+@implementation BTMockOpenURLContext
+
+- (instancetype)initWithURL:(NSURL *)url {
+    if (self = [super init]) {
+        _mock = OCMClassMock(UIOpenURLContext.class);
+        OCMStub(_mock.URL).andReturn(url);
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION

### Summary of changes

- Update GitHub Action workflows to use macOS 11 and Xcode 12.5
- Update how we mock `UIOpenURLContext` in unit tests. Creating a subclass is not longer possible since the initializer is not available. So now we use OCMock (an Obj-C mocking framework) instead, following [this approach](https://github.com/markspanbroek/MockingInSwift#cheating).

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 
- @sestevens 
