### PR TITLE
Fix build of package when parallelize build is enabled in Xcode scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+ * Add `PPRiskMagnes` dependency to `PayPalDataCollector` to allow application builds to be parallelized.
+ 
 ## 5.4.2 (2021-06-24)
 * Swift Package Manager
   * Remove product libraries for `KountDataCollector`, `PPRiskMagnes`, and `CardinalMobile` (requires Xcode 12.5+)

--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,7 @@ let package = Package(
         ),
         .target(
             name: "PayPalDataCollector",
-            dependencies: ["BraintreeCore"],
+            dependencies: ["BraintreeCore", "PPRiskMagnes"],
             path: "Sources/PayPalDataCollector"
         ),
         .binaryTarget(


### PR DESCRIPTION
### Summary of changes

Adds PPRiskMagnes as a dependency of PayPalDataCollector. Without this, projects using Braintree fail to build when the "parallelize build" is true as Xcode does not have a way to determine this dependency.

I checked the provided Xcode project and this dependency definition matches what is defined for the two framework targets. 

### Checklist

- [x] Added a changelog entry 

### Authors

- @danielctull
