### PR TITLE
Xcode13-beta3 Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Swift Package Manager
+  * Adds `NS_EXTENSION_UNAVAILABLE` annotations to methods unavailable for use in app extensions. Fixes (Drop-In issue #343)[https://github.com/braintree/braintree-ios-drop-in/issues/343] for Xcode 13-beta3.
+
 ## 5.4.2 (2021-06-24)
 * Swift Package Manager
   * Remove product libraries for `KountDataCollector`, `PPRiskMagnes`, and `CardinalMobile` (requires Xcode 12.5+)

--- a/Sources/BraintreeCore/Public/BraintreeCore/BTPreferredPaymentMethods.h
+++ b/Sources/BraintreeCore/Public/BraintreeCore/BTPreferredPaymentMethods.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param apiClient An API client
 */
-- (instancetype)initWithAPIClient:(BTAPIClient *)apiClient NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAPIClient:(BTAPIClient *)apiClient NS_DESIGNATED_INITIALIZER NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.");
 
 /**
  :nodoc:

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -419,7 +419,7 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
 
 #pragma mark - ASWebAuthenticationPresentationContextProviding protocol
 
-- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13)) {
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13)) NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (self.payPalRequest.activeWindow) {
         return self.payPalRequest.activeWindow;
     }

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -62,7 +62,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
 #pragma mark - Accessors
 
-- (id)application {
+- (id)application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (!_application) {
         _application = [UIApplication sharedApplication];
     }

--- a/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
+++ b/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
@@ -11,7 +11,7 @@
  to prevent calls to openURL. Its type is `id` and not `UIApplication` because trying to subclass
  UIApplication is not possible, since it enforces that only one instance can ever exist
 */
-@property (nonatomic, strong) id application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.");
+@property (nonatomic, strong) id application;
 
 /**
  Defaults to [NSBundle mainBundle], but exposed for unit tests to inject test doubles to stub values in infoDictionary

--- a/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
+++ b/Sources/BraintreeVenmo/BTVenmoDriver_Internal.h
@@ -11,7 +11,7 @@
  to prevent calls to openURL. Its type is `id` and not `UIApplication` because trying to subclass
  UIApplication is not possible, since it enforces that only one instance can ever exist
 */
-@property (nonatomic, strong) id application;
+@property (nonatomic, strong) id application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.");
 
 /**
  Defaults to [NSBundle mainBundle], but exposed for unit tests to inject test doubles to stub values in infoDictionary


### PR DESCRIPTION
### Background

[GitHub Issue](https://github.com/braintree/braintree-ios-drop-in/issues/343)

[XCode 13-beta3](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes) release notes call out the following change:
 > Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

### Changes

In places that we use Apple APIs which aren't usable in App Extensions (`UIApplication.sharedApplication`) we need to explicitly mark these methods as not usable for App Extensions.

### Resources
- [Twitter thread](https://twitter.com/twannl/status/1415643862761152513)

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
