### PR TITLE
Add `BTThreeDSecureCardAddChallenge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Swift Package Manager
   * Adds `NS_EXTENSION_UNAVAILABLE` annotations to methods unavailable for use in app extensions. Fixes (Drop-In issue #343)[https://github.com/braintree/braintree-ios-drop-in/issues/343] for Xcode 13-beta3.
 * ThreeDSecure
-  * Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
+  * Add `cardAddChallenge` to `BTThreeDSecureRequest`
 
 ## 5.4.2 (2021-06-24)
 * Swift Package Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * Swift Package Manager
   * Adds `NS_EXTENSION_UNAVAILABLE` annotations to methods unavailable for use in app extensions. Fixes (Drop-In issue #343)[https://github.com/braintree/braintree-ios-drop-in/issues/343] for Xcode 13-beta3.
+* ThreeDSecure
+  * Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
 
 ## 5.4.2 (2021-06-24)
 * Swift Package Manager

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -70,10 +70,10 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
             requestParameters[@"dataOnlyRequested"] = @(request.dataOnlyRequested);
         }
         
-        if (request.addCardChallengeRequested == BTThreeDSecureAddCardChallengeRequested) {
-            requestParameters[@"addCard"] = @(true);
-        } else if (request.addCardChallengeRequested == BTThreeDSecureAddCardChallengeNotRequested) {
-            requestParameters[@"addCard"] = @(false);
+        if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeRequested) {
+            requestParameters[@"cardAdd"] = @(true);
+        } else if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeNotRequested) {
+            requestParameters[@"cardAdd"] = @(false);
         }
 
         NSMutableDictionary *additionalInformation = [NSMutableDictionary dictionary];

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -69,6 +69,12 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
         if (request.dataOnlyRequested) {
             requestParameters[@"dataOnlyRequested"] = @(request.dataOnlyRequested);
         }
+        
+        if (request.addCardChallengeRequested == BTThreeDSecureAddCardChallengeRequested) {
+            requestParameters[@"addCard"] = @(true);
+        } else if (request.addCardChallengeRequested == BTThreeDSecureAddCardChallengeNotRequested) {
+            requestParameters[@"addCard"] = @(false);
+        }
 
         NSMutableDictionary *additionalInformation = [NSMutableDictionary dictionary];
         if (request.billingAddress) {

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -70,9 +70,9 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
             requestParameters[@"dataOnlyRequested"] = @(request.dataOnlyRequested);
         }
         
-        if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeRequested) {
+        if (request.cardAddChallenge == BTThreeDSecureCardAddChallengeRequested) {
             requestParameters[@"cardAdd"] = @(YES);
-        } else if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeNotRequested) {
+        } else if (request.cardAddChallenge == BTThreeDSecureCardAddChallengeNotRequested) {
             requestParameters[@"cardAdd"] = @(NO);
         }
 

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -73,7 +73,7 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
         if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeRequested) {
             requestParameters[@"cardAdd"] = @(YES);
         } else if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeNotRequested) {
-            requestParameters[@"cardAdd"] = @(false);
+            requestParameters[@"cardAdd"] = @(NO);
         }
 
         NSMutableDictionary *additionalInformation = [NSMutableDictionary dictionary];

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -71,7 +71,7 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
         }
         
         if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeRequested) {
-            requestParameters[@"cardAdd"] = @(true);
+            requestParameters[@"cardAdd"] = @(YES);
         } else if (request.cardAddChallengeRequested == BTThreeDSecureCardAddChallengeNotRequested) {
             requestParameters[@"cardAdd"] = @(false);
         }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -53,7 +53,7 @@
     self = [super init];
     if (self) {
         _versionRequested = BTThreeDSecureVersion2;
-        _addCardChallengeRequested = BTThreeDSecureAddCardChallengeUnspecified;
+        _cardAddChallengeRequested = BTThreeDSecureCardAddChallengeUnspecified;
     }
 
     return self;

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -53,6 +53,7 @@
     self = [super init];
     if (self) {
         _versionRequested = BTThreeDSecureVersion2;
+        _addCardChallengeRequested = BTThreeDSecureAddCardChallengeUnspecified;
     }
 
     return self;

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -53,7 +53,6 @@
     self = [super init];
     if (self) {
         _versionRequested = BTThreeDSecureVersion2;
-        _cardAddChallengeRequested = BTThreeDSecureCardAddChallengeUnspecified;
     }
 
     return self;

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureShippingMethod) {
 };
 
 /**
- The add card challenge request
+ The card add challenge request
  */
 typedef NS_ENUM(NSInteger, BTThreeDSecureCardAddChallenge) {
     /// Unspecified
@@ -158,10 +158,11 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureCardAddChallenge) {
  Optional. An authentication created using this property should only be used for adding a payment method to the merchant's vault and not for creating transactions.
  Defaults to BTThreeDSecureAddCardChallengeUnspecified.
  If set to BTThreeDSecureAddCardChallengeRequested, the authentication challenge will be requested from the issuer to confirm adding new card to the merchant's vault.
- If set to BTThreeDSecureAddCardChallengeUnspecified and amount is 0, the authentication challenge will be presented to the user.
- If set to BTThreeDSecureAddCardChallengeNotRequested, when the amount is 0, the authentication challenge will not be presented to the user
+ If set to BTThreeDSecureAddCardChallengeNotRequested the authentication challenge will not be requested from the issuer.
+ If set to BTThreeDSecureAddCardChallengeUnspecified, when the amount is 0, the authentication challenge will be requested from the issuer.
+ If set to BTThreeDSecureAddCardChallengeUnspecified, when the amount is greater than 0, the authentication challenge will not be requested from the issuer.
  */
-@property (nonatomic, assign) BTThreeDSecureCardAddChallenge cardAddChallengeRequested;
+@property (nonatomic, assign) BTThreeDSecureCardAddChallenge cardAddChallenge;
 
 /**
  Optional. UI Customization for 3DS2 challenge views.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -73,15 +73,15 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureShippingMethod) {
 /**
  The add card challenge request
  */
-typedef NS_ENUM(NSInteger, BTThreeDSecureAddCardChallenge) {
+typedef NS_ENUM(NSInteger, BTThreeDSecureCardAddChallenge) {
     /// Unspecified
-    BTThreeDSecureAddCardChallengeUnspecified,
+    BTThreeDSecureCardAddChallengeUnspecified,
     
     /// Requested
-    BTThreeDSecureAddCardChallengeRequested,
+    BTThreeDSecureCardAddChallengeRequested,
     
     /// Not Requested
-    BTThreeDSecureAddCardChallengeNotRequested
+    BTThreeDSecureCardAddChallengeNotRequested
 };
 
 /**
@@ -161,7 +161,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureAddCardChallenge) {
  If set to BTThreeDSecureAddCardChallengeUnspecified and amount is 0, the authentication challenge will be presented to the user.
  If set to BTThreeDSecureAddCardChallengeNotRequested, when the amount is 0, the authentication challenge will not be presented to the user
  */
-@property (nonatomic) BTThreeDSecureAddCardChallenge addCardChallengeRequested;
+@property (nonatomic) BTThreeDSecureCardAddChallenge cardAddChallengeRequested;
 
 /**
  Optional. UI Customization for 3DS2 challenge views.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -157,9 +157,11 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureAddCardChallenge) {
 /**
  Optional. An authentication created using this property should only be used for adding a payment method to the merchant's vault and not for creating transactions.
  Defaults to BTThreeDSecureAddCardChallengeUnspecified.
- If BTThreeDSecureAddCardChallengeUnspecified and the amount is 0
  If set to BTThreeDSecureAddCardChallengeRequested, the authentication challenge will be requested from the issuer to confirm adding new card to the merchant's vault.
- If not set and amount is 0, the authentication challenge will be presented to the user. If set to false, when the amount is 0, the authentication challenge will not be presented to the user*/
+ If set to BTThreeDSecureAddCardChallengeUnspecified and amount is 0, the authentication challenge will be presented to the user.
+ If set to BTThreeDSecureAddCardChallengeNotRequested, when the amount is 0, the authentication challenge will not be presented to the user
+ */
+@property (nonatomic) BTThreeDSecureAddCardChallenge addCardChallengeRequested;
 
 /**
  Optional. UI Customization for 3DS2 challenge views.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -71,6 +71,20 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureShippingMethod) {
 };
 
 /**
+ The add card challenge request
+ */
+typedef NS_ENUM(NSInteger, BTThreeDSecureAddCardChallenge) {
+    /// Unspecified
+    BTThreeDSecureAddCardChallengeUnspecified,
+    
+    /// Requested
+    BTThreeDSecureAddCardChallengeRequested,
+    
+    /// Not Requested
+    BTThreeDSecureAddCardChallengeNotRequested
+};
+
+/**
  Used to initialize a 3D Secure payment flow
  */
 @interface BTThreeDSecureRequest : BTPaymentFlowRequest <BTPaymentFlowRequestDelegate>
@@ -139,6 +153,13 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureShippingMethod) {
  :nodoc:
  */
 @property (nonatomic) BOOL dataOnlyRequested;
+
+/**
+ Optional. An authentication created using this property should only be used for adding a payment method to the merchant's vault and not for creating transactions.
+ Defaults to BTThreeDSecureAddCardChallengeUnspecified.
+ If BTThreeDSecureAddCardChallengeUnspecified and the amount is 0
+ If set to BTThreeDSecureAddCardChallengeRequested, the authentication challenge will be requested from the issuer to confirm adding new card to the merchant's vault.
+ If not set and amount is 0, the authentication challenge will be presented to the user. If set to false, when the amount is 0, the authentication challenge will not be presented to the user*/
 
 /**
  Optional. UI Customization for 3DS2 challenge views.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -161,7 +161,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureCardAddChallenge) {
  If set to BTThreeDSecureAddCardChallengeUnspecified and amount is 0, the authentication challenge will be presented to the user.
  If set to BTThreeDSecureAddCardChallengeNotRequested, when the amount is 0, the authentication challenge will not be presented to the user
  */
-@property (nonatomic) BTThreeDSecureCardAddChallenge cardAddChallengeRequested;
+@property (nonatomic, assign) BTThreeDSecureCardAddChallenge cardAddChallengeRequested;
 
 /**
  Optional. UI Customization for 3DS2 challenge views.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -156,7 +156,9 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureCardAddChallenge) {
 
 /**
  Optional. An authentication created using this property should only be used for adding a payment method to the merchant's vault and not for creating transactions.
+ 
  Defaults to BTThreeDSecureAddCardChallengeUnspecified.
+ 
  If set to BTThreeDSecureAddCardChallengeRequested, the authentication challenge will be requested from the issuer to confirm adding new card to the merchant's vault.
  If set to BTThreeDSecureAddCardChallengeNotRequested the authentication challenge will not be requested from the issuer.
  If set to BTThreeDSecureAddCardChallengeUnspecified, when the amount is 0, the authentication challenge will be requested from the issuer.

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -96,7 +96,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testPerformThreeDSecureLookup_whenCardAddChallengeRequestedNotSet_doesNotSendAddCardParameter() {
+    func testPerformThreeDSecureLookup_whenCardAddChallengeRequestedNotSet_doesNotSendCardAddParameter() {
         let expectation = self.expectation(description: "willCallCompletion")
 
         threeDSecureRequest.nonce = "fake-card-nonce"

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -27,7 +27,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.challengeRequested = true
         threeDSecureRequest.exemptionRequested = true
         threeDSecureRequest.dataOnlyRequested = true
-        threeDSecureRequest.cardAddChallengeRequested = .requested
+        threeDSecureRequest.cardAddChallenge = .requested
 
         threeDSecureRequest.mobilePhoneNumber = "5151234321"
         threeDSecureRequest.email = "tester@example.com"
@@ -85,7 +85,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.dfReferenceID = "df-reference-id"
 
-        threeDSecureRequest.cardAddChallengeRequested = .notRequested
+        threeDSecureRequest.cardAddChallenge = .notRequested
 
         driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
             XCTAssertFalse(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as! Bool)

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -78,7 +78,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testPerformThreeDSecureLookup_whenAddCardChallengeNotRequested_sendsAddCardFalse() {
+    func testPerformThreeDSecureLookup_whenCardAddChallengeNotRequested_sendsCardAddFalse() {
         let expectation = self.expectation(description: "willCallCompletion")
 
         threeDSecureRequest.nonce = "fake-card-nonce"

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -96,7 +96,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testPerformThreeDSecureLookup_whenAddCardChallengeUnspecified_doesNotSendAddCardParameter() {
+    func testPerformThreeDSecureLookup_whenCardAddChallengeRequestedNotSet_doesNotSendAddCardParameter() {
         let expectation = self.expectation(description: "willCallCompletion")
 
         threeDSecureRequest.nonce = "fake-card-nonce"

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -27,7 +27,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.challengeRequested = true
         threeDSecureRequest.exemptionRequested = true
         threeDSecureRequest.dataOnlyRequested = true
-        threeDSecureRequest.addCardChallengeRequested = .requested
+        threeDSecureRequest.cardAddChallengeRequested = .requested
 
         threeDSecureRequest.mobilePhoneNumber = "5151234321"
         threeDSecureRequest.email = "tester@example.com"
@@ -54,7 +54,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["challengeRequested"] as! Bool)
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["exemptionRequested"] as! Bool)
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["dataOnlyRequested"] as! Bool)
-            XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["addCard"] as! Bool)
+            XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as! Bool)
 
             let additionalInfo = self.mockAPIClient.lastPOSTParameters!["additionalInfo"] as! Dictionary<String, String>
             XCTAssertEqual(additionalInfo["mobilePhoneNumber"], "5151234321")
@@ -85,10 +85,10 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.dfReferenceID = "df-reference-id"
 
-        threeDSecureRequest.addCardChallengeRequested = .notRequested
+        threeDSecureRequest.cardAddChallengeRequested = .notRequested
 
         driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
-            XCTAssertFalse(self.mockAPIClient.lastPOSTParameters!["addCard"] as! Bool)
+            XCTAssertFalse(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as! Bool)
 
             expectation.fulfill()
         }
@@ -104,7 +104,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.dfReferenceID = "df-reference-id"
 
         driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
-            XCTAssertNil(self.mockAPIClient.lastPOSTParameters!["addCard"] as? Bool)
+            XCTAssertNil(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as? Bool)
 
             expectation.fulfill()
         }

--- a/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTPaymentFlowDriver+ThreeDSecure_Tests.swift
@@ -27,6 +27,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
         threeDSecureRequest.challengeRequested = true
         threeDSecureRequest.exemptionRequested = true
         threeDSecureRequest.dataOnlyRequested = true
+        threeDSecureRequest.addCardChallengeRequested = .requested
 
         threeDSecureRequest.mobilePhoneNumber = "5151234321"
         threeDSecureRequest.email = "tester@example.com"
@@ -53,6 +54,7 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["challengeRequested"] as! Bool)
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["exemptionRequested"] as! Bool)
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["dataOnlyRequested"] as! Bool)
+            XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["addCard"] as! Bool)
 
             let additionalInfo = self.mockAPIClient.lastPOSTParameters!["additionalInfo"] as! Dictionary<String, String>
             XCTAssertEqual(additionalInfo["mobilePhoneNumber"], "5151234321")
@@ -75,6 +77,41 @@ class BTPaymentFlowDriver_ThreeDSecure_Tests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testPerformThreeDSecureLookup_whenAddCardChallengeNotRequested_sendsAddCardFalse() {
+        let expectation = self.expectation(description: "willCallCompletion")
+
+        threeDSecureRequest.nonce = "fake-card-nonce"
+        threeDSecureRequest.amount = 9.97
+        threeDSecureRequest.dfReferenceID = "df-reference-id"
+
+        threeDSecureRequest.addCardChallengeRequested = .notRequested
+
+        driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
+            XCTAssertFalse(self.mockAPIClient.lastPOSTParameters!["addCard"] as! Bool)
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testPerformThreeDSecureLookup_whenAddCardChallengeUnspecified_doesNotSendAddCardParameter() {
+        let expectation = self.expectation(description: "willCallCompletion")
+
+        threeDSecureRequest.nonce = "fake-card-nonce"
+        threeDSecureRequest.amount = 9.97
+        threeDSecureRequest.dfReferenceID = "df-reference-id"
+
+        driver.performThreeDSecureLookup(threeDSecureRequest) { (lookup, error) in
+            XCTAssertNil(self.mockAPIClient.lastPOSTParameters!["addCard"] as? Bool)
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
 
     func testPerformThreeDSecureLookup_whenSuccessful_callsBackWithResult() {
         let responseBody =


### PR DESCRIPTION
### Summary of changes

- Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
- Create `BTThreeDSecureCardAddChallenge` enum to allow for true, false, or nil options for this param 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @kate-paypal 
- @sarahkoop 
