### PR TITLE
Remove "allow warnings" on pod lib lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,8 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Install CocoaPod dependencies
         run: pod install
-        # Allowing warnings until Xcode 13 CocoaPods vendored frameworks issue is resolved: https://github.com/CocoaPods/CocoaPods/issues/10731
       - name: Run pod lib lint 
-        run: pod lib lint --allow-warnings
+        run: pod lib lint
   carthage_xcode_beta:
     name: Carthage (Xcode 13-beta)
     runs-on: macOS-11


### PR DESCRIPTION
### Summary of changes

- We can remove the `--allow-warnings` tag on the `pod lib lint` command in our CI now that we fixed [this issue](https://github.com/braintree/braintree_ios/pull/719).

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
