### PR TITLE
Fix Flakey UI Tests

### DIFF
--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -44,7 +44,6 @@ class PayPal_Checkout_UITests: XCTestCase {
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
         let webviewElementsQuery = app.webViews.element.otherElements
-        
         self.waitForElementToAppear(webviewElementsQuery.links["Cancel Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -16,10 +16,8 @@ class PayPal_Checkout_UITests: XCTestCase {
         app.launchArguments.append("-TokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalCheckoutViewController")
         app.launch()
-        sleep(1)
-        self.waitForElementToBeHittable(app.buttons["PayPal Checkout"])
+        _ = app.buttons["PayPal Checkout"].waitForExistence(timeout: 2)
         app.buttons["PayPal Checkout"].tap()
-        sleep(2)
         
         // Tap "Continue" on alert
         app.tap()

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -26,7 +26,6 @@ class PayPal_Checkout_UITests: XCTestCase {
         if continueButton.waitForExistence(timeout: 2) {
             continueButton.tap()
         }
-        
         app.coordinate(withNormalizedOffset: CGVector.zero).tap()
         sleep(1)
     }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -20,15 +20,15 @@ class PayPal_Checkout_UITests: XCTestCase {
         self.waitForElementToBeHittable(app.buttons["PayPal Checkout"])
         app.buttons["PayPal Checkout"].tap()
         sleep(2)
-
+        
         // Tap "Continue" on alert
-        addUIInterruptionMonitor(withDescription: "Alert prompting user that the app wants to use PayPal.com to sign in.") { (alert) -> Bool in
-            let continueButton = alert.buttons["Continue"]
-            if (alert.buttons["Continue"].exists) {
-                continueButton.tap()
-            }
-            return true
+        app.tap()
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let continueButton = springboard.buttons["Continue"]
+        if continueButton.waitForExistence(timeout: 2) {
+            continueButton.tap()
         }
+        
         app.coordinate(withNormalizedOffset: CGVector.zero).tap()
         sleep(1)
     }
@@ -47,7 +47,7 @@ class PayPal_Checkout_UITests: XCTestCase {
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
         let webviewElementsQuery = app.webViews.element.otherElements
-
+        
         self.waitForElementToAppear(webviewElementsQuery.links["Cancel Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -27,7 +27,6 @@ class PayPal_Vault_UITests: XCTestCase {
         if continueButton.waitForExistence(timeout: 2) {
             continueButton.tap()
         }
-        
         app.coordinate(withNormalizedOffset: CGVector.zero).tap()
         sleep(1)
     }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -22,13 +22,13 @@ class PayPal_Vault_UITests: XCTestCase {
         sleep(2)
 
         // Tap "Continue" on alert
-        addUIInterruptionMonitor(withDescription: "Alert prompting user that the app wants to use PayPal.com to sign in.") { (alert) -> Bool in
-            let continueButton = alert.buttons["Continue"]
-            if (alert.buttons["Continue"].exists) {
-                continueButton.tap()
-            }
-            return true
+        app.tap()
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let continueButton = springboard.buttons["Continue"]
+        if continueButton.waitForExistence(timeout: 2) {
+            continueButton.tap()
         }
+        
         app.coordinate(withNormalizedOffset: CGVector.zero).tap()
         sleep(1)
     }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -16,11 +16,10 @@ class PayPal_Vault_UITests: XCTestCase {
         app.launchArguments.append("-TokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalVaultViewController")
         app.launch()
-        sleep(1)
-        self.waitForElementToBeHittable(app.buttons["PayPal Vault"])
+        
+        _ = app.buttons["PayPal Vault"].waitForExistence(timeout: 10)
         app.buttons["PayPal Vault"].tap()
-        sleep(2)
-
+        
         // Tap "Continue" on alert
         app.tap()
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V1_UITests.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V1_UITests.swift
@@ -17,7 +17,7 @@ class ThreeDSecure_V1_UITests: XCTestCase {
         app.launchArguments.append("-Integration:BraintreeDemoThreeDSecurePaymentFlowViewController")
         app.launch()
 
-        waitForElementToAppear(app.cardNumberTextField)
+        _ = app.cardNumberTextField.waitForExistence(timeout: 10)
     }
 
     func testThreeDSecurePaymentFlowV1_completesAuthentication_receivesNonce() {

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
@@ -13,7 +13,7 @@ class ThreeDSecure_V2_UITests: XCTestCase {
         app.launchArguments.append("-Integration:BraintreeDemoThreeDSecurePaymentFlowViewController")
         app.launch()
 
-        waitForElementToAppear(app.cardNumberTextField)
+        _ = app.cardNumberTextField.waitForExistence(timeout: 10)
     }
 
     func testThreeDSecurePaymentFlowV2_frictionlessFlow_andTransacts() {


### PR DESCRIPTION
### Summary of changes

- Use Apple built in `waitForExistence` method to speed up UI tests and fix flakiness when running locally
- Use Apple springboard to access built-in alert dialog button in PayPal UI tests to fix CI flakiness

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 
- @sarahkoop 
