### PR TITLE
Remove Xcode 12.5 GitHub Actions Jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,54 +2,6 @@ name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 12.5)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
-      - name: Install CocoaPod dependencies
-        run: pod install
-      - name: Run pod lib lint
-        run: pod lib lint
-  carthage:
-    name: Carthage (Xcode 12.5)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
-      - name: Remove SPMTest
-        run: |
-          git checkout $GITHUB_HEAD_REF
-          rm -rf SampleApps/SPMTest
-          git add SampleApps/SPMTest
-          git commit -m 'Remove SPMTest app to avoid Carthage timeout'
-      - name: Use current branch
-        run: echo 'git "file://'$PWD'" "'$GITHUB_HEAD_REF'"' > SampleApps/CarthageTest/Cartfile
-      - name: Run carthage update
-        run: cd SampleApps/CarthageTest && carthage update --use-xcframeworks
-      - name: Build CarthageTest
-        run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
-  spm:
-    name: SPM (Xcode 12.5)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
-  cocoapods_xcode_beta:
     name: CocoaPods (Xcode 13-beta)
     runs-on: macOS-11
     steps:
@@ -62,7 +14,7 @@ jobs:
         # Allowing warnings until Xcode 13 CocoaPods vendored frameworks issue is resolved: https://github.com/CocoaPods/CocoaPods/issues/10731
       - name: Run pod lib lint 
         run: pod lib lint --allow-warnings
-  carthage_xcode_beta:
+  carthage:
     name: Carthage (Xcode 13-beta)
     runs-on: macOS-11
     steps:
@@ -84,7 +36,7 @@ jobs:
         run: cd SampleApps/CarthageTest && carthage update --use-xcframeworks
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
-  spm_xcode_beta:
+  spm:
     name: SPM (Xcode 13-beta)
     runs-on: macOS-11
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run pod lib lint 
         run: pod lib lint --allow-warnings
   carthage:
-    name: Carthage (Xcode 13-beta)
+    name: Carthage
     runs-on: macOS-11
     steps:
       - name: Check out repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 13-beta)
+    name: CocoaPods
     runs-on: macOS-11
     steps:
       - name: Check out repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
-    name: SPM (Xcode 13-beta)
+    name: SPM
     runs-on: macOS-11
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+      - name: Use Xcode 13
+        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)


### PR DESCRIPTION
### Summary of changes

- Remove GitHub Actions jobs using Xcode 12.5 which will no longer be supported in v6.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 
- @sarahkoop 
