### PR TITLE
iOS v6 - Update Venmo Payment Context Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Braintree iOS SDK Release Notes
 
-## unreleased
+## unreleased (next-major-version)
 * Breaking Changes
   * Bump minimum supported deployment target to iOS 13+
   * Require Xcode 13
     * Bump Swift Tools Version to 5.5 for CocoaPods & SPM
+  * BraintreeVenmo
+    * Remove `.unspecified` case from `BTVenmoPaymentMethodUsage` enum
+    * Require `paymentMethodUsage` param in `BTVenmoRequest` initializer
 
 ## unreleased
 * Re-organize `/Frameworks` binaries into nested `/FatFrameworks` and `/XCFrameworks` directories.

--- a/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
+++ b/Demo/Application/Features/Preferred Payment Methods/BraintreeDemoPreferredPaymentMethodsViewController.swift
@@ -115,7 +115,8 @@ class BraintreeDemoPreferredPaymentMethodsViewController: BraintreeDemoBaseViewC
         button.setTitle("Processing...", for: .disabled)
         button.isEnabled = false
 
-        venmoDriver.tokenizeVenmoAccount(with: BTVenmoRequest()) { (nonce, error) in
+        let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (nonce, error) in
             button.isEnabled = true
             
             if let e = error {

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -27,7 +27,7 @@
 
 - (void)tappedCustomVenmo {
     self.progressBlock(@"Tapped Venmo - initiating Venmo auth");
-    BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] init];
+    BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] initWithPaymentMethodUsage: BTVenmoPaymentMethodUsageMultiUse];
     [self.venmoDriver tokenizeVenmoAccountWithVenmoRequest:venmoRequest completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
         if (venmoAccount) {
             self.progressBlock(@"Got a nonce 💎!");

--- a/Demo/MockVenmo/AppSwitcher.swift
+++ b/Demo/MockVenmo/AppSwitcher.swift
@@ -45,5 +45,4 @@ class AppSwitcher {
             .value
             .flatMap({ URL(string: $0) })
     }
-
 }

--- a/Demo/MockVenmo/AppSwitcher.swift
+++ b/Demo/MockVenmo/AppSwitcher.swift
@@ -45,4 +45,10 @@ class AppSwitcher {
             .value
             .flatMap({ URL(string: $0) })
     }
+
+    // TODO: We can update this MockVenmo returnURL to include the `resource_id` to more closely mimic the VenmoContext Flow.
+    // OPTION 1: We add another "SUCCESS-CONTEXT" type button which triggers the context flow,
+    // this way we can easily test both.
+    // OPTION 2: We just update the existing "SUCCESS" button URL.
+
 }

--- a/Demo/MockVenmo/AppSwitcher.swift
+++ b/Demo/MockVenmo/AppSwitcher.swift
@@ -46,9 +46,4 @@ class AppSwitcher {
             .flatMap({ URL(string: $0) })
     }
 
-    // TODO: We can update this MockVenmo returnURL to include the `resource_id` to more closely mimic the VenmoContext Flow.
-    // OPTION 1: We add another "SUCCESS-CONTEXT" type button which triggers the context flow,
-    // this way we can easily test both.
-    // OPTION 2: We just update the existing "SUCCESS" button URL.
-
 }

--- a/Sources/BraintreeVenmo/BTVenmoRequest.m
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.m
@@ -6,7 +6,12 @@
 
 @implementation BTVenmoRequest
 
-// NEXT_MAJOR_VERSION - make paymentMethodUsage a required param in the initializer & remove UNSPECIFIED case from enum
+- (instancetype)initWithPaymentMethodUsage:(BTVenmoPaymentMethodUsage)paymentMethodUsage {
+    if (self = [super init]) {
+        _paymentMethodUsage = paymentMethodUsage;
+    }
+    return self;
+}
 
 - (NSString *)paymentMethodUsageAsString {
     switch(self.paymentMethodUsage) {

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -6,18 +6,35 @@ NS_ASSUME_NONNULL_BEGIN
  Usage type for the tokenized Venmo account
  */
 typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
-    /// Unspecified
-    BTVenmoPaymentMethodUsageUnspecified = 0,
-    /// Multi-use
-    BTVenmoPaymentMethodUsageMultiUse = 1,
-    /// Single use
-    BTVenmoPaymentMethodUsageSingleUse = 2
+    /// The Venmo payment will be authorized for future payments and can be vaulted.
+    BTVenmoPaymentMethodUsageMultiUse = 0,
+    /// The Venmo payment will be authorized for a one-time payment and cannot be vaulted.
+    BTVenmoPaymentMethodUsageSingleUse
 };
 
 /**
  A BTVenmoRequest specifies options that contribute to the Venmo flow
 */
 @interface BTVenmoRequest : NSObject
+
+/**
+ Cannot be instantiated with [BTVenmoRequest new]
+ */
++ (instancetype)new __attribute__((unavailable("Please use initWithPaymentMethodUsage:")));
+
+/**
+ Base initializer - do not use.
+ */
+- (instancetype)init __attribute__((unavailable("Please use initWithPaymentMethodUsage:")));
+
+
+/**
+ Initialize a Venmo request with a payment method usage.
+
+ @param paymentMethodUsage `BTVenmoPaymentMethodUsage`
+ @return A Venmo request.
+*/
+- (instancetype)initWithPaymentMethodUsage:(BTVenmoPaymentMethodUsage)paymentMethodUsage;
 
 /**
  The Venmo profile ID to be used during payment authorization. Customers will see the business name and logo associated with this Venmo profile, and it may show up in the Venmo app as a "Connected Merchant". Venmo profile IDs can be found in the Braintree Control Panel. Leaving this `nil` will use the default Venmo profile.
@@ -36,11 +53,8 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 /**
  * If set to `.multiUse`, the Venmo payment will be authorized for future payments and can be vaulted.
  * If set to `.singleUse`, the Venmo payment will be authorized for a one-time payment and cannot be vaulted.
- * If set to `.unspecified`, the legacy Venmo UI flow will launch. It is recommended to use `.multiUse` or `.singleUse` for the best customer experience.
- *
- * Defaults to `.unspecified`.
  */
-@property (nonatomic) BTVenmoPaymentMethodUsage paymentMethodUsage;
+@property (nonatomic, readonly) BTVenmoPaymentMethodUsage paymentMethodUsage;
 
 /**
  * Optional. The business name that will be displayed in the Venmo app payment approval screen. Only used by merchants onboarded as PayFast channel partners.

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -4,19 +4,12 @@ import BraintreeVenmo
 class BTVenmoRequest_Tests: XCTestCase {
 
     func testPaymentMethodUsageAsString_whenPaymentMethodUsageIsMultiUse_returnsMultiUse() {
-        let request = BTVenmoRequest()
-        request.paymentMethodUsage = .multiUse
+        let request = BTVenmoRequest(paymentMethodUsage: .multiUse)
         XCTAssertEqual(request.paymentMethodUsageAsString, "MULTI_USE")
     }
 
     func testPaymentMethodUsageAsString_whenPaymentMethodUsageIsSingleUse_returnsSingleUse() {
-        let request = BTVenmoRequest()
-        request.paymentMethodUsage = .singleUse
+        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
         XCTAssertEqual(request.paymentMethodUsageAsString, "SINGLE_USE")
-    }
-
-    func testPaymentMethodUsageAsString_whenPaymentMethodUsageIsDefault_returnsNil() {
-        let request = BTVenmoRequest()
-        XCTAssertEqual(request.paymentMethodUsageAsString, nil)
     }
 }

--- a/V6_MIGRATION.md
+++ b/V6_MIGRATION.md
@@ -7,8 +7,30 @@ _Documentation for v6 will be published to https://developer.paypal.com/braintre
 ## Table of Contents
 
 1. [Supported Versions](#supported-versions)
+2. [Venmo](#venmo)
 
 ## Supported Versions
 
 v6 supports a minimum deployment target of iOS 13+. It requires the use of Xcode 13+. If your application contains Objective-C code, the `Enable Modules` build setting must be set to `YES`.
 
+## Venmo
+
+`BTVenmoRequest` must now be initialized with a `paymentMethodUsage`. 
+
+The possible values for `BTVenmoPaymentMethodUsage` include:
+* `.multiUse` - the Venmo payment will be authorized for future payments and can be vaulted.
+* `.singleUse` - the Venmo payment will be authorized for a one-time payment and cannot be vaulted.
+
+```
+let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
+venmoRequest.profileID = "my-profile-id"
+venmoRequest.vault = true
+
+venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { (venmoAccountNonce, error) -> Void in
+  if (error != nil) {
+    // handle error
+  }
+
+  // transact with nonce on server
+}
+```


### PR DESCRIPTION
### Summary

> NEXT_MAJOR_VERSION - make paymentMethodUsage a required param in the initializer & remove UNSPECIFIED case from enum

This PR addresses the above comment to achieve parity with Android v4.

### Changes

- Remove `BTVenmoPaymentMethodUsageUnspecified` case.
- Require merchant to initialize `BTVenmoRequest` with a `paymentMethodUsage` (single or multi use)
  - Always use the Venmo PaymentContext flow.
- Update UnitTests accordingly.

### Checklist

- [X] Added a CHANGELOG entry
- [X] Add MIGRATION guide entry

### Authors
@scannillo @sarahkoop 
