### PR TITLE
v4 - Add offerPayLater to BTPayPalRequest

### DIFF
--- a/BraintreePayPal/BTPayPalDriver.m
+++ b/BraintreePayPal/BTPayPalDriver.m
@@ -275,6 +275,7 @@ typedef NS_ENUM(NSUInteger, BTPayPalPaymentType) {
         }
 
         parameters[@"offer_paypal_credit"] = @(request.offerCredit);
+        parameters[@"offer_pay_later"] = @(request.offerPayLater);
 
         experienceProfile[@"no_shipping"] = @(!request.isShippingAddressRequired);
 
@@ -1014,6 +1015,12 @@ static NSString * const SFSafariViewControllerFinishedURL = @"sfsafariviewcontro
 
     if ((paymentType == BTPayPalPaymentTypeCheckout || paymentType == BTPayPalPaymentTypeBillingAgreement) && self.payPalRequest.offerCredit) {
         NSString *eventName = [NSString stringWithFormat:@"ios.%@.%@.credit.offered.%@", [self.class eventStringForPaymentType:paymentType], [self.class eventStringForRequestTarget:target], success ? @"started" : @"failed"];
+
+        [self.apiClient sendAnalyticsEvent:eventName];
+    }
+
+    if (paymentType == BTPayPalPaymentTypeCheckout && self.payPalRequest.offerPayLater) {
+        NSString *eventName = [NSString stringWithFormat:@"ios.%@.webswitch.paylater.offered.%@", [self.class eventStringForPaymentType:paymentType], success ? @"started" : @"failed"];
 
         [self.apiClient sendAnalyticsEvent:eventName];
     }

--- a/BraintreePayPal/BTPayPalRequest.m
+++ b/BraintreePayPal/BTPayPalRequest.m
@@ -8,6 +8,7 @@
     if (self) {
         _shippingAddressRequired = NO;
         _offerCredit = NO;
+        _offerPayLater = NO;
         _shippingAddressEditable = NO;
         _intent = BTPayPalRequestIntentAuthorize;
         _userAction = BTPayPalRequestUserActionDefault;

--- a/BraintreePayPal/Public/BTPayPalRequest.h
+++ b/BraintreePayPal/Public/BTPayPalRequest.h
@@ -172,6 +172,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestUserAction) {
 @property (nonatomic) BOOL offerCredit;
 
 /**
+ Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
+ */
+@property (nonatomic) BOOL offerPayLater;
+
+/**
  Optional: A non-default merchant account to use for tokenization.
 */
 @property (nonatomic, nullable, copy) NSString *merchantAccountId;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Add `offerPayLater` to `BTPayPalRequest`
+
 ## 4.37.1 (2021-04-06)
 * Update PPRiskMagnesOC to 4.0.12 (resolves potential duplicate symbols errors)
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,38 +1,38 @@
 PODS:
-  - Braintree/3D-Secure (4.37.0):
+  - Braintree/3D-Secure (4.37.1):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/AmericanExpress (4.37.0):
+  - Braintree/AmericanExpress (4.37.1):
     - Braintree/Core
-  - Braintree/Apple-Pay (4.37.0):
+  - Braintree/Apple-Pay (4.37.1):
     - Braintree/Core
-  - Braintree/Card (4.37.0):
+  - Braintree/Card (4.37.1):
     - Braintree/Core
-  - Braintree/Core (4.37.0)
-  - Braintree/DataCollector (4.37.0):
+  - Braintree/Core (4.37.1)
+  - Braintree/DataCollector (4.37.1):
     - Braintree/Core
-  - Braintree/PaymentFlow (4.37.0):
+  - Braintree/PaymentFlow (4.37.1):
     - Braintree/Card
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPal (4.37.0):
+  - Braintree/PayPal (4.37.1):
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.37.0):
+  - Braintree/PayPalDataCollector (4.37.1):
     - Braintree/Core
     - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.37.0):
+  - Braintree/PayPalOneTouch (4.37.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
     - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.37.0)
-  - Braintree/UI (4.37.0):
+  - Braintree/PayPalUtils (4.37.1)
+  - Braintree/UI (4.37.1):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/UnionPay (4.37.0):
+  - Braintree/UnionPay (4.37.1):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Venmo (4.37.0):
+  - Braintree/Venmo (4.37.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
   - BraintreeDropIn (99.99.99-github-master):
@@ -109,7 +109,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/braintree/braintree-ios-drop-in.git
 
 SPEC CHECKSUMS:
-  Braintree: e1f291d24a909bfbed88e86a0c3db76f26af9697
+  Braintree: 94a20907b70aeffb29c40380eec583d783a347b6
   BraintreeDropIn: fde15b17f6520e8be5dd9797f7cc87772509f345
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: f1ed0e0642ee5dc6af025450f4b44ecd0c15193e


### PR DESCRIPTION
### Summary of changes

- Add `offerPayLater` to `BTPayPalRequest` to v4 for an LE merchant
- Mimics (https://github.com/braintree/braintree_ios/pull/590) which added it to v5

### Checklist

- [ ] Added a changelog entry

### Authors
@scannillo
