### PR TITLE
Remove deprecated PayPal checkout methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * BraintreeVenmo
     * Remove `.unspecified` case from `BTVenmoPaymentMethodUsage` enum
     * Require `paymentMethodUsage` param in `BTVenmoRequest` initializer
+  * BraintreePayPal
+    * Remove `BTPayPalDriver.requestOneTimePayment` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`
+    * Remove `BTPayPalDriver.requestBillingAgreement` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`
 
 ## unreleased
 * Re-organize `/Frameworks` binaries into nested `/FatFrameworks` and `/XCFrameworks` directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
     * Remove `.unspecified` case from `BTVenmoPaymentMethodUsage` enum
     * Require `paymentMethodUsage` param in `BTVenmoRequest` initializer
   * BraintreePayPal
-    * Remove `BTPayPalDriver.requestOneTimePayment` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`
-    * Remove `BTPayPalDriver.requestBillingAgreement` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`
+    * Remove `BTPayPalDriver.requestOneTimePayment` in favor of `BTPayPalDriver.tokenizePayPalAccount`
+    * Remove `BTPayPalDriver.requestBillingAgreement` in favor of `BTPayPalDriver.tokenizePayPalAccount`
 
 ## unreleased
 * Re-organize `/Frameworks` binaries into nested `/FatFrameworks` and `/XCFrameworks` directories.

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -107,21 +107,7 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
     [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
-#pragma mark - Billing Agreement (Vault)
-
-- (void)requestBillingAgreement:(BTPayPalVaultRequest *)request
-                     completion:(void (^)(BTPayPalAccountNonce *tokenizedCheckout, NSError *error))completionBlock {
-    [self tokenizePayPalAccountWithPayPalRequest:request completion:completionBlock];
-}
-
-#pragma mark - One-Time Payment (Checkout)
-
-- (void)requestOneTimePayment:(BTPayPalCheckoutRequest *)request
-                   completion:(void (^)(BTPayPalAccountNonce *tokenizedCheckout, NSError *error))completionBlock {
-    [self tokenizePayPalAccountWithPayPalRequest:request completion:completionBlock];
-}
-
-#pragma mark - Helpers
+#pragma mark - Tokenize PayPal Account
 
 - (void)tokenizePayPalAccountWithPayPalRequest:(BTPayPalRequest *)request completion:(void (^)(BTPayPalAccountNonce *, NSError *))completionBlock {
     if (!self.apiClient) {
@@ -200,6 +186,8 @@ NSString * _Nonnull const PayPalEnvironmentMock = @"mock";
         }];
     }];
 }
+
+#pragma mark - Helpers
 
 - (NSDictionary *)dictionaryFromResponseURL:(NSURL *)url {
     if ([[self.class actionFromURLAction: url] isEqualToString:@"cancel"]) {

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalDriver.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalDriver.h
@@ -56,34 +56,6 @@ typedef NS_ENUM(NSInteger, BTPayPalDriverErrorType) {
 - (instancetype)init __attribute__((unavailable("Please use initWithAPIClient:")));
 
 /**
- Check out with PayPal to create a single-use PayPal payment method nonce.
-
- @note You can use this as the final step in your order/checkout flow. If you want, you may create a transaction from your
- server when this method completes without any additional user interaction.
-
- On success, you will receive an instance of `BTPayPalAccountNonce`; on failure or user cancelation you will receive an error. If the user cancels out of the flow, the error code will be `BTPayPalDriverErrorTypeCanceled`.
-
- @param request A PayPal Checkout request
- @param completionBlock This completion will be invoked exactly once when checkout is complete or an error occurs.
- */
-- (void)requestOneTimePayment:(BTPayPalCheckoutRequest *)request
-                   completion:(void (^)(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error))completionBlock DEPRECATED_MSG_ATTRIBUTE("Use tokenizePayPalAccount instead.");
-
-/**
- Create a PayPal Billing Agreement for repeat purchases.
-
- @note You can use this as the final step in your order/checkout flow. If you want, you may create a transaction from your
- server when this method completes without any additional user interaction.
- 
- On success, you will receive an instance of `BTPayPalAccountNonce`; on failure or user cancelation you will receive an error. If the user cancels out of the flow, the error code will be `BTPayPalDriverErrorTypeCanceled`.
-
- @param request A PayPal Vault request
- @param completionBlock This completion will be invoked exactly once when checkout is complete or an error occurs.
-*/
-- (void)requestBillingAgreement:(BTPayPalVaultRequest *)request
-                     completion:(void (^)(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error))completionBlock DEPRECATED_MSG_ATTRIBUTE("Use tokenizePayPalAccount instead.");
-
-/**
  Tokenize a PayPal account for vault or checkout.
 
  @note You can use this as the final step in your order/checkout flow. If you want, you may create a transaction from your

--- a/UnitTests/BraintreePayPalTests/BTPayPalDriver_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalDriver_Tests.swift
@@ -97,11 +97,11 @@ class BTPayPalDriver_Tests: XCTestCase {
 
     // MARK: - POST request to Hermes endpoint
 
-    func testRequestOneTimePayment_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
-        let request = BTPayPalCheckoutRequest(amount: "1")
-        request.intent = .sale
+    func testTokenizePayPalAccount_checkout_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
+        let checkoutRequest = BTPayPalCheckoutRequest(amount: "1")
+        checkoutRequest.intent = .sale
 
-        payPalDriver.requestOneTimePayment(request) { _,_  -> Void in }
+        payPalDriver.tokenizePayPalAccount(with: checkoutRequest) { (_, _) -> Void in }
 
         XCTAssertEqual("v1/paypal_hermes/create_payment_resource", mockAPIClient.lastPOSTPath)
         guard let lastPostParameters = mockAPIClient.lastPOSTParameters else { XCTFail(); return }
@@ -112,11 +112,11 @@ class BTPayPalDriver_Tests: XCTestCase {
         XCTAssertEqual(lastPostParameters["cancel_url"] as? String, "sdk.ios.braintree://onetouch/v1/cancel")
     }
 
-    func testRequestBillingAgreement_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
-        let request = BTPayPalVaultRequest()
-        request.billingAgreementDescription = "description"
-
-        payPalDriver.requestBillingAgreement(request) { _,_  -> Void in }
+    func testTokenizePayPalAccount_vault_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
+        let vaultRequest = BTPayPalVaultRequest()
+        vaultRequest.billingAgreementDescription = "description"
+        
+        payPalDriver.tokenizePayPalAccount(with: vaultRequest) { (_, _) -> Void in }
 
         XCTAssertEqual("v1/paypal_hermes/setup_billing_agreement", mockAPIClient.lastPOSTPath)
         guard let lastPostParameters = mockAPIClient.lastPOSTParameters else { XCTFail(); return }


### PR DESCRIPTION
### Summary of changes

* Remove `BTPayPalDriver.requestOneTimePayment` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`
* Remove `BTPayPalDriver.requestBillingAgreement` in favor of `tokenizePayPalAccount` on `BTPayPalDriver`

I didn't think this is worthy of a MIGRATION guide update since the methods were already deprecated and the new methods are documented how to use in the V5_MIGRATION guide.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo & Katy Perry
