### PR TITLE
Remove Xcode 13 Warnings

### DIFF
--- a/Demo/Application/Base/BraintreeDemoAppDelegate.m
+++ b/Demo/Application/Base/BraintreeDemoAppDelegate.m
@@ -44,7 +44,8 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.De
     UIColor *pleasantGray = [UIColor colorWithWhite:42/255.0f alpha:1.0f];
 
     [[UIToolbar appearance] setBarTintColor:pleasantGray];
-    [[UIToolbar appearance] setBarStyle:UIBarStyleBlackTranslucent];
+    [[UIToolbar appearance] setBarStyle:UIBarStyleBlack];
+    [[UIToolbar appearance] setTranslucent:YES];
 }
 
 - (void)registerDefaultsFromSettings {

--- a/Demo/Application/Base/BraintreeDemoContainmentViewController.m
+++ b/Demo/Application/Base/BraintreeDemoContainmentViewController.m
@@ -79,13 +79,11 @@
     if (self.latestTokenizedPayment) {
         NSString *nonce = self.latestTokenizedPayment.nonce;
         [self updateStatus:@"Creating Transaction…"];
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
         NSString *merchantAccountID = ([self.latestTokenizedPayment.type isEqualToString:@"UnionPay"]) ? @"fake_switch_usd" : nil;
         
         [BraintreeDemoMerchantAPIClient.shared makeTransactionWithPaymentMethodNonce:nonce
                                                                    merchantAccountID:merchantAccountID
                                                                           completion:^(NSString *transactionID, NSError *error) {
-            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
             self.latestTokenizedPayment = nil;
             if (error) {
                 [self updateStatus:error.localizedDescription];
@@ -150,10 +148,7 @@
         case BraintreeDemoAuthTypePayPalIDToken: {
             [self updateStatus:@"Fetching PayPal ID Token…"];
 
-            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
-
             [BraintreeDemoMerchantAPIClient.shared fetchPayPalIDTokenWithCompletion:^(NSString * _Nullable idToken, NSError * _Nullable err) {
-                [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
                 if (err) {
                     [self updateStatus:err.localizedDescription];
                 } else {
@@ -167,10 +162,7 @@
         case BraintreeDemoAuthTypeClientToken: {
             [self updateStatus:@"Fetching Client Token…"];
 
-            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
-
             [BraintreeDemoMerchantAPIClient.shared createCustomerAndFetchClientTokenWithCompletion:^(NSString *clientToken, NSError *error) {
-                [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
                 if (error) {
                     [self updateStatus:error.localizedDescription];
                 } else {

--- a/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
@@ -5,7 +5,7 @@
 @import Expecta;
 @import OHHTTPStubs;
 
-NSURL *validDataURL() {
+NSURL *validDataURL(void) {
     NSDictionary *validObject = @{@"clientId":@"a-client-id", @"nest": @{@"nested":@"nested-value"}};
     NSError *jsonSerializationError;
     NSData *configurationData = [NSJSONSerialization dataWithJSONObject:validObject
@@ -16,7 +16,7 @@ NSURL *validDataURL() {
     return [NSURL URLWithString:dataURLString];
 }
 
-NSDictionary *parameterDictionary() {
+NSDictionary *parameterDictionary(void) {
     return @{@"stringParameter": @"value",
              @"crazyStringParameter[]": @"crazy%20and&value",
              @"numericParameter": @42,
@@ -40,7 +40,7 @@ void withStub(void (^block)(void (^removeStub)(void))) {
     });
 }
 
-NSURLSession *testURLSession() {
+NSURLSession *testURLSession(void) {
     NSURLSessionConfiguration *testConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
     [testConfiguration setProtocolClasses:@[[BTHTTPTestProtocol class]]];
     return [NSURLSession sessionWithConfiguration:testConfiguration];


### PR DESCRIPTION
### Summary of changes

- Update deprecated `UIBarStyleBlackTranslucent`
- Remove deprecated network activity indicator methods
  - See [Apple doc](https://developer.apple.com/design/human-interface-guidelines/ios/controls/progress-indicators/)
  - "The network activity indicator is deprecated in iOS 13 and on devices with edge-to-edge displays."
- Silence function signature warning for old HTTPSpec tests

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo