### PR TITLE
Streamline SPM imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * Provides fix for this [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/10731) & allows proper usage of `PPRiskMagnes.xcframework` by `PayPalDataCollector` subspec.
 * Swift Package Manager
   * Update Package.swift to include `PPRiskMagnes` as explicit target for library products that require `PayPalDataCollector`
-  * _Note:_ This simplifies integrations by no longer requiring manual inclusion of `PayPalDataCollector` to use `BraintreeThreeDSecure`, `BraintreePayPal`, and `BraintreePaymentFlow`
+  * _Note:_ This simplifies integrations by no longer requiring manual inclusion of `PayPalDataCollector` in order to use `BraintreeThreeDSecure`, `BraintreePayPal`, and `BraintreePaymentFlow`
   
 ## 4.38.0 (2021-08-24)
 * Add `offerPayLater` to `BTPayPalRequest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased
 * Re-organize `/Frameworks` binaries into nested `/FatFrameworks` and `/XCFrameworks` directories.
   * Provides fix for this [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/10731) & allows proper usage of `PPRiskMagnes.xcframework` by `PayPalDataCollector` subspec.
+* Swift Package Manager
+  * Update Package.swift to include `PPRiskMagnes` as explicit target for library products that require `PayPalDataCollector`
+  * _Note:_ This simplifies integrations by no longer requiring manual inclusion of `PayPalDataCollector` to use `BraintreeThreeDSecure`, `BraintreePayPal`, and `BraintreePaymentFlow`
   
 ## 4.38.0 (2021-08-24)
 * Add `offerPayLater` to `BTPayPalRequest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * Provides fix for this [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/10731) & allows proper usage of `PPRiskMagnes.xcframework` by `PayPalDataCollector` subspec.
 * Swift Package Manager
   * Update Package.swift to include `PPRiskMagnes` as explicit target for library products that require `PayPalDataCollector`
-  * _Note:_ This simplifies integrations by no longer requiring manual inclusion of `PayPalDataCollector` in order to use `BraintreeThreeDSecure`, `BraintreePayPal`, and `BraintreePaymentFlow`
+  * _Note:_ No longer requires manual inclusion of `PayPalDataCollector` in order to use `BraintreeThreeDSecure`, `BraintreePayPal`, and `BraintreePaymentFlow`
   
 ## 4.38.0 (2021-08-24)
 * Add `offerPayLater` to `BTPayPalRequest`

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         ),
         .library(
             name: "BraintreePayPal",
-            targets: ["BraintreePayPal"]
+            targets: ["BraintreePayPal", "PayPalDataCollector"]
         ),
         .library(
             name: "BraintreeThreeDSecure",

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
         .library(
             name: "BraintreePaymentFlow",
-            targets: ["BraintreePaymentFlow"]
+            targets: ["BraintreePaymentFlow", "PPRiskMagnes"]
         ),
         .library(
             name: "BraintreePayPal",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .library(
             name: "BraintreeThreeDSecure",
-            targets: ["BraintreeThreeDSecure", "CardinalMobile"]
+            targets: ["BraintreeThreeDSecure", "CardinalMobile", "PPRiskMagnes"]
         ),
         .library(
             name: "BraintreeUnionPay",

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         ),
         .library(
             name: "BraintreePayPal",
-            targets: ["BraintreePayPal", "PayPalDataCollector"]
+            targets: ["BraintreePayPal", "PPRiskMagnes"]
         ),
         .library(
             name: "BraintreeThreeDSecure",


### PR DESCRIPTION
### Summary

These changes will help streamline our docs, as well as simplify things for merchants.

Before:
- 3DS via SPM: Include the `BraintreeThreeDSecure` and `PayPalDataCollector` frameworks
- PayPal via SPM: Include the `BraintreePayPal` and `PayPalDataCollector` frameworks
- Local Payments via SPM:  Include the `BraintreePaymentFlow` and `PayPalDataCollector` frameworks

After:
- 3DS via SPM: Include the `BraintreeThreeDSecure` framework
- PayPal via SPM: Include the `BraintreePayPal` framework
- Local Payments via SPM:  Include the `BraintreePaymentFlow` framework

### Changes

- Add `PPRiskMagnes` binary as target to SPM libraries which require PayPalDataCollector.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo
