### PR TITLE
PwPP: Add correlation id to BTPayPalRequest

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalRequest.m
+++ b/Sources/BraintreePayPal/BTPayPalRequest.m
@@ -53,6 +53,10 @@ NSString *const BTPayPalCallbackURLScheme = @"sdk.ios.braintree";
         parameters[@"merchant_account_id"] = self.merchantAccountID;
     }
 
+    if (self.correlationId) {
+        parameters[@"correlation_id"] = self.correlationId;
+    }
+
     if (self.shippingAddressOverride) {
         experienceProfile[@"address_override"] = @(!self.isShippingAddressEditable);
     } else {

--- a/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
+++ b/Sources/BraintreePayPal/Public/BraintreePayPal/BTPayPalRequest.h
@@ -112,6 +112,11 @@ typedef NS_ENUM(NSInteger, BTPayPalRequestLandingPageType) {
  */
 @property (nonatomic, nullable, strong) UIWindow *activeWindow;
 
+/**
+ Optional: A correlation ID created with Set Transaction Context on your server.
+*/
+@property (nonatomic, nullable, copy) NSString *correlationId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -44,6 +44,7 @@ class BTPayPalRequest_Tests: XCTestCase {
         request.displayName = "Display Name"
         request.landingPageType = .login
         request.localeCode = "locale-code"
+        request.correlationId = "123-correlation-id"
         request.merchantAccountID = "merchant-account-id"
         request.isShippingAddressEditable = true
 
@@ -57,6 +58,7 @@ class BTPayPalRequest_Tests: XCTestCase {
         XCTAssertEqual(experienceProfile["landing_page_type"] as? String, "login")
         XCTAssertEqual(experienceProfile["locale_code"] as? String, "locale-code")
         XCTAssertEqual(parameters["merchant_account_id"] as? String, "merchant-account-id")
+        XCTAssertEqual(parameters["correlation_id"] as? String, "123-correlation-id")
         XCTAssertEqual(experienceProfile["address_override"] as? Bool, false)
         XCTAssertEqual(parameters["line_items"] as? [[String : String]], [["quantity" : "1",
                                                                                    "unit_amount": "1",


### PR DESCRIPTION
### Summary of changes

- Add `correlation_id` to BTPayPalRequest.

Allows for the linking of STC and RDA _before_ the PwPP flow starts.

### Checklist

- [ ] Added a changelog entry

### Authors
- @demerino 
