### PR TITLE
Fix Flakey UI Tests

### DIFF
--- a/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
+++ b/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
@@ -29,6 +29,6 @@ class AmericanExpress_UITests: XCTestCase {
     func testIneligibleCard_receivesErrorMessage() {
         app.buttons["Ineligible card"].tap()
 
-        XCTAssertTrue(app.buttons["INQ2002: Card is not eligible for the Program"].waitForExistence(timeout: 10));
+        XCTAssertTrue(app.buttons["INQ2002: Card is not eligible for the Program"].waitForExistence(timeout: 10))
     }
 }

--- a/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
+++ b/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
@@ -12,24 +12,23 @@ class AmericanExpress_UITests: XCTestCase {
         app.launchArguments.append("-ClientToken")
         app.launchArguments.append("-Integration:BraintreeDemoAmexViewController")
         app.launch()
-
-        waitForElementToAppear(app.buttons["Valid card"])
     }
 
     func testValidCard_receivesRewardsBalance() {
         app.buttons["Valid card"].tap()
-        waitForElementToAppear(app.buttons["45256433 Points, 316795.03 USD"], timeout: 10)
+        XCTAssertTrue(app.buttons["45256433 Points, 316795.03 USD"].waitForExistence(timeout: 10));
     }
 
     func testInsufficientPointsCard_receivesErrorMessage() {
         app.buttons["Insufficient points card"].tap()
         sleep(2)
 
-        waitForElementToAppear(app.buttons["INQ2003: Not sufficient points in rewards account"], timeout: 10)
+        XCTAssertTrue(app.buttons["INQ2003: Not sufficient points in rewards account"].waitForExistence(timeout: 10));
     }
 
     func testIneligibleCard_receivesErrorMessage() {
         app.buttons["Ineligible card"].tap()
-        waitForElementToAppear(app.buttons["INQ2002: Card is not eligible for the Program"], timeout: 10)
+
+        XCTAssertTrue(app.buttons["INQ2002: Card is not eligible for the Program"].waitForExistence(timeout: 10));
     }
 }

--- a/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
+++ b/Demo/UI Tests/American Express UI Tests/AmericanExpress_UITests.swift
@@ -16,14 +16,14 @@ class AmericanExpress_UITests: XCTestCase {
 
     func testValidCard_receivesRewardsBalance() {
         app.buttons["Valid card"].tap()
-        XCTAssertTrue(app.buttons["45256433 Points, 316795.03 USD"].waitForExistence(timeout: 10));
+        XCTAssertTrue(app.buttons["45256433 Points, 316795.03 USD"].waitForExistence(timeout: 10))
     }
 
     func testInsufficientPointsCard_receivesErrorMessage() {
         app.buttons["Insufficient points card"].tap()
         sleep(2)
 
-        XCTAssertTrue(app.buttons["INQ2003: Not sufficient points in rewards account"].waitForExistence(timeout: 10));
+        XCTAssertTrue(app.buttons["INQ2003: Not sufficient points in rewards account"].waitForExistence(timeout: 10))
     }
 
     func testIneligibleCard_receivesErrorMessage() {

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -37,7 +37,7 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 
-        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
+        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2))
     }
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
@@ -46,7 +46,7 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2))
     }
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
@@ -54,6 +54,6 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         app.buttons["Cancel"].forceTapElement()
 
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2))
     }
 }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -37,9 +37,7 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Got a nonce. Tap to make a transaction."])
-
-        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].exists);
+        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
     }
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
@@ -48,9 +46,7 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal Checkout"])
-
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
     }
 
     func testPayPal_checkout_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
@@ -58,8 +54,6 @@ class PayPal_Checkout_UITests: XCTestCase {
 
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal Checkout"])
-
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
     }
 }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -6,28 +6,28 @@
 import XCTest
 
 class PayPal_Checkout_UITests: XCTestCase {
-    var app: XCUIApplication!
+
+    var app = XCUIApplication()
+    var springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
         app.launchArguments.append("-TokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalCheckoutViewController")
         app.launch()
-        _ = app.buttons["PayPal Checkout"].waitForExistence(timeout: 2)
+
         app.buttons["PayPal Checkout"].tap()
         
         // Tap "Continue" on alert
-        app.tap()
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let continueButton = springboard.buttons["Continue"]
-        if continueButton.waitForExistence(timeout: 2) {
-            continueButton.tap()
-        }
-        app.coordinate(withNormalizedOffset: CGVector.zero).tap()
-        sleep(1)
+        springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        waitForAuthDialogAndTapButton(named: "Continue")
+    }
+
+    private func waitForAuthDialogAndTapButton(named buttonName: String) {
+        _ = springboard.buttons[buttonName].waitForExistence(timeout: 20.0)
+        springboard.buttons[buttonName].tap()
     }
 
     func testPayPal_checkout_receivesNonce() {

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -37,7 +37,7 @@ class PayPal_Vault_UITests: XCTestCase {
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 
-        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
+        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2))
     }
 
     func testPayPal_vault_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
@@ -53,6 +53,6 @@ class PayPal_Vault_UITests: XCTestCase {
     func testPayPal_vault_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
         app.buttons["Cancel"].forceTapElement()
 
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2))
     }
 }

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -6,29 +6,28 @@
 import XCTest
 
 class PayPal_Vault_UITests: XCTestCase {
-    var app: XCUIApplication!
+    
+    var app = XCUIApplication()
+    var springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
         app.launchArguments.append("-TokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalVaultViewController")
         app.launch()
         
-        _ = app.buttons["PayPal Vault"].waitForExistence(timeout: 10)
         app.buttons["PayPal Vault"].tap()
         
         // Tap "Continue" on alert
-        app.tap()
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let continueButton = springboard.buttons["Continue"]
-        if continueButton.waitForExistence(timeout: 2) {
-            continueButton.tap()
-        }
-        app.coordinate(withNormalizedOffset: CGVector.zero).tap()
-        sleep(1)
+        springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        waitForAuthDialogAndTapButton(named: "Continue")
+    }
+
+    private func waitForAuthDialogAndTapButton(named buttonName: String) {
+        _ = springboard.buttons[buttonName].waitForExistence(timeout: 20.0)
+        springboard.buttons[buttonName].tap()
     }
 
     func testPayPal_vault_receivesNonce() {

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -37,9 +37,7 @@ class PayPal_Vault_UITests: XCTestCase {
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Got a nonce. Tap to make a transaction."])
-
-        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].exists);
+        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
     }
 
     func testPayPal_vault_cancelsSuccessfully_whenTappingCancelButtonOnPayPalSite() {
@@ -49,18 +47,12 @@ class PayPal_Vault_UITests: XCTestCase {
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal Vault"])
-
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists)
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2))
     }
 
     func testPayPal_vault_cancelsSuccessfully_whenTappingAuthenticationSessionCancelButton() {
-        self.waitForElementToAppear(app.buttons["Cancel"])
-
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["PayPal Vault"])
-
-        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].exists);
+        XCTAssertTrue(app.buttons["PayPal flow was canceled by the user."].waitForExistence(timeout: 2));
     }
 }

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -18,39 +18,24 @@ class Venmo_UITests: XCTestCase {
         demoApp.launchArguments.append("-Integration:BraintreeDemoCustomVenmoButtonViewController")
         demoApp.launch()
 
-        waitForElementToAppear(demoApp.buttons["Venmo (custom button)"])
+        demoApp.buttons["Venmo (custom button)"].tap()
     }
 
     func testTokenizeVenmo_whenSignInSuccessful_returnsNonce() {
-        demoApp.buttons["Venmo (custom button)"].tap()
-
-        waitForElementToAppear(mockVenmo.buttons["SUCCESS"])
         mockVenmo.buttons["SUCCESS"].tap()
 
-        waitForElementToAppear(demoApp.buttons["Got a nonce. Tap to make a transaction."])
-        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].exists);
+        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
     }
 
     func testTokenizeVenmo_whenErrorOccurs_returnsError() {
-        demoApp.buttons["Venmo (custom button)"].tap()
-
-        waitForElementToAppear(mockVenmo.buttons["ERROR"])
         mockVenmo.buttons["ERROR"].tap()
 
-        // Add check for Settings button to debug error message not being found in CI
-        waitForElementToAppear(demoApp.buttons["Settings"])
-
-        waitForElementToAppear(demoApp.buttons["An error occurred during the Venmo flow"])
-        XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].exists);
+        XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].waitForExistence(timeout: 2))
     }
 
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
-        demoApp.buttons["Venmo (custom button)"].tap()
-
-        waitForElementToAppear(mockVenmo.buttons["Cancel"])
         mockVenmo.buttons["Cancel"].tap()
 
-        waitForElementToAppear(demoApp.buttons["Canceled 🔰"])
         XCTAssertTrue(demoApp.buttons["Canceled 🔰"].exists);
     }
 }

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -24,7 +24,7 @@ class Venmo_UITests: XCTestCase {
     func testTokenizeVenmo_whenSignInSuccessful_returnsNonce() {
         mockVenmo.buttons["SUCCESS"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2));
+        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2))
     }
 
     func testTokenizeVenmo_whenErrorOccurs_returnsError() {
@@ -36,6 +36,6 @@ class Venmo_UITests: XCTestCase {
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
         mockVenmo.buttons["Cancel"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].exists);
+        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].exists)
     }
 }


### PR DESCRIPTION
### Summary of changes

- Updates logic to click on the "Continue" button required for the alert that shows (by Apple) before the PayPal flow.
- Remove use of internal helper method `waitForElementToAppear` when not needed, and rely solely on Apple's UI test tools when appropriate.
    - Note: There are a handful of other UI test files (3DS) that might benefit from these updates as well. However that work constituted a larger refactor, that I am going to throw a JIRA ticket in for.
    - For now, this PR _should_ get our CI UITests more stable.

### Authors
@scannillo @sshropshire 
