### PR TITLE
Add Mac Processor Type to Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ about: Create a report to help us improve
  - Xcode Version: [e.g. Xcode 12.5]
  - Device: [e.g. iPhone 12]
  - Integration type & version: [e.g. CocoaPods 1.1.1, Carthage 0.18.1, Swift Package Manager 5.2.0]
+ - Development Processor Type: [e.g. Intel, M1/ Apple Silicon]
 
 **Describe the bug**
 Description of what the bug is. Please include as many details as possible.


### PR DESCRIPTION
### Summary of changes

- Lately, we have to follow up most iOS inquiries asking which mac type they're using for development (Intel or M1). This PR adds that criteria to the GH Issue template.

### Authors
@scannillo 
