### PR TITLE
Fix Flakey Venmo UI Tests

### DIFF
--- a/Demo/UI Tests/Helpers/BTUITest.swift
+++ b/Demo/UI Tests/Helpers/BTUITest.swift
@@ -1,42 +1,20 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
+    func waitForElementToAppear(_ element: XCUIElement, timeout: TimeInterval = 10) {
         let existsPredicate = NSPredicate(format: "exists == true")
         
-        expectation(for: existsPredicate,
-                                evaluatedWith: element, handler: nil)
+        expectation(for: existsPredicate, evaluatedWith: element)
         
-        waitForExpectations(timeout: timeout) { (error) -> Void in
-            if (error != nil) {
-                let message = "Failed to find \(element) after \(timeout) seconds."
-                self.record(XCTIssue(type: .assertionFailure,
-                                     compactDescription: message,
-                                     detailedDescription: nil,
-                                     sourceCodeContext: XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))),
-                                     associatedError: error,
-                                     attachments: []))
-            }
-        }
+        waitForExpectations(timeout: timeout)
     }
     
-    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 10,  file: String = #file, line: UInt = #line) {
+    func waitForElementToBeHittable(_ element: XCUIElement, timeout: TimeInterval = 10) {
         let existsPredicate = NSPredicate(format: "exists == true && hittable == true")
         
-        expectation(for: existsPredicate,
-                                evaluatedWith: element, handler: nil)
+        expectation(for: existsPredicate, evaluatedWith: element)
         
-        waitForExpectations(timeout: timeout) { (error) -> Void in
-            if (error != nil) {
-                let message = "Failed to find \(element) after \(timeout) seconds."
-                self.record(XCTIssue(type: .assertionFailure,
-                                     compactDescription: message,
-                                     detailedDescription: nil,
-                                     sourceCodeContext: XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))),
-                                     associatedError: error,
-                                     attachments: []))
-            }
-        }
+        waitForExpectations(timeout: timeout)
     }
 }
 

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -23,18 +23,21 @@ class Venmo_UITests: XCTestCase {
     }
 
     func testTokenizeVenmo_whenSignInSuccessful_returnsNonce() {
+        waitForElementToBeHittable(mockVenmo.buttons["SUCCESS"])
         mockVenmo.buttons["SUCCESS"].tap()
 
         XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 5))
     }
 
     func testTokenizeVenmo_whenErrorOccurs_returnsError() {
+        waitForElementToBeHittable(mockVenmo.buttons["ERROR"])
         mockVenmo.buttons["ERROR"].tap()
 
         XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].waitForExistence(timeout: 5))
     }
 
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
+        waitForElementToBeHittable(mockVenmo.buttons["Cancel"])
         mockVenmo.buttons["Cancel"].tap()
 
         XCTAssertTrue(demoApp.buttons["Canceled 🔰"].waitForExistence(timeout: 5))

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -18,24 +18,25 @@ class Venmo_UITests: XCTestCase {
         demoApp.launchArguments.append("-Integration:BraintreeDemoCustomVenmoButtonViewController")
         demoApp.launch()
 
+        waitForElementToBeHittable(demoApp.buttons["Venmo (custom button)"])
         demoApp.buttons["Venmo (custom button)"].tap()
     }
 
     func testTokenizeVenmo_whenSignInSuccessful_returnsNonce() {
         mockVenmo.buttons["SUCCESS"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 2))
+        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 5))
     }
 
     func testTokenizeVenmo_whenErrorOccurs_returnsError() {
         mockVenmo.buttons["ERROR"].tap()
 
-        XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].waitForExistence(timeout: 2))
+        XCTAssertTrue(demoApp.buttons["An error occurred during the Venmo flow"].waitForExistence(timeout: 5))
     }
 
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
         mockVenmo.buttons["Cancel"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].waitForExistence(timeout: 2))
+        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].waitForExistence(timeout: 5))
     }
 }

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -36,6 +36,6 @@ class Venmo_UITests: XCTestCase {
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
         mockVenmo.buttons["Cancel"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].exists)
+        XCTAssertTrue(demoApp.buttons["Canceled 🔰"].waitForExistence(timeout: 2))
     }
 }


### PR DESCRIPTION
### Summary of changes

- Simplify `XCTestCase` helper methods
- Add `waitForElementToBeHittable` timeout to all button presses in the UI Venmo test flow (in hopes to reduce UI test flakiness on CI)

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo @sarahkoop @jaxdesmarais 
