### PR TITLE
Consolidate Release Instructions to Knowledge Repo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,16 +79,4 @@ To import a Braintree framework written in **Swift** into an Objective-C file, u
 
 ## Releasing
 
-A release is triggered via the `Release` workflow in the repo's `Actions` tab.
-
-### v5
-
-To release a version of the v5 SDK, select `Use workflow from: master` and then the appropriate Semantic Version to release under `Version to release`.
-
-### v4
-
-_Note: development for older SDK versions should happen off branches `3.x`, `4.x`, etc._
-
-To release a version of the v4 SDK, select `Use workflow from: 4.x` and then the appropriate Semantic Version to release under `Version to release`.
-
-Once complete, manually update the CHANGELOG on the `master` branch to include your latest v4 release notes.
+Refer to the `ios/releases` section in the SDK Knowledge Repo.


### PR DESCRIPTION
### Summary of changes

Prior - we had release instructions in 2 places, this repo itself & the knowledge repo. The knowledge repo had instructions for releasing the Carthage binaries to hosted-mobile-assets.

Let's consolidate them all to one place.

### Authors
@scannillo
