### PR TITLE
Clarify Carthage Instructions - Require `xcframework`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Convert `BraintreeAmericanExpress` module to Swift
 * Breaking Changes
   * Bump minimum supported deployment target to iOS 13+
-  * Require Carthage 0.38.0+
+  * Require Carthage 0.38.0+ and xcframeworks via `carthage update --use-xcframeworks`
   * Require Xcode 13
     * Bump Swift Tools Version to 5.5 for CocoaPods & SPM
   * BraintreeVenmo

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pod 'Braintree/Venmo'
 *Note:* If you are using version 4.x.x of the Braintree iOS SDK in Xcode 12, you may see the warning `The iOS Simulator deployment target is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99`. This will not prevent your app from compiling. This is a [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/7314) with a known workaround.
 
 ### Carthage
-Braintree 6.0.0+ requires Carthage 0.38.0+.
+Braintree 6.0.0+ requires Carthage 0.38.0+ and the `--use-xcframeworks` option when running `carthage update`.
 
 Add `github "braintree/braintree_ios"` to your `Cartfile`, and [add the frameworks to your project](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 


### PR DESCRIPTION
### Summary of changes

- This PR clarifies our README and CHANGELOG to explicitly state that v6 requires Carthage merchants use `xcframeworks`. 
- _Note:_ `xcframework`s are required by Apple for M1 support. `.framework` use is discouraged since Xcode 13 and requires some weird workarounds to get working. Let's follow Apple's standards.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 