### PR TITLE
Remove Duplicate Expiration Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Remove expiration date duplication in card tokenization (fixes #772)
+
 ## 5.5.0 (2021-11-01)
 * Add `displayName` to `BTLocalPaymentRequest`
 * Add `riskCorrelationId` to `BTPayPalRequest`

--- a/Sources/BraintreeCard/BTCard.m
+++ b/Sources/BraintreeCard/BTCard.m
@@ -34,10 +34,6 @@
         p[@"cardholder_name"] = self.cardholderName;
     }
 
-    if (self.expirationMonth && self.expirationYear) {
-        p[@"expiration_date"] = [NSString stringWithFormat:@"%@/%@", self.expirationMonth, self.expirationYear];
-    }
-    
     if (self.cvv) {
         p[@"cvv"] = self.cvv;
     }

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -37,7 +37,8 @@ class BTCardClient_Tests: XCTestCase {
             }
             
             XCTAssertEqual(cardParams["number"] as? String, "4111111111111111")
-            XCTAssertEqual(cardParams["expiration_date"] as? String, "12/2038")
+            XCTAssertEqual(cardParams["expiration_month"] as? String, "12")
+            XCTAssertEqual(cardParams["expiration_year"] as? String, "2038")
             XCTAssertEqual(cardParams["cvv"] as? String, "1234")
             XCTAssertEqual(cardParams["cardholder_name"] as? String, "Brian Tree")
             

--- a/UnitTests/BraintreeCardTests/BTCard_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCard_Tests.swift
@@ -46,7 +46,6 @@ class BTCard_Tests: XCTestCase {
             "expiration_month": "12",
             "expiration_year": "2038",
             "cardholder_name": "Brian Tree",
-            "expiration_date": "12/2038",
             "cvv": "123",
             "billing_address": [
                 "first_name": "Brian",

--- a/UnitTests/BraintreeUnionPayTests/BTCardClient_UnionPayTests.swift
+++ b/UnitTests/BraintreeUnionPayTests/BTCardClient_UnionPayTests.swift
@@ -493,7 +493,8 @@ class BTCardClient_UnionPayTests: XCTestCase {
                 return
             }
             XCTAssertEqual(cardParameters["number"] as? String, "4111111111111111")
-            XCTAssertEqual(cardParameters["expiration_date"] as? String, "12/2038")
+            XCTAssertEqual(cardParameters["expiration_month"] as? String, "12")
+            XCTAssertEqual(cardParameters["expiration_year"] as? String, "2038")
             XCTAssertEqual(cardParameters["cvv"] as? String, "123")
 
             guard let tokenizationOptionsParameters = cardParameters["options"] as? [String: AnyObject] else {
@@ -540,7 +541,8 @@ class BTCardClient_UnionPayTests: XCTestCase {
                 return
             }
             XCTAssertEqual(cardParameters["number"] as? String, "4111111111111111")
-            XCTAssertEqual(cardParameters["expiration_date"] as? String, "12/2038")
+            XCTAssertEqual(cardParameters["expiration_month"] as? String, "12")
+            XCTAssertEqual(cardParameters["expiration_year"] as? String, "2038")
             XCTAssertEqual(cardParameters["cvv"] as? String, "123")
 
             guard let tokenizationOptionsParameters = cardParameters["options"] as? [String: AnyObject] else {


### PR DESCRIPTION
### Summary of changes

- The iOS SDK sets expiration date, month, and year for non-graphQL card tokenization requests. Having all three of these set is not allowed for expiration date validation in the gateway. We only set month and year on Android and JS. This PR updates iOS to align with those and resolve that validation error (fixes: #772)

### Checklist

- [x] Added a changelog entry

### Authors

- @sarahkoop 
- @jaxdesmarais 
