### PR TITLE
Add Nil Check for Success/Failure Handlers in 3DS Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* Add nil checks for 3DS handlers (fixes #769)
 * Remove expiration date duplication in card tokenization (fixes #772)
 
 ## 5.5.0 (2021-11-01)

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.m
@@ -30,7 +30,9 @@
                                              code:BTThreeDSecureFlowErrorTypeFailedAuthentication
                                          userInfo:@{NSLocalizedDescriptionKey: @"Tokenized card nonce is required"}];
         [apiClient sendAnalyticsEvent:@"ios.three-d-secure.verification-flow.upgrade-payment-method.errored"];
-        failureHandler(error);
+        if (failureHandler != nil) {
+            failureHandler(error);
+        }
         return;
     }
 
@@ -41,7 +43,9 @@
          completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
         if (error) {
             [apiClient sendAnalyticsEvent:@"ios.three-d-secure.verification-flow.upgrade-payment-method.errored"];
-            failureHandler(error);
+            if (failureHandler != nil) {
+                failureHandler(error);
+            }
             return;
         }
 
@@ -56,7 +60,9 @@
             result.tokenizedCard = lookupResult.tokenizedCard;
         }
 
-        successHandler(result);
+        if (successHandler != nil) {
+            successHandler(result);
+        }
     }];
 }
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
@@ -92,7 +92,9 @@
                                          code:errorCode
                                      userInfo:errorUserInfo];
 
-    failureHandler(error);
+    if (failureHandler != nil) {
+        failureHandler(error);
+    }
 }
 
 #pragma mark - Cardinal Delegate


### PR DESCRIPTION
### Summary of changes

- Add checks to confirm success/failure handlers are not nil before invoking in Cardinal authentication flow (fixes #769)
- Cardinal is still investigating the underlying cause of this issue, but until we get an updated SDK, the nil checks should prevent merchant apps from crashing when the authentication flow is invoked again after we've set the handlers to nil. 

**Note**: We don't currently have a test suite for `BTThreeDSecureV2Provider`. We tried to create one, but there are limitations in mocking the required Cardinal classes to invoke the delegate method. 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @sarahkoop 
