### PR TITLE
Add `BTCardClientErrorTypeCardAlreadyExists`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Remove expiration date duplication in card tokenization (fixes #772)
+* Card Tokenization
+  * Remove expiration date duplication in card tokenization (fixes #772)
+  * Add `BTCardClientErrorTypeCardAlreadyExists` to `BTCardClientErrorType` 
 
 ## 5.5.0 (2021-11-01)
 * Add `displayName` to `BTLocalPaymentRequest`

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -235,20 +235,20 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
 
 - (NSError *)cardTokenizationErrorForError:(NSError *)error {
     NSError *callbackError = error;
-    NSDictionary<NSErrorUserInfoKey,id> *errorMap = error.userInfo;
-    BTJSON *errorFields = [errorMap objectForKey:BTHTTPJSONResponseBodyKey];
-    
-    BTJSON *errorCode = errorFields[@"fieldErrors"][0][@"fieldErrors"][0][@"code"];
-    
-    // Gateway error code for card already exists
-    if ([errorCode.asString  isEqual: @"81724"]) {
-        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                            code:BTCardClientErrorTypeCardAlreadyExists
-                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
-    } else {
-        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                            code:BTCardClientErrorTypeCustomerInputInvalid
-                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+    if (error.userInfo) {
+        BTJSON *errorFields = [error.userInfo objectForKey:BTHTTPJSONResponseBodyKey];
+        BTJSON *errorCode = errorFields[@"fieldErrors"][0][@"fieldErrors"][0][@"code"];
+        
+        // Gateway error code for card already exists
+        if ([errorCode.asString  isEqual: @"81724"]) {
+            callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                                code:BTCardClientErrorTypeCardAlreadyExists
+                                            userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+        } else {
+            callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                                code:BTCardClientErrorTypeCustomerInputInvalid
+                                            userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+        }
     }
     return callbackError;
 }

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -244,7 +244,7 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
     return graphQLFeatures && [graphQLFeatures containsObject:BTCardClientGraphQLTokenizeFeature];
 }
 
-- (NSError *)constructCallbackErrorResponseForErrorCode:(BTJSON *)errorCode error:(NSError *)error {
+- (NSError *)constructCallbackErrorForErrorCode:(String *)errorCode error:(NSError *)error {
     NSError *callbackError = error;
 
     // Gateway error code for card already exists

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -101,7 +101,7 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
                              BTJSON *errorResponse = [error.userInfo objectForKey:BTHTTPJSONResponseBodyKey];
                              BTJSON *errorCode = [errorResponse[@"errors"] asArray].firstObject[@"extensions"][@"legacyCode"];
 
-                             callbackError = [self constructCallbackErrorResponseForErrorCode:errorCode error:error];
+                             callbackError = [self constructCallbackErrorForErrorCode:errorCode error:error];
                          }
                      }
 
@@ -133,7 +133,7 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
                              BTJSON *fieldErrors = [errorResponse[@"fieldErrors"] asArray].firstObject;
                              BTJSON *errorCode = [fieldErrors[@"fieldErrors"] asArray].firstObject[@"code"];
 
-                             callbackError = [self constructCallbackErrorResponseForErrorCode:errorCode error:error];
+                             callbackError = [self constructCallbackErrorForErrorCode:errorCode error:error];
                          }
                      }
 

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -97,7 +97,12 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
                      NSError *callbackError = error;
 
                      if (response.statusCode == 422) {
-                         callbackError = [self cardTokenizationErrorForError:error];
+                         if (error.userInfo) {
+                             BTJSON *errorResponse = [error.userInfo objectForKey:BTHTTPJSONResponseBodyKey];
+                             BTJSON *errorCode = [errorResponse[@"errors"] asArray].firstObject[@"extensions"][@"legacyCode"];
+
+                             callbackError = [self constructCallbackErrorResponseForErrorCode:errorCode error:error];
+                         }
                      }
 
                      [self sendGraphQLAnalyticsEventWithSuccess:NO];
@@ -123,7 +128,13 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
                      NSError *callbackError = error;
 
                      if (response.statusCode == 422) {
-                         callbackError = [self cardTokenizationErrorForError:error];
+                         if (error.userInfo) {
+                             BTJSON *errorResponse = [error.userInfo objectForKey:BTHTTPJSONResponseBodyKey];
+                             BTJSON *fieldErrors = [errorResponse[@"fieldErrors"] asArray].firstObject;
+                             BTJSON *errorCode = [fieldErrors[@"fieldErrors"] asArray].firstObject[@"code"];
+
+                             callbackError = [self constructCallbackErrorResponseForErrorCode:errorCode error:error];
+                         }
                      }
 
                      if (request.enrollmentID) {
@@ -233,22 +244,18 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
     return graphQLFeatures && [graphQLFeatures containsObject:BTCardClientGraphQLTokenizeFeature];
 }
 
-- (NSError *)cardTokenizationErrorForError:(NSError *)error {
+- (NSError *)constructCallbackErrorResponseForErrorCode:(BTJSON *)errorCode error:(NSError *)error {
     NSError *callbackError = error;
-    if (error.userInfo) {
-        BTJSON *errorFields = [error.userInfo objectForKey:BTHTTPJSONResponseBodyKey];
-        BTJSON *errorCode = errorFields[@"fieldErrors"][0][@"fieldErrors"][0][@"code"];
-        
-        // Gateway error code for card already exists
-        if ([errorCode.asString  isEqual: @"81724"]) {
-            callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                                code:BTCardClientErrorTypeCardAlreadyExists
-                                            userInfo:[self.class validationErrorUserInfo:error.userInfo]];
-        } else {
-            callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                                code:BTCardClientErrorTypeCustomerInputInvalid
-                                            userInfo:[self.class validationErrorUserInfo:error.userInfo]];
-        }
+
+    // Gateway error code for card already exists
+    if ([errorCode.asString  isEqual: @"81724"]) {
+        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                            code:BTCardClientErrorTypeCardAlreadyExists
+                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+    } else {
+        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                            code:BTCardClientErrorTypeCustomerInputInvalid
+                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
     }
     return callbackError;
 }

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -234,22 +234,22 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
 }
 
 - (NSError *)cardTokenizationErrorForError:(NSError *)error {
-     NSError *callbackError = error;
-     NSDictionary<NSErrorUserInfoKey,id> *errorMap = error.userInfo;
-     BTJSON *errorFields = [errorMap objectForKey:BTHTTPJSONResponseBodyKey];
-     
-     BTJSON *errorCode = errorFields[@"fieldErrors"][0][@"fieldErrors"][0][@"code"];
-     
+    NSError *callbackError = error;
+    NSDictionary<NSErrorUserInfoKey,id> *errorMap = error.userInfo;
+    BTJSON *errorFields = [errorMap objectForKey:BTHTTPJSONResponseBodyKey];
+    
+    BTJSON *errorCode = errorFields[@"fieldErrors"][0][@"fieldErrors"][0][@"code"];
+    
     // Gateway error code for card already exists
-     if ([errorCode.asString  isEqual: @"81724"]) {
-         callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                             code:BTCardClientErrorTypeCardAlreadyExists
-                                         userInfo:[self.class validationErrorUserInfo:error.userInfo]];
-     } else {
-         callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
-                                             code:BTCardClientErrorTypeCustomerInputInvalid
-                                         userInfo:[self.class validationErrorUserInfo:error.userInfo]];
-     }
+    if ([errorCode.asString  isEqual: @"81724"]) {
+        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                            code:BTCardClientErrorTypeCardAlreadyExists
+                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+    } else {
+        callbackError = [NSError errorWithDomain:BTCardClientErrorDomain
+                                            code:BTCardClientErrorTypeCustomerInputInvalid
+                                        userInfo:[self.class validationErrorUserInfo:error.userInfo]];
+    }
     return callbackError;
 }
 

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -244,7 +244,7 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
     return graphQLFeatures && [graphQLFeatures containsObject:BTCardClientGraphQLTokenizeFeature];
 }
 
-- (NSError *)constructCallbackErrorForErrorCode:(String *)errorCode error:(NSError *)error {
+- (NSError *)constructCallbackErrorForErrorCode:(BTJSON *)errorCode error:(NSError *)error {
     NSError *callbackError = error;
 
     // Gateway error code for card already exists

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
@@ -26,6 +26,9 @@ typedef NS_ENUM(NSInteger, BTCardClientErrorType) {
 
     /// Customer provided invalid input
     BTCardClientErrorTypeCustomerInputInvalid,
+    
+    /// Card already exists as a saved payment method
+    BTCardClientErrorTypeCardAlreadyExists,
 };
 
 /**

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -268,23 +268,35 @@ class BTCardClient_Tests: XCTestCase {
             ]
         ])
         let stubJSONResponse = BTJSON(value: [
-            "data": [
-                "tokenizeCreditCard": "null"
-            ],
             "errors": [
                 [
-                    "message": "Duplicate card exists in the vault.",
-                    "path": ["tokenizeCreditCard"],
+                    "message": "Duplicate card exists in the vault",
+                    "locations": [
+                        [
+                            "line": 2,
+                            "column": 3
+                        ]
+                    ],
+                    "path": [
+                        "tokenizeCreditCard"
+                    ],
                     "extensions": [
-                        "errorType": "user_error",
                         "errorClass": "VALIDATION",
-                        "legacyCode": "81724",
-                        "inputPath": ["input"]
+                        "errorType": "user_error",
+                        "inputPath": [
+                            "input",
+                            "creditCard",
+                            "number"
+                        ],
+                        "legacyCode": "81724"
                     ]
                 ]
             ],
+            "data": [
+                "tokenizeCreditCard": "null"
+            ],
             "extensions": [
-                "requestId": "abc-123-def-456"
+                "requestId": "3521c97e-a420-47f4-a8ef-a8cefb0fa635"
             ]
         ])
         let stubError = NSError(domain: BTHTTPErrorDomain, code: BTHTTPErrorCode.clientError.rawValue, userInfo: [

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -202,6 +202,63 @@ class BTCardClient_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
     
+    func testTokenization_whenTokenizationEndpointReturns422AndCode81724_callCompletionWithValidationError() {
+        let stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
+        let stubJSONResponse = BTJSON(value: [
+            "error" : [
+                "message" : "Credit card is invalid"
+            ],
+            "fieldErrors" : [
+                [
+                    "field" : "creditCard",
+                    "fieldErrors" : [
+                        [
+                            "field" : "number",
+                            "message" : "Duplicate card exists in the vault.",
+                            "code" : "81724"
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        let stubError = NSError(domain: BTHTTPErrorDomain, code: BTHTTPErrorCode.clientError.rawValue, userInfo: [
+            BTHTTPURLResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
+            BTHTTPJSONResponseBodyKey: stubJSONResponse
+        ])
+        stubAPIClient.cannedResponseError = stubError
+        let cardClient = BTCardClient(apiClient: stubAPIClient)
+
+        let card = BTCard()
+        card.number = "4111111111111111"
+        card.expirationMonth = "12"
+        card.expirationYear = "2038"
+        card.cvv = "123"
+
+        let request = BTCardRequest()
+        request.card = card
+
+        let expectation = self.expectation(description: "Callback invoked with error")
+        cardClient.tokenizeCard(request, options: nil) { (cardNonce, error) -> Void in
+            XCTAssertNil(cardNonce)
+            guard let error = error as NSError? else {return}
+            
+            XCTAssertEqual(error.domain, BTCardClientErrorDomain)
+            XCTAssertEqual(error.code, BTCardClientErrorType.cardAlreadyExists.rawValue)
+            if let json = (error.userInfo as NSDictionary)[BTCustomerInputBraintreeValidationErrorsKey] as? NSDictionary {
+                XCTAssertEqual(json, (stubJSONResponse as BTJSON).asDictionary()! as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response in userInfo[BTCustomInputBraintreeValidationErrorsKey]")
+            }
+            XCTAssertEqual(error.localizedDescription, "Credit card is invalid")
+            XCTAssertEqual((error as NSError).localizedFailureReason, "Duplicate card exists in the vault.")
+            
+            
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+    
     func testTokenization_whenTokenizationEndpointReturnsAnyNon422Error_callCompletionWithError() {
         let stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
         stubAPIClient.cannedResponseError = NSError(domain: BTHTTPErrorDomain, code: BTHTTPErrorCode.clientError.rawValue, userInfo: nil)

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -314,10 +314,7 @@ class BTCardClient_Tests: XCTestCase {
                 XCTAssertEqual(json, (stubJSONResponse as BTJSON).asDictionary()! as NSDictionary)
             } else {
                 XCTFail("Expected JSON response in userInfo[BTCustomInputBraintreeValidationErrorsKey]")
-            }
-            XCTAssertEqual(error.localizedDescription, "Credit card is invalid")
-            XCTAssertEqual((error as NSError).localizedFailureReason, "Duplicate card exists in the vault.")
-            
+            }            
             
             expectation.fulfill()
         }


### PR DESCRIPTION
### Summary of changes

- Add explicit error case for error code returned from Gateway when a card already exists in the vault.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @sarahkoop 
