### PR TITLE
Fix card already exists error construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Fix error construction for duplicate card error
+
 ## 5.6.0 (2022-01-13)
 * Card Tokenization
   * Remove expiration date duplication in card tokenization (fixes #772)


### PR DESCRIPTION
### Summary of changes

- Updated error response construction

Note: Previously, when hitting the GQL tokenization call, we were not getting the error response back in the expected format. Instead it was being constructed the same as non-GQL api calls. Now we should correctly handle either format when constructing the errors as well as throw a default error if the response is `nil`.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop @jaxdesmarais 
