### PR TITLE
Update braintreepayments URLs to paypal URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 
 
 ## Supported Payment Methods
 
-- [Credit Cards](https://developers.braintreepayments.com/guides/credit-cards/overview)
-- [PayPal](https://developers.braintreepayments.com/guides/paypal/overview)
-- [Pay with Venmo](https://developers.braintreepayments.com/guides/venmo/overview)
-- [Apple Pay](https://developers.braintreepayments.com/guides/apple-pay/overview)
-- [ThreeDSecure](https://developers.braintreepayments.com/guides/3d-secure/overview)
-- [Visa Checkout](https://developers.braintreepayments.com/guides/visa-checkout/overview)
+- [Credit Cards](https://developer.paypal.com/braintree/docs/guides/credit-cards/overview)
+- [PayPal](https://developer.paypal.com/braintree/docs/guides/paypal/overview)
+- [Pay with Venmo](https://developer.paypal.com/braintree/docs/guides/venmo/overview)
+- [Apple Pay](https://developer.paypal.com/braintree/docs/guides/apple-pay/overview)
+- [ThreeDSecure](https://developer.paypal.com/braintree/docs/guides/3d-secure/overview)
+- [Visa Checkout](https://developer.paypal.com/braintree/docs/guides/secure-remote-commerce/overview)
 
 ## Installation
 
@@ -71,7 +71,7 @@ Next, read the [**full documentation**](https://developer.paypal.com/braintree/d
 
 ## Versions
 
-This SDK abides by our Client SDK Deprecation Policy. For more information on the potential statuses of an SDK check our [developer docs](http://developers.braintreepayments.com/guides/client-sdk/deprecation-policy).
+This SDK abides by our Client SDK Deprecation Policy. For more information on the potential statuses of an SDK check our [developer docs](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/ios/v5).
 
 | Major version number | Status | Released | Deprecated | Unsupported |
 | -------------------- | ------ | -------- | ---------- | ----------- |

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTAuthenticationInsight.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTAuthenticationInsight.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The regulation environment for the associated nonce to help determine the need
- for 3D Secure. See https://developers.braintreepayments.com/guides/3d-secure/advanced-options/ios/v4#authentication-insight
+ for 3D Secure. See https://developer.paypal.com/braintree/docs/guides/3d-secure/advanced-options/ios/v5#authentication-insight
  for a list of possible values.
  */
 @property (nonatomic, nullable, copy) NSString *regulationEnvironment;

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTCard.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTCard.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
  Optional: the country name associated with the card's billing address.
 
  @note Braintree only accepts specific country names.
- @see https://developers.braintreepayments.com/reference/general/countries#list-of-countries
+ @see https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
 */
 @property (nonatomic, nullable, copy) NSString *countryName;
 
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  Optional: the ISO 3166-1 alpha-2 country code specified in the card's billing address.
 
  @note Braintree only accepts specific alpha-2 values.
- @see https://developers.braintreepayments.com/reference/general/countries#list-of-countries
+ @see https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
 */
 @property (nonatomic, nullable, copy) NSString *countryCodeAlpha2;
 
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  Optional: The ISO 3166-1 alpha-3 country code specified in the card's billing address.
 
  @note Braintree only accepts specific alpha-3 values.
- @see https://developers.braintreepayments.com/reference/general/countries#list-of-countries
+ @see https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
  */
 @property (nonatomic, nullable, copy) NSString *countryCodeAlpha3;
 
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
  Optional: The ISO 3166-1 numeric country code specified in the card's billing address.
 
  @note Braintree only accepts specific numeric values.
- @see https://developers.braintreepayments.com/reference/general/countries#list-of-countries
+ @see https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
  */
 @property (nonatomic, nullable, copy) NSString *countryCodeNumeric;
 

--- a/Sources/BraintreeCore/BTPostalAddress.m
+++ b/Sources/BraintreeCore/BTPostalAddress.m
@@ -7,7 +7,7 @@
 @implementation BTPostalAddress
 
 // Property names follow the `Braintree_Address` convention as documented at:
-// https://developers.braintreepayments.com/ios+php/reference/response/address
+// https://developer.paypal.com/braintree/docs/reference/request/address/create
 
 - (id)copyWithZone:(__unused NSZone *)zone {
     BTPostalAddress *address = [[BTPostalAddress alloc] init];

--- a/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTLocalPaymentRequest.h
+++ b/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTLocalPaymentRequest.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This value must be one of the supported country codes for a given local payment type listed at the link below. For local payments supported in multiple countries, this value may determine which banks are presented to the customer.
 
- https://developers.braintreepayments.com/guides/local-payment-methods/client-side-custom/ios/v4#invoke-payment-flow
+ https://developer.paypal.com/braintree/docs/guides/local-payment-methods/client-side-custom/ios/v5#invoke-payment-flow
  */
 @property (nonatomic, nullable, copy) NSString *paymentTypeCountryCode;
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecurePostalAddress.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecurePostalAddress.m
@@ -3,7 +3,7 @@
 @implementation BTThreeDSecurePostalAddress
 
 // Property names follow the `Braintree_Address` convention as documented at:
-// https://developers.braintreepayments.com/ios+php/reference/response/address
+// https://developer.paypal.com/braintree/docs/reference/request/address/create
 
 - (id)copyWithZone:(__unused NSZone *)zone {
     BTThreeDSecurePostalAddress *address = [[BTThreeDSecurePostalAddress alloc] init];

--- a/V5_MIGRATION.md
+++ b/V5_MIGRATION.md
@@ -4,7 +4,7 @@ See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migratio
 
 v5 introduces support for Swift Package Manager. See the [Swift Package Manager guide](/SWIFT_PACKAGE_MANAGER.md) for more details.
 
-_Documentation for v5 will be published to https://developers.braintreepayments.com once it is available for general release._
+_Documentation for v5 will be published to https://developer.paypal.com/braintree/docs once it is available for general release._
 
 ## Table of Contents
 


### PR DESCRIPTION
### Summary of changes

- Update URLs from `developers.braintreepayments.com` to the correct `developer.paypal.com` URLs

### Checklist

- ~[ ] Added a changelog entry~ I do not think we need a changelog for this since no behavior changed we are just fixing links, but can add an entry if someone feels strongly about it

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @Epreuve @jaxdesmarais 
