### PR TITLE
Add 3DS Autofill Buttons to Demo App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Add 3DS v1 and v2 card autofill buttons to Demo App
+
 ## 5.6.3 (2022-02-09)
 * Swift Package Manager
   * Add explicit package dependancies for `BraintreeDataCollector`, `BraintreeThreeDSecure`, and `PayPalDataCollector` (fixes #735)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Braintree iOS SDK Release Notes
 
-## unreleased
-* Add 3DS v1 and v2 card autofill buttons to Demo App
-
 ## 5.6.3 (2022-02-09)
 * Swift Package Manager
   * Add explicit package dependancies for `BraintreeDataCollector`, `BraintreeThreeDSecure`, and `PayPalDataCollector` (fixes #735)

--- a/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.h
+++ b/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.h
@@ -6,6 +6,7 @@
 
 @property (nonatomic, strong) BTAPIClient *apiClient;
 @property (nonatomic, strong) UIView *paymentButton;
+@property (nonatomic, readwrite) CGFloat centerYConstant;
 
 /// A factory method that subclasses must implement to return a payment button view.
 - (UIView *)createPaymentButton;

--- a/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.m
+++ b/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.m
@@ -24,7 +24,7 @@
 
     [NSLayoutConstraint activateConstraints:@[
         [self.paymentButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-        [self.paymentButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+        [self.paymentButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:self.centerYConstant],
         [self.paymentButton.heightAnchor constraintEqualToConstant:44.0]
     ]];
 }

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -7,6 +7,8 @@
 @property (nonatomic, strong) BTPaymentFlowDriver *paymentFlowDriver;
 @property (nonatomic, strong) UILabel *callbackCountLabel;
 @property (nonatomic, strong) BTCardFormView *cardFormView;
+@property (nonatomic, strong) UIButton *autofillButton3DS1;
+@property (nonatomic, strong) UIButton *autofillButton3DS2;
 @property (nonatomic) int callbackCount;
 
 @end
@@ -21,12 +23,32 @@
     [self.view addSubview:self.cardFormView];
     self.cardFormView.translatesAutoresizingMaskIntoConstraints = NO;
     self.cardFormView.hidePhoneNumberField = YES;
+    
+    self.autofillButton3DS1 = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.autofillButton3DS1.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.autofillButton3DS1 setTitle:NSLocalizedString(@"Autofill 3DS v1 Card", nil) forState:UIControlStateNormal];
+    [self.autofillButton3DS1 addTarget:self action:@selector(tappedToAutofill3DS1Card) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.autofillButton3DS1];
+    
+    self.autofillButton3DS2 = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.autofillButton3DS2.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.autofillButton3DS2 setTitle:NSLocalizedString(@"Autofill 3DS v2 Card", nil) forState:UIControlStateNormal];
+    [self.autofillButton3DS2 addTarget:self action:@selector(tappedToAutofill3DS2Card) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.autofillButton3DS2];
 
     [NSLayoutConstraint activateConstraints:@[
         [self.cardFormView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
         [self.cardFormView.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor],
         [self.cardFormView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor],
-        [self.cardFormView.heightAnchor constraintEqualToConstant:200]
+        [self.cardFormView.heightAnchor constraintEqualToConstant:200],
+        
+        [self.autofillButton3DS1.topAnchor constraintEqualToAnchor:self.cardFormView.bottomAnchor constant:10],
+        [self.autofillButton3DS1.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:10],
+        [self.autofillButton3DS1.heightAnchor constraintEqualToConstant:30],
+        
+        [self.autofillButton3DS2.topAnchor constraintEqualToAnchor:self.autofillButton3DS1.bottomAnchor constant:10],
+        [self.autofillButton3DS2.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:10],
+        [self.autofillButton3DS2.heightAnchor constraintEqualToConstant:30]
     ]];
 }
 
@@ -83,6 +105,33 @@
 
 - (void)updateCallbackCount {
     self.callbackCountLabel.text = [NSString stringWithFormat:@"Callback Count: %i", self.callbackCount];
+}
+
+-(void)tappedToAutofill3DS1Card {
+    self.cardFormView.cardNumberTextField.text = @"4000000000000002";
+    self.cardFormView.expirationTextField.text = self.generateFutureDate;
+    self.cardFormView.cvvTextField.text = @"123";
+    self.cardFormView.postalCodeTextField.text = @"12345";
+}
+
+-(void)tappedToAutofill3DS2Card {
+    self.cardFormView.cardNumberTextField.text = @"4000000000001091";
+    self.cardFormView.expirationTextField.text = self.generateFutureDate;
+    self.cardFormView.cvvTextField.text = @"123";
+    self.cardFormView.postalCodeTextField.text = @"12345";
+}
+
+-(NSString *)generateFutureDate {
+    NSString *monthString = @"12";
+
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yy"];
+
+    NSDate *futureYear = [[NSCalendar currentCalendar]dateByAddingUnit:NSCalendarUnitYear value:3 toDate:[NSDate date] options:0];
+    NSString *yearString = [dateFormatter stringFromDate:futureYear];
+    NSString *futureDateString = [NSString stringWithFormat:@"%@/%@", monthString, yearString];
+
+    return futureDateString;
 }
 
 /// "Tokenize and Verify New Card"

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -69,6 +69,8 @@
     [threeDSecureButtonsContainer addSubview:self.callbackCountLabel];
     self.callbackCount = 0;
     [self updateCallbackCount];
+    
+    self.centerYConstant = 100;
 
     [NSLayoutConstraint activateConstraints:@[
         [verifyNewCardButton.topAnchor constraintEqualToAnchor:threeDSecureButtonsContainer.topAnchor],

--- a/Demo/Application/Features/Views/BTCardFormView.swift
+++ b/Demo/Application/Features/Views/BTCardFormView.swift
@@ -44,9 +44,9 @@ class BTCardFormView: UIView {
     // MARK: - Internal UI Properties
 
     @objc var cardNumberTextField: UITextField = UITextField() // exposed for UnionPay demo
-    var expirationTextField: UITextField = UITextField()
-    var cvvTextField: UITextField = UITextField()
-    var postalCodeTextField: UITextField = UITextField()
+    @objc var expirationTextField: UITextField = UITextField() // exposed for 3DS demo
+    @objc var cvvTextField: UITextField = UITextField() // exposed for 3DS demo
+    @objc var postalCodeTextField: UITextField = UITextField() // exposed for 3DS demo
     var phoneNumberTextField: UITextField = UITextField()
     var stackView: UIStackView = UIStackView()
 


### PR DESCRIPTION
### Summary of changes

- Add 3D Secure v1 and v2 card autofill buttons to demo app

### ✨  Visuals ✨ 
| Before | After |
|-----|-----|
![Simulator Screen Shot - iPhone 12 - 2022-02-28 at 08 38 26](https://user-images.githubusercontent.com/20733831/156061943-f265e1c6-bf89-4125-9e25-b82f8cec2d92.png)|![Simulator Screen Shot - iPhone 12 - 2022-02-28 at 08 57 34](https://user-images.githubusercontent.com/20733831/156061961-1e7223ab-b5af-488d-9d70-ee6a95b2864f.png)|

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
