### PR TITLE
Fix crash caused by failed http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * PPDataCollector
   * Allow passing isSandbox bool for data collection in `clientMetadataID` and `collectPayPalDeviceData` functions
+* Fix potential crash when http request fails (no error, but empty body)
 
 ## 5.8.0 (2022-03-24)
 * PPRiskMagnes

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -67,15 +67,7 @@ static NSString *BraintreeVersion = @"2018-03-06";
         return;
     }
 
-    if (data == nil || data.length == 0) {
-        NSError *error = [[NSError alloc] initWithDomain:BTHTTPErrorDomain
-                                                    code:BTHTTPErrorCodeUnknown
-                                                userInfo:@{NSLocalizedDescriptionKey: @"An unexpected error occurred with the HTTP request."}];
-        [self callCompletionBlock:completionBlock body:nil response:nil error:error];
-        return;
-    }
-
-    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data?:[NSData data] options:0 error:NULL];
     BTJSON *body = [[BTJSON alloc] initWithValue:json];
 
     // Success case

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -67,8 +67,7 @@ static NSString *BraintreeVersion = @"2018-03-06";
         return;
     }
 
-    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
-    BTJSON *body = [[BTJSON alloc] initWithValue:json];
+    BTJSON *body = (data.length == 0) ? [BTJSON new] : [[BTJSON alloc] initWithData:data];
 
     // Success case
     if ([body asDictionary] && ![body[@"errors"] asArray]) {

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -67,7 +67,15 @@ static NSString *BraintreeVersion = @"2018-03-06";
         return;
     }
 
-    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data?:[NSData data] options:0 error:NULL];
+    if (data == nil || data.length == 0) {
+        NSError *error = [[NSError alloc] initWithDomain:BTHTTPErrorDomain
+                                                    code:BTHTTPErrorCodeUnknown
+                                                userInfo:@{NSLocalizedDescriptionKey: @"An unexpected error occurred with the HTTP request."}];
+        [self callCompletionBlock:completionBlock body:nil response:nil error:error];
+        return;
+    }
+
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
     BTJSON *body = [[BTJSON alloc] initWithValue:json];
 
     // Success case

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -63,11 +63,12 @@ static NSString *BraintreeVersion = @"2018-03-06";
 {
     // Network error
     if (error) {
-        [self callCompletionBlock:completionBlock body:nil response:nil error:error];
+        [self callCompletionBlock:completionBlock body:nil response:(NSHTTPURLResponse *)response error:error];
         return;
     }
 
-    BTJSON *body = (data.length == 0) ? [BTJSON new] : [[BTJSON alloc] initWithData:data];
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data?:[NSData data] options:0 error:NULL];
+    BTJSON *body = [[BTJSON alloc] initWithValue:json];
 
     // Success case
     if ([body asDictionary] && ![body[@"errors"] asArray]) {
@@ -173,11 +174,6 @@ static NSString *BraintreeVersion = @"2018-03-06";
 
     // Perform the actual request
     NSURLSessionTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (error) {
-            [self callCompletionBlock:completionBlock body:nil response:(NSHTTPURLResponse *)response error:error];
-            return;
-        }
-
         [self handleRequestCompletion:data response:response error:error completionBlock:completionBlock];
     }];
     [task resume];

--- a/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
@@ -71,7 +71,7 @@ describe(@"metadata", ^{
     });
     describe(@"deviceModel", ^{
         it(@"returns the device model", ^{
-            expect([BTAnalyticsMetadata metadata][@"deviceModel"]).to.match(@"iPhone\\d,\\d|i386|x86_64");
+            expect([BTAnalyticsMetadata metadata][@"deviceModel"]).to.match(@"iPhone\\d,\\d|i386|x86_64|arm64");
         });
     });
 

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -522,12 +522,15 @@
         return [HTTPStubsResponse responseWithData:[NSData data] statusCode:500 headers:@{}];
     }];
 
+    id expectedErrorBody = @{
+         @"error": @{@"message": @"An unexpected error occurred"},
+     };
+
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback invoked"];
     [http POST:@"" completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertNil(body);
-        XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], @"An unexpected error occurred with the HTTP request.");
+        XCTAssertEqualObjects(body.asDictionary, expectedErrorBody);
         XCTAssertEqualObjects(error.domain, BTHTTPErrorDomain);
-        XCTAssertEqual(error.code, BTHTTPErrorCodeUnknown);
+        XCTAssertEqual(error.code, BTHTTPErrorCodeServerError);
         [expectation fulfill];
     }];
 

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -522,15 +522,12 @@
         return [HTTPStubsResponse responseWithData:[NSData data] statusCode:500 headers:@{}];
     }];
 
-    id expectedErrorBody = @{
-        @"error": @{@"message": @"An unexpected error occurred"},
-    };
-
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback invoked"];
     [http POST:@"" completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertEqualObjects(body.asDictionary, expectedErrorBody);
+        XCTAssertNil(body);
+        XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], @"An unexpected error occurred with the HTTP request.");
         XCTAssertEqualObjects(error.domain, BTHTTPErrorDomain);
-        XCTAssertEqual(error.code, BTHTTPErrorCodeServerError);
+        XCTAssertEqual(error.code, BTHTTPErrorCodeUnknown);
         [expectation fulfill];
     }];
 


### PR DESCRIPTION
### Summary of changes

`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'data parameter is nil'` could happen for failed http requests (no response body).

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @cltnschlosser
