### PR TITLE
Update Configuration Threading Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* Venmo
+  * Reduce network connection lost error frequency on older iOS and Venmo app versions
 * PPDataCollector
   * Allow passing isSandbox bool for data collection in `clientMetadataID` and `collectPayPalDeviceData` functions
 

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -27,6 +27,8 @@
 - (void)tappedCustomVenmo {
     self.progressBlock(@"Tapped Venmo - initiating Venmo auth");
     BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] init];
+    [venmoRequest setVault:YES];
+    [venmoRequest setPaymentMethodUsage:BTVenmoPaymentMethodUsageMultiUse];
     [self.venmoDriver tokenizeVenmoAccountWithVenmoRequest:venmoRequest completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
         if (venmoAccount) {
             self.progressBlock(@"Got a nonce 💎!");

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		803FB9DE26D93146002BF92D /* BTCardFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803FB9DD26D93146002BF92D /* BTCardFormView.swift */; };
 		80581A5F2553170000006F53 /* Venmo_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581A5D2553152A00006F53 /* Venmo_UITests.swift */; };
 		9C36BD2926B3071B00F0A559 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD2826B3071A00F0A559 /* PPRiskMagnes.xcframework */; };
-		9C36BD2A26B3071B00F0A559 /* PPRiskMagnes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD2826B3071A00F0A559 /* PPRiskMagnes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9C36BD4C26B311D900F0A559 /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; };
 		9C36BD4D26B311D900F0A559 /* CardinalMobile.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A0988F9124DB44B20095EEEE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A0988E7B24DB44B10095EEEE /* Localizable.strings */; };
@@ -110,7 +109,6 @@
 				803D650A256DAF9A00ACE692 /* PayPalDataCollector.framework in Embed Frameworks */,
 				803D64FA256DAF9A00ACE692 /* BraintreeCard.framework in Embed Frameworks */,
 				803D64FE256DAF9A00ACE692 /* BraintreeDataCollector.framework in Embed Frameworks */,
-				9C36BD2A26B3071B00F0A559 /* PPRiskMagnes.xcframework in Embed Frameworks */,
 				803D64FC256DAF9A00ACE692 /* BraintreeCore.framework in Embed Frameworks */,
 				803D6504256DAF9A00ACE692 /* BraintreeThreeDSecure.framework in Embed Frameworks */,
 				803D6500256DAF9A00ACE692 /* BraintreePaymentFlow.framework in Embed Frameworks */,

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -22,11 +22,11 @@ class Venmo_UITests: XCTestCase {
         demoApp.buttons["Venmo (custom button)"].tap()
     }
     
-    func testTokenizeVenmo_whenSignInSuccessfulWithPaymentContext_returnsNonce() {
+    func testTokenizeVenmo_whenSignInSuccessfulWithPaymentContext_returnsToApp() {
         waitForElementToBeHittable(mockVenmo.buttons["SUCCESS WITH PAYMENT CONTEXT"])
         mockVenmo.buttons["SUCCESS WITH PAYMENT CONTEXT"].tap()
 
-        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 15))
+        XCTAssertTrue(demoApp.buttons["Failed to store Venmo Account in vault"].waitForExistence(timeout: 15))
     }
     
     func testTokenizeVenmo_whenSignInSuccessfulWithoutPaymentContext_returnsNonce() {

--- a/Sources/BraintreeCore/BTAPIClient.m
+++ b/Sources/BraintreeCore/BTAPIClient.m
@@ -90,7 +90,7 @@ NSString *const BTAPIClientErrorDomain = @"com.braintreepayments.BTAPIClientErro
             configurationCache = [[NSURLCache alloc] initWithMemoryCapacity:1 * 1024 * 1024 diskCapacity:0 diskPath:nil];
         });
         configuration.URLCache = configurationCache;
-        configuration.requestCachePolicy = NSURLRequestReturnCacheDataElseLoad;
+        configuration.requestCachePolicy = NSURLRequestUseProtocolCachePolicy;
         _configurationHTTP.session = [NSURLSession sessionWithConfiguration:configuration];
 
         // Kickoff the background request to fetch the config

--- a/Sources/BraintreeCore/BTAPIClient.m
+++ b/Sources/BraintreeCore/BTAPIClient.m
@@ -280,13 +280,14 @@ NSString *const BTAPIClientErrorDomain = @"com.braintreepayments.BTAPIClientErro
     //   - If cachedConfiguration is present, return it without a request
     //   - If cachedConfiguration is not present, fetch it and cache the successful response
     //   - If fetching fails, return error
-    __block NSError *fetchError;
-    __block BTConfiguration *configuration;
     NSString *configPath = @"v1/configuration"; // Default for tokenizationKey
     if (self.clientToken) {
         configPath = [self.clientToken.configURL absoluteString];
     }
     [self.configurationHTTP GET:configPath parameters:@{ @"configVersion": @"3" } shouldCache:YES completion:^(BTJSON * _Nullable body, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSError *fetchError;
+        BTConfiguration *configuration;
+
         if (error) {
             fetchError = error;
         } else if (response.statusCode != 200) {

--- a/Sources/BraintreeCore/BTAnalyticsService.m
+++ b/Sources/BraintreeCore/BTAnalyticsService.m
@@ -147,7 +147,7 @@ NSString * const BTAnalyticsServiceErrorDomain = @"com.braintreepayments.BTAnaly
 }
 
 - (void)sendAnalyticsEvent:(NSString *)eventKind completion:(__unused void(^)(NSError *error))completionBlock {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_after(0.2, dispatch_get_main_queue(), ^{
         [self enqueueEvent:eventKind];
         [self flush:completionBlock];
     });

--- a/Sources/BraintreeCore/BTAnalyticsService.m
+++ b/Sources/BraintreeCore/BTAnalyticsService.m
@@ -147,7 +147,7 @@ NSString * const BTAnalyticsServiceErrorDomain = @"com.braintreepayments.BTAnaly
 }
 
 - (void)sendAnalyticsEvent:(NSString *)eventKind completion:(__unused void(^)(NSError *error))completionBlock {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self enqueueEvent:eventKind];
         [self flush:completionBlock];
     });

--- a/Sources/BraintreeCore/BTAnalyticsService.m
+++ b/Sources/BraintreeCore/BTAnalyticsService.m
@@ -147,7 +147,7 @@ NSString * const BTAnalyticsServiceErrorDomain = @"com.braintreepayments.BTAnaly
 }
 
 - (void)sendAnalyticsEvent:(NSString *)eventKind completion:(__unused void(^)(NSError *error))completionBlock {
-    dispatch_after(0.2, dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
         [self enqueueEvent:eventKind];
         [self flush:completionBlock];
     });

--- a/Sources/BraintreeCore/BTAnalyticsService.m
+++ b/Sources/BraintreeCore/BTAnalyticsService.m
@@ -129,7 +129,6 @@ NSString * const BTAnalyticsServiceErrorDomain = @"com.braintreepayments.BTAnaly
         _sessionsQueue = dispatch_queue_create("com.braintreepayments.BTAnalyticsService", DISPATCH_QUEUE_SERIAL);
         _apiClient = apiClient;
         _flushThreshold = 1;
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResign:) name:UIApplicationWillResignActiveNotification object:nil];
     }
     return self;
 }
@@ -239,27 +238,6 @@ NSString * const BTAnalyticsServiceErrorDomain = @"com.braintreepayments.BTAnaly
             }
         });
     }];
-}
-
-#pragma mark - Private methods
-
-- (void)appWillResign:(NSNotification *)notification {
-    UIApplication *application = notification.object;
-    
-    __block UIBackgroundTaskIdentifier bgTask;
-    bgTask = [application beginBackgroundTaskWithName:@"BTAnalyticsService" expirationHandler:^{
-        [[BTLogger sharedLogger] warning:@"Analytics service background task expired"];
-        [application endBackgroundTask:bgTask];
-        bgTask = UIBackgroundTaskInvalid;
-    }];
-    
-    // Start the long-running task and return immediately.
-    dispatch_async(self.sessionsQueue, ^{
-        [self flush:^(__unused NSError * _Nullable error) {
-            [application endBackgroundTask:bgTask];
-            bgTask = UIBackgroundTaskInvalid;
-        }];
-    });
 }
 
 #pragma mark - Helpers

--- a/Sources/BraintreeCore/BTHTTP.m
+++ b/Sources/BraintreeCore/BTHTTP.m
@@ -157,7 +157,7 @@
             cachedResponse = nil;
         }
         
-        dispatch_after(0.2, dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             if (cachedResponse != nil) {
                 [self handleRequestCompletion:cachedResponse.data request:nil shouldCache:NO response:cachedResponse.response error:nil completionBlock:completionBlock];
             } else {

--- a/Sources/BraintreeCore/BTHTTP.m
+++ b/Sources/BraintreeCore/BTHTTP.m
@@ -156,15 +156,17 @@
             [[NSURLCache sharedURLCache] removeAllCachedResponses];
             cachedResponse = nil;
         }
-
-        if (cachedResponse != nil) {
-            [self handleRequestCompletion:cachedResponse.data request:nil shouldCache:NO response:cachedResponse.response error:nil completionBlock:completionBlock];
-        } else {
-            NSURLSessionTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                [self handleRequestCompletion:data request:request shouldCache:YES response:response error:error completionBlock:completionBlock];
-            }];
-            [task resume];
-        }
+        
+        dispatch_after(0.2, dispatch_get_main_queue(), ^{
+            if (cachedResponse != nil) {
+                [self handleRequestCompletion:cachedResponse.data request:nil shouldCache:NO response:cachedResponse.response error:nil completionBlock:completionBlock];
+            } else {
+                NSURLSessionTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                    [self handleRequestCompletion:data request:request shouldCache:YES response:response error:error completionBlock:completionBlock];
+                }];
+                [task resume];
+            }
+        });
     }];
 }
 

--- a/Sources/BraintreeCore/BTHTTP.m
+++ b/Sources/BraintreeCore/BTHTTP.m
@@ -157,6 +157,8 @@
             cachedResponse = nil;
         }
         
+        // The increase in speed of API calls with cached configuration caused an increase in "network connection lost" errors.
+        // Adding this delay allows us to throttle the network requests slightly to reduce load on the servers and decrease connection lost errors.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             if (cachedResponse != nil) {
                 [self handleRequestCompletion:cachedResponse.data request:nil shouldCache:NO response:cachedResponse.response error:nil completionBlock:completionBlock];

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -159,6 +159,9 @@ static BTVenmoDriver *appSwitchedDriver;
 
             [self.apiClient POST:@"" parameters:params httpType:BTAPIClientHTTPTypeGraphQLAPI completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *err) {
                 if (err) {
+                    if ([err.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                        [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
+                    }
                     NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
                                                          code:BTVenmoDriverErrorTypeInvalidRequestURL
                                                      userInfo:@{NSLocalizedDescriptionKey: @"Failed to fetch a Venmo paymentContextID while constructing the requestURL."}];
@@ -210,6 +213,9 @@ static BTVenmoDriver *appSwitchedDriver;
               parameters:params
               completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
                   if (error) {
+                      if ([error.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                          [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
+                      }
                       [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.vault.failure"];
                       self.appSwitchCompletionBlock(nil, error);
                   } else {
@@ -280,6 +286,9 @@ static BTVenmoDriver *appSwitchedDriver;
 
             [self.apiClient POST:@"" parameters:params httpType:BTAPIClientHTTPTypeGraphQLAPI completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
                 if (error) {
+                    if ([error.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                        [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
+                    }
                     [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.appswitch.handle.client-failure"];
                     self.appSwitchCompletionBlock(nil, error);
                     self.appSwitchCompletionBlock = nil;

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -160,7 +160,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
             [self.apiClient POST:@"" parameters:params httpType:BTAPIClientHTTPTypeGraphQLAPI completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *err) {
                 if (err) {
-                    if (error.code == NetworkConnectionLostCode) {
+                    if (err.code == NetworkConnectionLostCode) {
                         [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
                     }
                     NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -35,6 +35,7 @@
 
 NSString * const BTVenmoDriverErrorDomain = @"com.braintreepayments.BTVenmoDriverErrorDomain";
 NSString * const BTVenmoAppStoreUrl = @"https://itunes.apple.com/us/app/venmo-send-receive-money/id351727428";
+NSInteger const NetworkConnectionLostCode = -1005;
 
 @implementation BTVenmoDriver
 
@@ -159,7 +160,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
             [self.apiClient POST:@"" parameters:params httpType:BTAPIClientHTTPTypeGraphQLAPI completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *err) {
                 if (err) {
-                    if ([err.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                    if (error.code == NetworkConnectionLostCode) {
                         [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
                     }
                     NSError *error = [NSError errorWithDomain:BTVenmoDriverErrorDomain
@@ -213,7 +214,7 @@ static BTVenmoDriver *appSwitchedDriver;
               parameters:params
               completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
                   if (error) {
-                      if ([error.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                      if (error.code == NetworkConnectionLostCode) {
                           [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
                       }
                       [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.vault.failure"];
@@ -286,7 +287,7 @@ static BTVenmoDriver *appSwitchedDriver;
 
             [self.apiClient POST:@"" parameters:params httpType:BTAPIClientHTTPTypeGraphQLAPI completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, NSError *error) {
                 if (error) {
-                    if ([error.localizedDescription isEqualToString:@"The network connection was lost."]) {
+                    if (error.code == NetworkConnectionLostCode) {
                         [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.network-connection.failure"];
                     }
                     [self.apiClient sendAnalyticsEvent:@"ios.pay-with-venmo.appswitch.handle.client-failure"];

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -60,10 +60,6 @@ static BTVenmoDriver *appSwitchedDriver;
     return nil;
 }
 
-- (void)setAppSwitchedDriver {
-    appSwitchedDriver = self;
-}
-
 #pragma mark - Accessors
 
 - (id)application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -60,6 +60,10 @@ static BTVenmoDriver *appSwitchedDriver;
     return nil;
 }
 
+- (void)setAppSwitchedDriver {
+    appSwitchedDriver = self;
+}
+
 #pragma mark - Accessors
 
 - (id)application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {

--- a/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTAnalyticsMetadataSpec.m
@@ -71,7 +71,7 @@ describe(@"metadata", ^{
     });
     describe(@"deviceModel", ^{
         it(@"returns the device model", ^{
-            expect([BTAnalyticsMetadata metadata][@"deviceModel"]).to.match(@"iPhone\\d,\\d|i386|x86_64");
+            expect([BTAnalyticsMetadata metadata][@"deviceModel"]).to.match(@"iPhone\\d,\\d|i386|x86_64|arm64");
         });
     });
 

--- a/UnitTests/BraintreeCoreTests/BTAnalyticsService_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTAnalyticsService_Tests.m
@@ -224,33 +224,6 @@
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
-- (void)testAnalyticsService_whenAppIsBackgrounded_sendsQueuedAnalyticsEvents {
-    MockAPIClient *stubAPIClient = [self stubbedAPIClientWithAnalyticsURL:@"test://do-not-send.url"];
-    FakeHTTP *mockAnalyticsHTTP = [FakeHTTP fakeHTTP];
-    BTAnalyticsService *analyticsService = [[BTAnalyticsService alloc] initWithAPIClient:stubAPIClient];
-    analyticsService.flushThreshold = 5;
-    analyticsService.http = mockAnalyticsHTTP;
-    
-    [analyticsService sendAnalyticsEvent:@"an.analytics.event"];
-    [analyticsService sendAnalyticsEvent:@"another.analytics.event"];
-    // Pause briefly to allow analytics service to dispatch async blocks
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-    
-    XCTAssertTrue(mockAnalyticsHTTP.POSTRequestCount == 1);
-    XCTAssertEqualObjects(mockAnalyticsHTTP.lastRequestEndpoint, @"/");
-    XCTAssertEqualObjects(mockAnalyticsHTTP.lastRequestParameters[@"analytics"][0][@"kind"], @"an.analytics.event");
-    XCTAssertGreaterThanOrEqual([mockAnalyticsHTTP.lastRequestParameters[@"analytics"][0][@"timestamp"] unsignedIntegerValue], self.currentTime);
-    XCTAssertLessThanOrEqual([mockAnalyticsHTTP.lastRequestParameters[@"analytics"][0][@"timestamp"] unsignedIntegerValue], self.oneSecondLater);
-
-    XCTAssertEqualObjects(mockAnalyticsHTTP.lastRequestParameters[@"analytics"][1][@"kind"], @"another.analytics.event");
-    XCTAssertGreaterThanOrEqual([mockAnalyticsHTTP.lastRequestParameters[@"analytics"][1][@"timestamp"] unsignedIntegerValue], self.currentTime);
-    XCTAssertLessThanOrEqual([mockAnalyticsHTTP.lastRequestParameters[@"analytics"][1][@"timestamp"] unsignedIntegerValue], self.oneSecondLater);
-    [self validateMetaParameters:mockAnalyticsHTTP.lastRequestParameters[@"_meta"]];
-}
-
 #pragma mark - Helpers
 
 - (MockAPIClient *)stubbedAPIClientWithAnalyticsURL:(NSString *)analyticsURL {

--- a/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
@@ -413,6 +413,7 @@ NSURLSession *testURLSession(void) {
 }
 
 - (void)testGETRequests_whenShouldNotCache_doesNotStoreInCache {
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
     waitUntil(^(DoneCallback done){
         [self->http GET:@"/configuration" parameters:@{ @"configVersion": @"3" } shouldCache:NO completion:^(BTJSON *body, NSHTTPURLResponse *response, NSError *error) {
             XCTAssertNotNil(body);

--- a/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
+++ b/UnitTests/BraintreeCoreTests/BTHTTPSpec.m
@@ -61,6 +61,7 @@ NSURLSession *testURLSession(void) {
 
     http = [[BTHTTP alloc] initWithBaseURL:[BTHTTPTestProtocol testBaseURL] authorizationFingerprint:@"test-authorization-fingerprint"];
     http.session = testURLSession();
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 - (void)tearDown {
@@ -410,6 +411,7 @@ NSURLSession *testURLSession(void) {
             done();
         }];
     });
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 - (void)testGETRequests_whenShouldNotCache_doesNotStoreInCache {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -633,21 +633,6 @@ class BTVenmoDriver_Tests: XCTestCase {
         
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
     }
-    
-    func testHandleOpenURL_whenNetworkConnectionLost_sendsAnalytics() {
-        mockAPIClient.cannedResponseError = NSError(domain: NSURLErrorDomain, code: -1005, userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
-        venmoRequest.paymentMethodUsage = .multiUse
-        
-        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
-        venmoDriver.
-        venmoDriver.application = FakeApplication()
-        venmoDriver.bundle = FakeBundle()
-        venmoDriver.returnURLScheme = "scheme"
-
-        BTVenmoDriver.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
-
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
-    }
 
     // MARK: - BTAppContextSwitchDriver
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -614,6 +614,40 @@ class BTVenmoDriver_Tests: XCTestCase {
         
         XCTAssertEqual(venmoDriver.apiClient.metadata.integration, BTClientMetadataIntegrationType.custom)
     }
+    
+    func testTokenizeVenmoAccount_whenNetworkConnectionLost_sendsAnalytics() {
+        mockAPIClient.cannedResponseError = NSError(domain: NSURLErrorDomain, code: -1005, userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
+        venmoRequest.paymentMethodUsage = .multiUse
+        
+        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
+        venmoDriver.application = FakeApplication()
+        venmoDriver.bundle = FakeBundle()
+        venmoDriver.returnURLScheme = "scheme"
+
+        let expectation = self.expectation(description: "Callback invoked")
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { nonce, error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+        
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
+    }
+    
+    func testHandleOpenURL_whenNetworkConnectionLost_sendsAnalytics() {
+        mockAPIClient.cannedResponseError = NSError(domain: NSURLErrorDomain, code: -1005, userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
+        venmoRequest.paymentMethodUsage = .multiUse
+        
+        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
+        venmoDriver.
+        venmoDriver.application = FakeApplication()
+        venmoDriver.bundle = FakeBundle()
+        venmoDriver.returnURLScheme = "scheme"
+
+        BTVenmoDriver.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
+
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
+    }
 
     // MARK: - BTAppContextSwitchDriver
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -633,7 +633,7 @@ class BTVenmoDriver_Tests: XCTestCase {
         
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
     }
-
+    
     // MARK: - BTAppContextSwitchDriver
 
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenVenmoURL_returnsTrue() {


### PR DESCRIPTION
### Summary of changes

- Update demo app to vault Venmo and use Payment Context
- Update demo app to not embed & sign Magnes framework (static framework should not be embedded)
- Update configuration cache request policy
- Moved logic for dispatch queue of configuration calls
- Remove unnecessary flushing of analytics when app enters background
- Throttle requests for configuration to reduce load on servers and network connection lost errors
- Add analytics events for network connection lost errors in Venmo flow

**Note:** The scope of impact for this is older devices running older iOS and Venmo app versions

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @sarahkoop 
