### PR TITLE
Create temporary `BraintreeCoreSwift` module

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |s|
     s.source_files  = "Sources/BraintreeCore/**/*.{h,m}"
     s.public_header_files = "Sources/BraintreeCore/Public/BraintreeCore/*.h"
-    s.dependency = "Braintree/CoreSwift"
+    s.dependency "Braintree/CoreSwift"
   end
 
   s.subspec "CoreSwift" do |s|

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -42,6 +42,11 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |s|
     s.source_files  = "Sources/BraintreeCore/**/*.{h,m}"
     s.public_header_files = "Sources/BraintreeCore/Public/BraintreeCore/*.h"
+    s.depencency = "Braintree/CoreSwift"
+  end
+
+  s.subspect "CoreSwift" do |s|
+    s.source_files = "Sources/BraintreeCoreSwift/*.swift"
   end
 
   s.subspec "DataCollector" do |s|

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |s|
     s.source_files  = "Sources/BraintreeCore/**/*.{h,m}"
     s.public_header_files = "Sources/BraintreeCore/Public/BraintreeCore/*.h"
-    s.depencency = "Braintree/CoreSwift"
+    s.dependency = "Braintree/CoreSwift"
   end
 
   s.subspect "CoreSwift" do |s|

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
     s.dependency = "Braintree/CoreSwift"
   end
 
-  s.subspect "CoreSwift" do |s|
+  s.subspec "CoreSwift" do |s|
     s.source_files = "Sources/BraintreeCoreSwift/*.swift"
   end
 

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		42FC234325CE0A400047C49A /* BTPayPalCheckoutRequest_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FC234225CE0A400047C49A /* BTPayPalCheckoutRequest_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
+		570B93B02853980C0041BAFE /* BTAPIClientSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B93AF2853980C0041BAFE /* BTAPIClientSwift.swift */; };
 		800FC544257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */; };
 		8016A87D2509185C00DB5EF3 /* BTPaymentFlow_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8016A87C2509185C00DB5EF3 /* BTPaymentFlow_Tests.swift */; };
 		804B5712275AAF8500E51A52 /* BTAmericanExpressRewardsBalance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804B5711275AAF8500E51A52 /* BTAmericanExpressRewardsBalance.swift */; };
@@ -801,6 +802,8 @@
 		42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
+		570B93AC285397520041BAFE /* BraintreeCoreSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreeCoreSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		570B93AF2853980C0041BAFE /* BTAPIClientSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAPIClientSwift.swift; sourceTree = "<group>"; };
 		59A4135427B90CD7AE94D5CC /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		80036F7B21F7BAC6003A9F5C /* BTConfiguration+ThreeDSecure.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BTConfiguration+ThreeDSecure.h"; sourceTree = "<group>"; };
 		80036F7C21F7BB7F003A9F5C /* BTConfiguration+ThreeDSecure.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "BTConfiguration+ThreeDSecure.m"; sourceTree = "<group>"; };
@@ -1085,6 +1088,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				4164B9B11C9B68CC006AE861 /* BraintreeCard.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		570B9385285397520041BAFE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1538,6 +1548,14 @@
 			path = BraintreeThreeDSecure;
 			sourceTree = "<group>";
 		};
+		570B93AE285397D20041BAFE /* BraintreeCoreSwift */ = {
+			isa = PBXGroup;
+			children = (
+				570B93AF2853980C0041BAFE /* BTAPIClientSwift.swift */,
+			);
+			path = BraintreeCoreSwift;
+			sourceTree = "<group>";
+		};
 		6A50887E9E10BEB122A9F45D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1571,13 +1589,14 @@
 				A7C889751B5EF5DE007A0E9C /* BraintreeApplePay */,
 				A7C889911B5F043B007A0E9C /* BraintreeCard */,
 				2DE12F0A1B59BE0100EA1BCF /* BraintreeCore */,
+				570B93AE285397D20041BAFE /* BraintreeCoreSwift */,
 				A76D7C011BB1CAB00000FA6A /* BraintreeDataCollector */,
+				BEA1B425284167AE00994F61 /* BraintreeKountDataCollector */,
 				038C7FBB1EA1648900241ABE /* BraintreePaymentFlow */,
 				2D941D391B59C76A0016EFB4 /* BraintreePayPal */,
 				A91E1EAC24FEEF21007540E5 /* BraintreeThreeDSecure */,
 				4164B9891C9B6553006AE861 /* BraintreeUnionPay */,
 				A7C889F01B5F0B30007A0E9C /* BraintreeVenmo */,
-				BEA1B425284167AE00994F61 /* BraintreeKountDataCollector */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1661,6 +1680,7 @@
 				A91E1EAB24FEEF21007540E5 /* BraintreeThreeDSecure.framework */,
 				A91E1EF224FEF2E3007540E5 /* BraintreeThreeDSecureTests.xctest */,
 				BEA1B4232841679200994F61 /* BraintreeKountDataCollector.framework */,
+				570B93AC285397520041BAFE /* BraintreeCoreSwift.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2128,6 +2148,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		570B9386285397520041BAFE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A76D7BFD1BB1CAB00000FA6A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2331,6 +2358,24 @@
 			name = BraintreeUnionPay;
 			productName = BraintreeCard;
 			productReference = 4164B9AC1C9B658E006AE861 /* BraintreeUnionPay.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		570B936A285397520041BAFE /* BraintreeCoreSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 570B93A9285397520041BAFE /* Build configuration list for PBXNativeTarget "BraintreeCoreSwift" */;
+			buildPhases = (
+				570B936B285397520041BAFE /* Sources */,
+				570B9385285397520041BAFE /* Frameworks */,
+				570B9386285397520041BAFE /* Headers */,
+				570B93A8285397520041BAFE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BraintreeCoreSwift;
+			productName = BraintreeCore;
+			productReference = 570B93AC285397520041BAFE /* BraintreeCoreSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		A76D7BFF1BB1CAB00000FA6A /* BraintreeDataCollector */ = {
@@ -2715,6 +2760,9 @@
 					2DE12F081B59BE0100EA1BCF = {
 						CreatedOnToolsVersion = 7.0;
 					};
+					570B936A285397520041BAFE = {
+						LastSwiftMigration = 1340;
+					};
 					A76D7BFF1BB1CAB00000FA6A = {
 						CreatedOnToolsVersion = 7.0;
 						LastSwiftMigration = 1340;
@@ -2791,6 +2839,7 @@
 				A948D6DB24FAC6C000F4F178 /* BraintreeApplePayTests */,
 				A7C8898F1B5F043B007A0E9C /* BraintreeCard */,
 				A95C410724FAEF2100045045 /* BraintreeCardTests */,
+				570B936A285397520041BAFE /* BraintreeCoreSwift */,
 				2DE12F081B59BE0100EA1BCF /* BraintreeCore */,
 				A9E5C22324FD6D0800EE691F /* BraintreeCoreTests */,
 				A76D7BFF1BB1CAB00000FA6A /* BraintreeDataCollector */,
@@ -2842,6 +2891,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4164B9A81C9B658E006AE861 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		570B93A8285397520041BAFE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3151,6 +3207,14 @@
 				4164B9BB1C9B6988006AE861 /* BTCardClient+UnionPay.m in Sources */,
 				A77426581CA20793003CACBA /* BTCardCapabilities.m in Sources */,
 				41472F951CB6D52200AFA75C /* BTConfiguration+UnionPay.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		570B936B285397520041BAFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				570B93B02853980C0041BAFE /* BTAPIClientSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4216,6 +4280,127 @@
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		570B93AA285397520041BAFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREFIX_HEADER = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.BraintreeCoreSwift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		570B93AB285397520041BAFE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.BraintreeCoreSwift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -6217,6 +6402,15 @@
 			buildConfigurations = (
 				4164B9AA1C9B658E006AE861 /* Debug */,
 				4164B9AB1C9B658E006AE861 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		570B93A9285397520041BAFE /* Build configuration list for PBXNativeTarget "BraintreeCoreSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				570B93AA285397520041BAFE /* Debug */,
+				570B93AB285397520041BAFE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/BraintreeCoreSwift.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/BraintreeCoreSwift.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "570B936A285397520041BAFE"
+               BuildableName = "BraintreeCoreSwift.framework"
+               BlueprintName = "BraintreeCoreSwift"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "570B936A285397520041BAFE"
+            BuildableName = "BraintreeCoreSwift.framework"
+            BlueprintName = "BraintreeCoreSwift"
+            ReferencedContainer = "container:Braintree.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574D425FA6CAC008B3681 /* AppSwitcher.swift */; };
 		42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */; };
 		42D47A152554679D0012BAF1 /* BraintreeDemoSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */; };
+		570B93D42853A6D30041BAFE /* BraintreeCoreSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93D32853A6D30041BAFE /* BraintreeCoreSwift.framework */; };
+		570B93D52853A6D30041BAFE /* BraintreeCoreSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93D32853A6D30041BAFE /* BraintreeCoreSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		803D64F5256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */; };
 		803D64F6256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		803D64F7256DAF9A00ACE692 /* BraintreeApplePay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 803D64EB256DAF9A00ACE692 /* BraintreeApplePay.framework */; };
@@ -104,6 +106,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				803D64F6256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Embed Frameworks */,
+				570B93D52853A6D30041BAFE /* BraintreeCoreSwift.framework in Embed Frameworks */,
 				9C36BD4D26B311D900F0A559 /* CardinalMobile.xcframework in Embed Frameworks */,
 				803D6508256DAF9A00ACE692 /* BraintreeVenmo.framework in Embed Frameworks */,
 				803D64FA256DAF9A00ACE692 /* BraintreeCard.framework in Embed Frameworks */,
@@ -138,6 +141,7 @@
 		42D47A132554679D0012BAF1 /* BraintreeDemoSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoSceneDelegate.h; sourceTree = "<group>"; };
 		42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoSceneDelegate.m; sourceTree = "<group>"; };
 		42F3F6DB2603B83100401B0D /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../Frameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
+		570B93D32853A6D30041BAFE /* BraintreeCoreSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeCoreSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73498B4265CA7D315E2FBF38 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeAmericanExpress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -226,6 +230,7 @@
 				803D64FB256DAF9A00ACE692 /* BraintreeCore.framework in Frameworks */,
 				9C36BD4C26B311D900F0A559 /* CardinalMobile.xcframework in Frameworks */,
 				803D64F5256DAF9A00ACE692 /* BraintreeAmericanExpress.framework in Frameworks */,
+				570B93D42853A6D30041BAFE /* BraintreeCoreSwift.framework in Frameworks */,
 				9C36BD2926B3071B00F0A559 /* PPRiskMagnes.xcframework in Frameworks */,
 				803D6501256DAF9A00ACE692 /* BraintreePayPal.framework in Frameworks */,
 				803D64FD256DAF9A00ACE692 /* BraintreeDataCollector.framework in Frameworks */,
@@ -508,6 +513,7 @@
 		A0988FFB24DB44D60095EEEE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				570B93D32853A6D30041BAFE /* BraintreeCoreSwift.framework */,
 				BE57E114284912D6002CFBAC /* BraintreeKountDataCollector.framework */,
 				BEA1B42728416C5800994F61 /* KountDataCollector.framework */,
 				9C36BD2826B3071A00F0A559 /* PPRiskMagnes.xcframework */,

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,11 @@ let package = Package(
         ),
         .library(
             name: "BraintreeCore",
-            targets: ["BraintreeCore"]
+            targets: ["BraintreeCore", "BraintreeCoreSwift"]
+        ),
+        .library(
+            name: "BraintreeCoreSwift",
+            targets: ["BraintreeCoreSwift"]
         ),
         .library(
             name: "BraintreeDataCollector",
@@ -74,8 +78,13 @@ let package = Package(
         ),
         .target(
             name: "BraintreeCore",
+            dependencies: ["BraintreeCoreSwift"],
             exclude: ["Info.plist"],
             publicHeadersPath: "Public"
+        ),
+        .target(
+            name: "BraintreeCoreSwift",
+            dependencies: []
         ),
         .target(
             name: "BraintreeDataCollector",

--- a/Package.swift
+++ b/Package.swift
@@ -83,8 +83,7 @@ let package = Package(
             publicHeadersPath: "Public"
         ),
         .target(
-            name: "BraintreeCoreSwift",
-            dependencies: []
+            name: "BraintreeCoreSwift"
         ),
         .target(
             name: "BraintreeDataCollector",

--- a/SampleApps/CarthageTest/Cartfile
+++ b/SampleApps/CarthageTest/Cartfile
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" "next-major-version"
+github "braintree/braintree_ios" "create-temporary-braintree-core-swift-module"

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		429925C0266189020085F77D /* BraintreePayPal.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A7266189010085F77D /* BraintreePayPal.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */; };
 		429925C2266189020085F77D /* BraintreeThreeDSecure.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		570B93B22853A0A30041BAFE /* BraintreeCoreSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93B12853A0A30041BAFE /* BraintreeCoreSwift.xcframework */; };
+		570B93B32853A0A30041BAFE /* BraintreeCoreSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93B12853A0A30041BAFE /* BraintreeCoreSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A74D4AF51BFBB3FB00BF36CD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74D4AF41BFBB3FB00BF36CD /* AppDelegate.swift */; };
 		A74D4AF71BFBB3FB00BF36CD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74D4AF61BFBB3FB00BF36CD /* ViewController.swift */; };
 		A74D4AFA1BFBB3FB00BF36CD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74D4AF81BFBB3FB00BF36CD /* Main.storyboard */; };
@@ -60,6 +62,7 @@
 				429925C2266189020085F77D /* BraintreeThreeDSecure.xcframework in Embed Frameworks */,
 				429925AE266189010085F77D /* BraintreeDataCollector.xcframework in Embed Frameworks */,
 				429925AC266189010085F77D /* BraintreeAmericanExpress.xcframework in Embed Frameworks */,
+				570B93B32853A0A30041BAFE /* BraintreeCoreSwift.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -79,6 +82,7 @@
 		429925A6266189010085F77D /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = Carthage/Build/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		429925A7266189010085F77D /* BraintreePayPal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPal.xcframework; path = Carthage/Build/BraintreePayPal.xcframework; sourceTree = "<group>"; };
 		429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeThreeDSecure.xcframework; path = Carthage/Build/BraintreeThreeDSecure.xcframework; sourceTree = "<group>"; };
+		570B93B12853A0A30041BAFE /* BraintreeCoreSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeCoreSwift.xcframework; path = Carthage/Build/BraintreeCoreSwift.xcframework; sourceTree = "<group>"; };
 		A74D4AF11BFBB3FB00BF36CD /* CarthageTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarthageTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A74D4AF41BFBB3FB00BF36CD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A74D4AF61BFBB3FB00BF36CD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -108,6 +112,7 @@
 				429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */,
 				429925AD266189010085F77D /* BraintreeDataCollector.xcframework in Frameworks */,
 				429925AB266189010085F77D /* BraintreeAmericanExpress.xcframework in Frameworks */,
+				570B93B22853A0A30041BAFE /* BraintreeCoreSwift.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,6 +122,7 @@
 		03BFA5C81FB2F0BB0003ABCE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				570B93B12853A0A30041BAFE /* BraintreeCoreSwift.xcframework */,
 				BE57E13028491ED2002CFBAC /* BraintreeKountDataCollector.xcframework */,
 				BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */,
 				4299259D266189010085F77D /* BraintreeAmericanExpress.xcframework */,

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -3,6 +3,7 @@ import BraintreeAmericanExpress
 import BraintreeApplePay
 import BraintreeCard
 import BraintreeCore
+import BraintreeCoreSwift
 import BraintreeDataCollector
 import BraintreePaymentFlow
 import BraintreePayPal

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -7,23 +7,24 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		570B93BC2853A6A40041BAFE /* BraintreeAmericanExpress in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */; };
+		570B93BE2853A6A40041BAFE /* BraintreeApplePay in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BD2853A6A40041BAFE /* BraintreeApplePay */; };
+		570B93C02853A6A40041BAFE /* BraintreeCard in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BF2853A6A40041BAFE /* BraintreeCard */; };
+		570B93C22853A6A40041BAFE /* BraintreeCore in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C12853A6A40041BAFE /* BraintreeCore */; };
+		570B93C42853A6A40041BAFE /* BraintreeCoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C32853A6A40041BAFE /* BraintreeCoreSwift */; };
+		570B93C62853A6A40041BAFE /* BraintreeDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C52853A6A40041BAFE /* BraintreeDataCollector */; };
+		570B93C82853A6A40041BAFE /* BraintreeKountDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */; };
+		570B93CA2853A6A40041BAFE /* BraintreePayPal in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C92853A6A40041BAFE /* BraintreePayPal */; };
+		570B93CC2853A6A40041BAFE /* BraintreePaymentFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */; };
+		570B93CE2853A6A40041BAFE /* BraintreeThreeDSecure in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */; };
+		570B93D02853A6A40041BAFE /* BraintreeUnionPay in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CF2853A6A40041BAFE /* BraintreeUnionPay */; };
+		570B93D22853A6A40041BAFE /* BraintreeVenmo in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93D12853A6A40041BAFE /* BraintreeVenmo */; };
 		80214E042551FB5A00695A6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E032551FB5A00695A6F /* AppDelegate.swift */; };
 		80214E062551FB5A00695A6F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E052551FB5A00695A6F /* SceneDelegate.swift */; };
 		80214E082551FB5A00695A6F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E072551FB5A00695A6F /* ViewController.swift */; };
 		80214E0B2551FB5A00695A6F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80214E092551FB5A00695A6F /* Main.storyboard */; };
 		80214E0D2551FB5C00695A6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80214E0C2551FB5C00695A6F /* Assets.xcassets */; };
 		80214E102551FB5C00695A6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80214E0E2551FB5C00695A6F /* LaunchScreen.storyboard */; };
-		BE70A968284FBAC500F6D3F7 /* BraintreeAmericanExpress in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A967284FBAC500F6D3F7 /* BraintreeAmericanExpress */; };
-		BE70A96A284FBAC500F6D3F7 /* BraintreeApplePay in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A969284FBAC500F6D3F7 /* BraintreeApplePay */; };
-		BE70A96C284FBAC500F6D3F7 /* BraintreeCard in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A96B284FBAC500F6D3F7 /* BraintreeCard */; };
-		BE70A96E284FBAC500F6D3F7 /* BraintreeCore in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A96D284FBAC500F6D3F7 /* BraintreeCore */; };
-		BE70A970284FBAC500F6D3F7 /* BraintreeDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A96F284FBAC500F6D3F7 /* BraintreeDataCollector */; };
-		BE70A972284FBAC500F6D3F7 /* BraintreeKountDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A971284FBAC500F6D3F7 /* BraintreeKountDataCollector */; };
-		BE70A974284FBAC500F6D3F7 /* BraintreePayPal in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A973284FBAC500F6D3F7 /* BraintreePayPal */; };
-		BE70A976284FBAC500F6D3F7 /* BraintreePaymentFlow in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A975284FBAC500F6D3F7 /* BraintreePaymentFlow */; };
-		BE70A978284FBAC500F6D3F7 /* BraintreeThreeDSecure in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A977284FBAC500F6D3F7 /* BraintreeThreeDSecure */; };
-		BE70A97A284FBAC500F6D3F7 /* BraintreeUnionPay in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A979284FBAC500F6D3F7 /* BraintreeUnionPay */; };
-		BE70A97C284FBAC500F6D3F7 /* BraintreeVenmo in Frameworks */ = {isa = PBXBuildFile; productRef = BE70A97B284FBAC500F6D3F7 /* BraintreeVenmo */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,17 +44,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE70A97C284FBAC500F6D3F7 /* BraintreeVenmo in Frameworks */,
-				BE70A970284FBAC500F6D3F7 /* BraintreeDataCollector in Frameworks */,
-				BE70A96C284FBAC500F6D3F7 /* BraintreeCard in Frameworks */,
-				BE70A97A284FBAC500F6D3F7 /* BraintreeUnionPay in Frameworks */,
-				BE70A968284FBAC500F6D3F7 /* BraintreeAmericanExpress in Frameworks */,
-				BE70A96E284FBAC500F6D3F7 /* BraintreeCore in Frameworks */,
-				BE70A96A284FBAC500F6D3F7 /* BraintreeApplePay in Frameworks */,
-				BE70A974284FBAC500F6D3F7 /* BraintreePayPal in Frameworks */,
-				BE70A978284FBAC500F6D3F7 /* BraintreeThreeDSecure in Frameworks */,
-				BE70A976284FBAC500F6D3F7 /* BraintreePaymentFlow in Frameworks */,
-				BE70A972284FBAC500F6D3F7 /* BraintreeKountDataCollector in Frameworks */,
+				570B93C42853A6A40041BAFE /* BraintreeCoreSwift in Frameworks */,
+				570B93C02853A6A40041BAFE /* BraintreeCard in Frameworks */,
+				570B93CA2853A6A40041BAFE /* BraintreePayPal in Frameworks */,
+				570B93D22853A6A40041BAFE /* BraintreeVenmo in Frameworks */,
+				570B93BC2853A6A40041BAFE /* BraintreeAmericanExpress in Frameworks */,
+				570B93C22853A6A40041BAFE /* BraintreeCore in Frameworks */,
+				570B93C82853A6A40041BAFE /* BraintreeKountDataCollector in Frameworks */,
+				570B93CE2853A6A40041BAFE /* BraintreeThreeDSecure in Frameworks */,
+				570B93BE2853A6A40041BAFE /* BraintreeApplePay in Frameworks */,
+				570B93D02853A6A40041BAFE /* BraintreeUnionPay in Frameworks */,
+				570B93CC2853A6A40041BAFE /* BraintreePaymentFlow in Frameworks */,
+				570B93C62853A6A40041BAFE /* BraintreeDataCollector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,17 +118,18 @@
 			);
 			name = SPMTest;
 			packageProductDependencies = (
-				BE70A967284FBAC500F6D3F7 /* BraintreeAmericanExpress */,
-				BE70A969284FBAC500F6D3F7 /* BraintreeApplePay */,
-				BE70A96B284FBAC500F6D3F7 /* BraintreeCard */,
-				BE70A96D284FBAC500F6D3F7 /* BraintreeCore */,
-				BE70A96F284FBAC500F6D3F7 /* BraintreeDataCollector */,
-				BE70A971284FBAC500F6D3F7 /* BraintreeKountDataCollector */,
-				BE70A973284FBAC500F6D3F7 /* BraintreePayPal */,
-				BE70A975284FBAC500F6D3F7 /* BraintreePaymentFlow */,
-				BE70A977284FBAC500F6D3F7 /* BraintreeThreeDSecure */,
-				BE70A979284FBAC500F6D3F7 /* BraintreeUnionPay */,
-				BE70A97B284FBAC500F6D3F7 /* BraintreeVenmo */,
+				570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */,
+				570B93BD2853A6A40041BAFE /* BraintreeApplePay */,
+				570B93BF2853A6A40041BAFE /* BraintreeCard */,
+				570B93C12853A6A40041BAFE /* BraintreeCore */,
+				570B93C32853A6A40041BAFE /* BraintreeCoreSwift */,
+				570B93C52853A6A40041BAFE /* BraintreeDataCollector */,
+				570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */,
+				570B93C92853A6A40041BAFE /* BraintreePayPal */,
+				570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */,
+				570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */,
+				570B93CF2853A6A40041BAFE /* BraintreeUnionPay */,
+				570B93D12853A6A40041BAFE /* BraintreeVenmo */,
 			);
 			productName = SPMTest;
 			productReference = 80214E002551FB5A00695A6F /* SPMTest.app */;
@@ -156,7 +159,7 @@
 			);
 			mainGroup = 80214DF72551FB5A00695A6F;
 			packageReferences = (
-				BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */,
+				570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */,
 			);
 			productRefGroup = 80214E012551FB5A00695A6F /* Products */;
 			projectDirPath = "";
@@ -404,70 +407,75 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */ = {
+		570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braintree/braintree_ios";
 			requirement = {
-				branch = "next-major-version";
+				branch = "create-temporary-braintree-core-swift-module";
 				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		BE70A967284FBAC500F6D3F7 /* BraintreeAmericanExpress */ = {
+		570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeAmericanExpress;
 		};
-		BE70A969284FBAC500F6D3F7 /* BraintreeApplePay */ = {
+		570B93BD2853A6A40041BAFE /* BraintreeApplePay */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeApplePay;
 		};
-		BE70A96B284FBAC500F6D3F7 /* BraintreeCard */ = {
+		570B93BF2853A6A40041BAFE /* BraintreeCard */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeCard;
 		};
-		BE70A96D284FBAC500F6D3F7 /* BraintreeCore */ = {
+		570B93C12853A6A40041BAFE /* BraintreeCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeCore;
 		};
-		BE70A96F284FBAC500F6D3F7 /* BraintreeDataCollector */ = {
+		570B93C32853A6A40041BAFE /* BraintreeCoreSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			productName = BraintreeCoreSwift;
+		};
+		570B93C52853A6A40041BAFE /* BraintreeDataCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeDataCollector;
 		};
-		BE70A971284FBAC500F6D3F7 /* BraintreeKountDataCollector */ = {
+		570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeKountDataCollector;
 		};
-		BE70A973284FBAC500F6D3F7 /* BraintreePayPal */ = {
+		570B93C92853A6A40041BAFE /* BraintreePayPal */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreePayPal;
 		};
-		BE70A975284FBAC500F6D3F7 /* BraintreePaymentFlow */ = {
+		570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreePaymentFlow;
 		};
-		BE70A977284FBAC500F6D3F7 /* BraintreeThreeDSecure */ = {
+		570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeThreeDSecure;
 		};
-		BE70A979284FBAC500F6D3F7 /* BraintreeUnionPay */ = {
+		570B93CF2853A6A40041BAFE /* BraintreeUnionPay */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeUnionPay;
 		};
-		BE70A97B284FBAC500F6D3F7 /* BraintreeVenmo */ = {
+		570B93D12853A6A40041BAFE /* BraintreeVenmo */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BE70A966284FBAC500F6D3F7 /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeVenmo;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -7,18 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		570B93BC2853A6A40041BAFE /* BraintreeAmericanExpress in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */; };
-		570B93BE2853A6A40041BAFE /* BraintreeApplePay in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BD2853A6A40041BAFE /* BraintreeApplePay */; };
-		570B93C02853A6A40041BAFE /* BraintreeCard in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93BF2853A6A40041BAFE /* BraintreeCard */; };
-		570B93C22853A6A40041BAFE /* BraintreeCore in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C12853A6A40041BAFE /* BraintreeCore */; };
-		570B93C42853A6A40041BAFE /* BraintreeCoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C32853A6A40041BAFE /* BraintreeCoreSwift */; };
-		570B93C62853A6A40041BAFE /* BraintreeDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C52853A6A40041BAFE /* BraintreeDataCollector */; };
-		570B93C82853A6A40041BAFE /* BraintreeKountDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */; };
-		570B93CA2853A6A40041BAFE /* BraintreePayPal in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93C92853A6A40041BAFE /* BraintreePayPal */; };
-		570B93CC2853A6A40041BAFE /* BraintreePaymentFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */; };
-		570B93CE2853A6A40041BAFE /* BraintreeThreeDSecure in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */; };
-		570B93D02853A6A40041BAFE /* BraintreeUnionPay in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93CF2853A6A40041BAFE /* BraintreeUnionPay */; };
-		570B93D22853A6A40041BAFE /* BraintreeVenmo in Frameworks */ = {isa = PBXBuildFile; productRef = 570B93D12853A6A40041BAFE /* BraintreeVenmo */; };
+		57004D69285A311A00BFC1D2 /* BraintreeAmericanExpress in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D68285A311A00BFC1D2 /* BraintreeAmericanExpress */; };
+		57004D6B285A311A00BFC1D2 /* BraintreeApplePay in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D6A285A311A00BFC1D2 /* BraintreeApplePay */; };
+		57004D6D285A311A00BFC1D2 /* BraintreeCard in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D6C285A311A00BFC1D2 /* BraintreeCard */; };
+		57004D6F285A311A00BFC1D2 /* BraintreeCore in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D6E285A311A00BFC1D2 /* BraintreeCore */; };
+		57004D71285A311A00BFC1D2 /* BraintreeCoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D70285A311A00BFC1D2 /* BraintreeCoreSwift */; };
+		57004D73285A311A00BFC1D2 /* BraintreeDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D72285A311A00BFC1D2 /* BraintreeDataCollector */; };
+		57004D75285A311A00BFC1D2 /* BraintreeKountDataCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D74285A311A00BFC1D2 /* BraintreeKountDataCollector */; };
+		57004D77285A311A00BFC1D2 /* BraintreePayPal in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D76285A311A00BFC1D2 /* BraintreePayPal */; };
+		57004D79285A311A00BFC1D2 /* BraintreePaymentFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D78285A311A00BFC1D2 /* BraintreePaymentFlow */; };
+		57004D7B285A311A00BFC1D2 /* BraintreeThreeDSecure in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D7A285A311A00BFC1D2 /* BraintreeThreeDSecure */; };
+		57004D7D285A311A00BFC1D2 /* BraintreeUnionPay in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D7C285A311A00BFC1D2 /* BraintreeUnionPay */; };
+		57004D7F285A311A00BFC1D2 /* BraintreeVenmo in Frameworks */ = {isa = PBXBuildFile; productRef = 57004D7E285A311A00BFC1D2 /* BraintreeVenmo */; };
 		80214E042551FB5A00695A6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E032551FB5A00695A6F /* AppDelegate.swift */; };
 		80214E062551FB5A00695A6F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E052551FB5A00695A6F /* SceneDelegate.swift */; };
 		80214E082551FB5A00695A6F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E072551FB5A00695A6F /* ViewController.swift */; };
@@ -44,18 +44,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				570B93C42853A6A40041BAFE /* BraintreeCoreSwift in Frameworks */,
-				570B93C02853A6A40041BAFE /* BraintreeCard in Frameworks */,
-				570B93CA2853A6A40041BAFE /* BraintreePayPal in Frameworks */,
-				570B93D22853A6A40041BAFE /* BraintreeVenmo in Frameworks */,
-				570B93BC2853A6A40041BAFE /* BraintreeAmericanExpress in Frameworks */,
-				570B93C22853A6A40041BAFE /* BraintreeCore in Frameworks */,
-				570B93C82853A6A40041BAFE /* BraintreeKountDataCollector in Frameworks */,
-				570B93CE2853A6A40041BAFE /* BraintreeThreeDSecure in Frameworks */,
-				570B93BE2853A6A40041BAFE /* BraintreeApplePay in Frameworks */,
-				570B93D02853A6A40041BAFE /* BraintreeUnionPay in Frameworks */,
-				570B93CC2853A6A40041BAFE /* BraintreePaymentFlow in Frameworks */,
-				570B93C62853A6A40041BAFE /* BraintreeDataCollector in Frameworks */,
+				57004D71285A311A00BFC1D2 /* BraintreeCoreSwift in Frameworks */,
+				57004D6D285A311A00BFC1D2 /* BraintreeCard in Frameworks */,
+				57004D77285A311A00BFC1D2 /* BraintreePayPal in Frameworks */,
+				57004D7F285A311A00BFC1D2 /* BraintreeVenmo in Frameworks */,
+				57004D69285A311A00BFC1D2 /* BraintreeAmericanExpress in Frameworks */,
+				57004D6F285A311A00BFC1D2 /* BraintreeCore in Frameworks */,
+				57004D75285A311A00BFC1D2 /* BraintreeKountDataCollector in Frameworks */,
+				57004D7B285A311A00BFC1D2 /* BraintreeThreeDSecure in Frameworks */,
+				57004D6B285A311A00BFC1D2 /* BraintreeApplePay in Frameworks */,
+				57004D7D285A311A00BFC1D2 /* BraintreeUnionPay in Frameworks */,
+				57004D79285A311A00BFC1D2 /* BraintreePaymentFlow in Frameworks */,
+				57004D73285A311A00BFC1D2 /* BraintreeDataCollector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,18 +118,18 @@
 			);
 			name = SPMTest;
 			packageProductDependencies = (
-				570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */,
-				570B93BD2853A6A40041BAFE /* BraintreeApplePay */,
-				570B93BF2853A6A40041BAFE /* BraintreeCard */,
-				570B93C12853A6A40041BAFE /* BraintreeCore */,
-				570B93C32853A6A40041BAFE /* BraintreeCoreSwift */,
-				570B93C52853A6A40041BAFE /* BraintreeDataCollector */,
-				570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */,
-				570B93C92853A6A40041BAFE /* BraintreePayPal */,
-				570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */,
-				570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */,
-				570B93CF2853A6A40041BAFE /* BraintreeUnionPay */,
-				570B93D12853A6A40041BAFE /* BraintreeVenmo */,
+				57004D68285A311A00BFC1D2 /* BraintreeAmericanExpress */,
+				57004D6A285A311A00BFC1D2 /* BraintreeApplePay */,
+				57004D6C285A311A00BFC1D2 /* BraintreeCard */,
+				57004D6E285A311A00BFC1D2 /* BraintreeCore */,
+				57004D70285A311A00BFC1D2 /* BraintreeCoreSwift */,
+				57004D72285A311A00BFC1D2 /* BraintreeDataCollector */,
+				57004D74285A311A00BFC1D2 /* BraintreeKountDataCollector */,
+				57004D76285A311A00BFC1D2 /* BraintreePayPal */,
+				57004D78285A311A00BFC1D2 /* BraintreePaymentFlow */,
+				57004D7A285A311A00BFC1D2 /* BraintreeThreeDSecure */,
+				57004D7C285A311A00BFC1D2 /* BraintreeUnionPay */,
+				57004D7E285A311A00BFC1D2 /* BraintreeVenmo */,
 			);
 			productName = SPMTest;
 			productReference = 80214E002551FB5A00695A6F /* SPMTest.app */;
@@ -159,7 +159,7 @@
 			);
 			mainGroup = 80214DF72551FB5A00695A6F;
 			packageReferences = (
-				570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */,
+				57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */,
 			);
 			productRefGroup = 80214E012551FB5A00695A6F /* Products */;
 			projectDirPath = "";
@@ -407,7 +407,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */ = {
+		57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braintree/braintree_ios";
 			requirement = {
@@ -418,64 +418,64 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		570B93BB2853A6A40041BAFE /* BraintreeAmericanExpress */ = {
+		57004D68285A311A00BFC1D2 /* BraintreeAmericanExpress */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeAmericanExpress;
 		};
-		570B93BD2853A6A40041BAFE /* BraintreeApplePay */ = {
+		57004D6A285A311A00BFC1D2 /* BraintreeApplePay */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeApplePay;
 		};
-		570B93BF2853A6A40041BAFE /* BraintreeCard */ = {
+		57004D6C285A311A00BFC1D2 /* BraintreeCard */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeCard;
 		};
-		570B93C12853A6A40041BAFE /* BraintreeCore */ = {
+		57004D6E285A311A00BFC1D2 /* BraintreeCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeCore;
 		};
-		570B93C32853A6A40041BAFE /* BraintreeCoreSwift */ = {
+		57004D70285A311A00BFC1D2 /* BraintreeCoreSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeCoreSwift;
 		};
-		570B93C52853A6A40041BAFE /* BraintreeDataCollector */ = {
+		57004D72285A311A00BFC1D2 /* BraintreeDataCollector */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeDataCollector;
 		};
-		570B93C72853A6A40041BAFE /* BraintreeKountDataCollector */ = {
+		57004D74285A311A00BFC1D2 /* BraintreeKountDataCollector */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeKountDataCollector;
 		};
-		570B93C92853A6A40041BAFE /* BraintreePayPal */ = {
+		57004D76285A311A00BFC1D2 /* BraintreePayPal */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreePayPal;
 		};
-		570B93CB2853A6A40041BAFE /* BraintreePaymentFlow */ = {
+		57004D78285A311A00BFC1D2 /* BraintreePaymentFlow */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreePaymentFlow;
 		};
-		570B93CD2853A6A40041BAFE /* BraintreeThreeDSecure */ = {
+		57004D7A285A311A00BFC1D2 /* BraintreeThreeDSecure */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeThreeDSecure;
 		};
-		570B93CF2853A6A40041BAFE /* BraintreeUnionPay */ = {
+		57004D7C285A311A00BFC1D2 /* BraintreeUnionPay */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeUnionPay;
 		};
-		570B93D12853A6A40041BAFE /* BraintreeVenmo */ = {
+		57004D7E285A311A00BFC1D2 /* BraintreeVenmo */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 570B93BA2853A6A40041BAFE /* XCRemoteSwiftPackageReference "braintree_ios" */;
+			package = 57004D67285A311A00BFC1D2 /* XCRemoteSwiftPackageReference "braintree_ios" */;
 			productName = BraintreeVenmo;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Sources/BraintreeCoreSwift/BTAPIClientSwift.swift
+++ b/Sources/BraintreeCoreSwift/BTAPIClientSwift.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public class BTAPIClientSwift: NSObject {
+    
+}

--- a/Sources/BraintreeCoreSwift/BTAPIClientSwift.swift
+++ b/Sources/BraintreeCoreSwift/BTAPIClientSwift.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public class BTAPIClientSwift: NSObject {
+@objcMembers public class BTAPIClientSwift: NSObject {
     
 }


### PR DESCRIPTION
Merging into `next-major-version`

### Summary of changes

- Created a temporary module `BraintreeCoreSwift` to hold Swift code while we convert the Core Module.

### Checklist

~- [ ] Added a changelog entry~ This module will be removed once the conversion is done, so no changelog is necessary.

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @mattwylder 
