### PR TITLE
Update PayPal UI Test Tokenization Key

### DIFF
--- a/Demo/Application/Base/BraintreeDemoAppDelegate.m
+++ b/Demo/Application/Base/BraintreeDemoAppDelegate.m
@@ -60,6 +60,8 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.De
         [[NSUserDefaults standardUserDefaults] setInteger:BraintreeDemoAuthTypeClientToken forKey:BraintreeDemoSettings.AuthorizationTypeDefaultsKey];
     }else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-TokenizationKey"]) {
         [[NSUserDefaults standardUserDefaults] setInteger:BraintreeDemoAuthTypeTokenizationKey forKey:BraintreeDemoSettings.AuthorizationTypeDefaultsKey];
+    } else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-MockedPayPalTokenizationKey"]) {
+        [[NSUserDefaults standardUserDefaults] setInteger:BraintreeDemoAuthTypeMockedPayPalTokenizationKey forKey:BraintreeDemoSettings.AuthorizationTypeDefaultsKey];
     }
     
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"BraintreeDemoSettingsAuthorizationOverride"];

--- a/Demo/Application/Base/BraintreeDemoContainmentViewController.m
+++ b/Demo/Application/Base/BraintreeDemoContainmentViewController.m
@@ -159,6 +159,12 @@
 
             break;
         }
+        case BraintreeDemoAuthTypeMockedPayPalTokenizationKey: {
+            NSString *tokenizationKey;
+            tokenizationKey = @"sandbox_q7v35n9n_555d2htrfsnnmfb3";
+            self.currentDemoViewController = [self instantiateCurrentIntegrationViewControllerWithAuthorization:tokenizationKey];
+            return;
+        }
     }
 }
 

--- a/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
+++ b/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
@@ -11,6 +11,7 @@ enum BraintreeDemoEnvironment: Int {
 enum BraintreeDemoAuthType: Int {
     case clientToken
     case tokenizationKey
+    case mockedPayPalTokenizationKey
 }
 
 @objc

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Checkout_UITests.swift
@@ -14,7 +14,7 @@ class PayPal_Checkout_UITests: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-TokenizationKey")
+        app.launchArguments.append("-MockedPayPalTokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalCheckoutViewController")
         app.launch()
 

--- a/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
+++ b/Demo/UI Tests/PayPal UI Tests/PayPal_Vault_UITests.swift
@@ -14,7 +14,7 @@ class PayPal_Vault_UITests: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-TokenizationKey")
+        app.launchArguments.append("-MockedPayPalTokenizationKey")
         app.launchArguments.append("-Integration:BraintreeDemoPayPalVaultViewController")
         app.launch()
         


### PR DESCRIPTION
### Summary of changes

Now that the tokenization key used in the Gateway has a PayPal account linked, our UI tests have started failing as it expects the mocked flow. PayPal webviews cache data heavily so UI testing that would be quite difficult. Instead we can use a tokenization key with the mocked PayPal flow attached for the PayPal UI tests. The tokenization key used here is listed under the username `devs` in 1pass.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
