### PR TITLE
IMPROVEMENT - Added c header search path in Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreeSEPADirectDebit
   * Update nonce to pull in ibanLastFour and customerID as expected
+* Package.swift improvement - Added C Header setting in Package.swift
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,10 +45,7 @@ In general, we avoid importing **internal headers from other modules**, but occa
 #if __has_include(<Braintree/BraintreeAmericanExpress.h>) // CocoaPods
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeCore/BTAPIClient_Internal.h>
 #endif
 ```

--- a/Package.swift
+++ b/Package.swift
@@ -141,7 +141,10 @@ let package = Package(
             name: "BraintreeThreeDSecure",
             dependencies: ["BraintreePaymentFlow", "BraintreeCard", "CardinalMobile", "PPRiskMagnes"],
             publicHeadersPath: "Public",
-            cSettings: [.headerSearchPath("V2UICustomization")]
+            cSettings: [
+                .headerSearchPath("V2UICustomization"),
+                .headerSearchPath("../")
+            ]
         ),
         .binaryTarget(
             name: "CardinalMobile",
@@ -150,7 +153,10 @@ let package = Package(
         .target(
             name: "BraintreeUnionPay",
             dependencies: ["BraintreeCard"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeVenmo",

--- a/Package.swift
+++ b/Package.swift
@@ -69,17 +69,26 @@ let package = Package(
         .target(
             name: "BraintreeAmericanExpress",
             dependencies: ["BraintreeCore"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeApplePay",
             dependencies: ["BraintreeCore"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeCard",
             dependencies: ["BraintreeCore"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeCore",
@@ -95,26 +104,38 @@ let package = Package(
         .target(
             name: "BraintreePaymentFlow",
             dependencies: ["BraintreeCore", "PayPalDataCollector"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreePayPal",
             dependencies: ["BraintreeCore", "PayPalDataCollector"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreePayPalNativeCheckout",
             dependencies: [
                 "BraintreeCore",
                 "BraintreePayPal",
-                "PayPalCheckout",
+                "PayPalCheckout"
             ],
-            path: "Sources/BraintreePayPalNativeCheckout"
+            path: "Sources/BraintreePayPalNativeCheckout",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeSEPADirectDebit",
             dependencies: ["BraintreeCore"],
-            path: "Sources/BraintreeSEPADirectDebit"
+            path: "Sources/BraintreeSEPADirectDebit",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .target(
             name: "BraintreeThreeDSecure",
@@ -134,7 +155,10 @@ let package = Package(
         .target(
             name: "BraintreeVenmo",
             dependencies: ["BraintreeCore"],
-            publicHeadersPath: "Public"
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .binaryTarget(
             name: "KountDataCollector",

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.m
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.m
@@ -5,12 +5,7 @@
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeAmericanExpress/BTAmericanExpressRewardsBalance.h>
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeAmericanExpress/BTAmericanExpressRewardsBalance.h>
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>

--- a/Sources/BraintreeApplePay/BTApplePayClient.m
+++ b/Sources/BraintreeApplePay/BTApplePayClient.m
@@ -8,14 +8,7 @@
 #import <Braintree/BTAPIClient_Internal.h>
 #import <Braintree/BTPaymentMethodNonceParser.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeApplePay/BTConfiguration+ApplePay.h>
-#import <BraintreeApplePay/BTApplePayCardNonce.h>
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/BTPaymentMethodNonceParser.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeApplePay/BTConfiguration+ApplePay.h>
 #import <BraintreeApplePay/BTApplePayCardNonce.h>
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -9,13 +9,7 @@
 #import <Braintree/BTPaymentMethodNonceParser.h>
 #import <Braintree/BraintreeCore.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeCard/BTCardRequest.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/BTPaymentMethodNonceParser.h"
-#import <BraintreeCore/BraintreeCore.h>
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeCard/BTCardRequest.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>
 #import <BraintreeCore/BTPaymentMethodNonceParser.h>

--- a/Sources/BraintreePayPal/BTPayPalDriver.m
+++ b/Sources/BraintreePayPal/BTPayPalDriver.m
@@ -13,14 +13,6 @@
 #import <Braintree/BTConfiguration+PayPal.h>
 #import <Braintree/BTPayPalLineItem.h>
 
-#elif SWIFT_PACKAGE                              // SPM
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/BTPaymentMethodNonceParser.h"
-#import "../BraintreeCore/BTLogger_Internal.h"
-#import <BraintreePayPal/BTConfiguration+PayPal.h>
-#import <BraintreePayPal/BTPayPalLineItem.h>
-
 #else                                            // Carthage
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>

--- a/Sources/BraintreePaymentFlow/BTLocalPaymentRequest.m
+++ b/Sources/BraintreePaymentFlow/BTLocalPaymentRequest.m
@@ -10,15 +10,7 @@
 #import <Braintree/BTAPIClient_Internal.h>
 #import <Braintree/BraintreeCore.h>
 
-#elif SWIFT_PACKAGE                                   // SPM
-#import <BraintreePaymentFlow/BTLocalPaymentRequest.h>
-#import <BraintreePaymentFlow/BTConfiguration+LocalPayment.h>
-#import <BraintreePaymentFlow/BTLocalPaymentResult.h>
-#import "../BraintreeCore/BTLogger_Internal.h"
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import <BraintreeCore/BraintreeCore.h>
-
-#else                                                 // Carthage
+#else                                                 // Carthage & SPM
 #import <BraintreePaymentFlow/BTLocalPaymentRequest.h>
 #import <BraintreePaymentFlow/BTConfiguration+LocalPayment.h>
 #import <BraintreePaymentFlow/BTLocalPaymentResult.h>

--- a/Sources/BraintreePaymentFlow/BTPaymentFlowDriver+LocalPayment.m
+++ b/Sources/BraintreePaymentFlow/BTPaymentFlowDriver+LocalPayment.m
@@ -5,12 +5,7 @@
 #import <Braintree/BTConfiguration+LocalPayment.h>
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreePaymentFlow/BTPaymentFlowDriver+LocalPayment.h>
-#import <BraintreePaymentFlow/BTConfiguration+LocalPayment.h>
-#import "../BTAPIClient_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreePaymentFlow/BTPaymentFlowDriver+LocalPayment.h>
 #import <BraintreePaymentFlow/BTConfiguration+LocalPayment.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>

--- a/Sources/BraintreePaymentFlow/BTPaymentFlowDriver.m
+++ b/Sources/BraintreePaymentFlow/BTPaymentFlowDriver.m
@@ -7,13 +7,7 @@
 #import <Braintree/BTLogger_Internal.h>
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreePaymentFlow/BTPaymentFlowRequest.h>
-#import <BraintreePaymentFlow/BTPaymentFlowResult.h>
-#import "../BraintreeCore/BTLogger_Internal.h"
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreePaymentFlow/BTPaymentFlowRequest.h>
 #import <BraintreePaymentFlow/BTPaymentFlowResult.h>
 #import <BraintreeCore/BTLogger_Internal.h>

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.m
@@ -12,15 +12,7 @@
 #import <Braintree/BTAPIClient_Internal.h>
 #import <Braintree/Braintree-Version.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreePaymentFlow/BTPaymentFlowDriver_Internal.h"
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/Braintree-Version.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeThreeDSecure/BTPaymentFlowDriver+ThreeDSecure.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.m
@@ -6,10 +6,6 @@
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeCard/BraintreeCard.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
 #else // Carthage
 #import <BraintreeCard/BraintreeCard.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -18,18 +18,7 @@
 #import <Braintree/Braintree-Version.h>
 #import <Braintree/BTPaymentFlowDriver_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureResult.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureLookup.h>
-#import <BraintreeThreeDSecure/BTConfiguration+ThreeDSecure.h>
-#import <BraintreeCard/BraintreeCard.h>
-#import "../BraintreeCore/BTLogger_Internal.h"
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/Braintree-Version.h"
-#import "../BraintreePaymentFlow/BTPaymentFlowDriver_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureResult.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureLookup.h>

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureResult.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureResult.m
@@ -5,11 +5,7 @@
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BTCardNonce_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCard/BTCardNonce_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeCard/BTCardNonce_Internal.h>
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
@@ -12,15 +12,7 @@
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BTAPIClient_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeThreeDSecure/BTConfiguration+ThreeDSecure.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureResult.h>
-#import <BraintreeThreeDSecure/BTThreeDSecureLookup.h>
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeThreeDSecure/BTConfiguration+ThreeDSecure.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
 #import <BraintreeThreeDSecure/BTThreeDSecureResult.h>

--- a/Sources/BraintreeUnionPay/BTCardClient+UnionPay.m
+++ b/Sources/BraintreeUnionPay/BTCardClient+UnionPay.m
@@ -7,16 +7,7 @@
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BraintreeCard.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeUnionPay/BTCardClient+UnionPay.h>
-#import <BraintreeUnionPay/BTConfiguration+UnionPay.h>
-#import <BraintreeUnionPay/BTCardCapabilities.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCard/BTCardClient_Internal.h"
-#import <BraintreeCore/BraintreeCore.h>
-#import <BraintreeCard/BraintreeCard.h>
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeUnionPay/BTCardClient+UnionPay.h>
 #import <BraintreeUnionPay/BTConfiguration+UnionPay.h>
 #import <BraintreeUnionPay/BTCardCapabilities.h>

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchRequestURL.m
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchRequestURL.m
@@ -4,11 +4,7 @@
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/Braintree-Version.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/Braintree-Version.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeCore/Braintree-Version.h>
 

--- a/Sources/BraintreeVenmo/BTVenmoDriver.m
+++ b/Sources/BraintreeVenmo/BTVenmoDriver.m
@@ -11,14 +11,7 @@
 #import <Braintree/BTPaymentMethodNonceParser.h>
 #import <Braintree/BTLogger_Internal.h>
 
-#elif SWIFT_PACKAGE // SPM
-#import <BraintreeVenmo/BTConfiguration+Venmo.h>
-#import <BraintreeCore/BraintreeCore.h>
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-#import "../BraintreeCore/BTPaymentMethodNonceParser.h"
-#import "../BraintreeCore/BTLogger_Internal.h"
-
-#else // Carthage
+#else // Carthage & SPM
 #import <BraintreeVenmo/BTConfiguration+Venmo.h>
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeCore/BTAPIClient_Internal.h>


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
During working with [tuist](https://tuist.io) we found a 🐞 regarding the header search path with SPM Brain tree dependency 

Using `BrainTree SPM` package and run `tuist test` will throw the following error

Import headrs are release 
![Screenshot 2022-08-11 at 10 45 16](https://user-images.githubusercontent.com/25608902/184097601-743e3b23-90cd-4a3d-80b0-3d97486c1ee1.png)

Reason behind this is `tuist generate` and `tuist test` create different graphs for project as per following table. 
Due to different structure of `tuist test`  all file that impot`../BraintreeCore{ANY_CLASS}.h`  will not found.

| `tuist generate` | `tuist test`
| :---: | :---: | 
| <img width="664" alt="Screenshot 2022-08-11 at 23 29 39" src="https://user-images.githubusercontent.com/25608902/184246259-80a05563-e4b1-4eb3-8e7b-19b7b652fd9a.png"> | <img width="443" alt="Screenshot 2022-08-11 at 23 28 25" src="https://user-images.githubusercontent.com/25608902/184246306-fc6b114e-22cd-4add-9e26-12501841c21f.png"> |

from the [tuist test](https://docs.tuist.io/commands/test/)
> Tuist also automatically caches successful test runs - this means that the subsequent tuist test calls will test only what has changed! You will see which test targets are skipped in the log. This is extremely useful especially on CI - if you make a simple change in a module that other targets do not depend on, CI can test only this module and nothing else.

# CHANGELOG

- Remove `#import "../BraintreeCore/{ANY_CLASS}.h`
- Use Same header for Carthage and SPM 
- To resolve the headers use added following in Package.swift
```
cSettings: [
                .headerSearchPath("../")
            ]
``` 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @kabirkhaan 
