### PR TITLE
Fix CI on PRs from Forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 concurrency:
   group: build-${{ github.event.number }} 
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 12.5
         run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
       - name: Install CocoaPod dependencies
@@ -21,9 +24,11 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 12.5
         run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
       - name: Remove SPMTest
@@ -45,7 +50,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 12.5
         run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
       - name: Use current branch
@@ -59,7 +67,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+           ref: ${{ github.event.pull_request.head.ref }}
+           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Install CocoaPod dependencies
@@ -71,9 +82,11 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Remove SPMTest
@@ -99,7 +112,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Use current branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Install Package dependencies
@@ -23,7 +26,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Install CocoaPod dependencies
@@ -35,7 +41,10 @@ jobs:
     runs-on: macOS-11
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 13
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Install Package dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 concurrency:
   group: tests-${{ github.event.number }} 
   cancel-in-progress: true


### PR DESCRIPTION
### Summary of changes

- Updated `checkout` action in test and build workflows to v3 with use of parameters to specify use of source repo
- Removed `workflow_dispatch` GitHub actions event, as it was unused and didn't work.

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder @jaxdesmarais 
