### PR TITLE
Updating PayPalCheckout to 0.102.0

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '~> 0.100.0'
+    s.dependency "PayPalCheckout", '~> 0.102.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeSEPADirectDebit
   * Update nonce to pull in ibanLastFour and customerID as expected
+* BraintreePayPalNativeCheckout
+  * Updating NativeCheckout version from `0.100.0` to `0.102.0`
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * BraintreeSEPADirectDebit
   * Update nonce to pull in ibanLastFour and customerID as expected
 * BraintreePayPalNativeCheckout
-  * Updating NativeCheckout version from `0.100.0` to `0.102.0`
+  * Update NativeCheckout version from `0.100.0` to `0.102.0`
+  * This version update allows US based customers to log into their PayPal account using a one time passcode sent via SMS without needing to authenticate through a webview
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-3-xcframework-only-update
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.0
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.100.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.102.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" "2.2.5-3-xcframework-only-update"
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" "5.4.0"
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" "0.100.0"
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" "0.102.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/paypal/paypalcheckout-ios",
         "state": {
           "branch": null,
-          "revision": "122a8a67f30b55768321e3cb3d30ce6792585063",
-          "version": "0.100.0"
+          "revision": "19c2f1062a88294f1ba5b1c5e5fabcf7f6825afa",
+          "version": "0.102.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.100.0"))
+        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.102.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

This PR updates the included version of NXO from `0.100.0` to `0.102.0`. There aren't public interface changes between these versions, so the only updates required should be in the associated package version numbers.

This version of NXO includes OTP support, allowing for a fully native login / checkout flow.

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- jonathajones
