### PR TITLE
Add support for Xcode 14 & iOS 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,23 +5,23 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 12.5)
-    runs-on: macOS-11
+    name: CocoaPods (Xcode 14.0)
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
+      - name: Use Xcode 14.0
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
-    name: Carthage (Xcode 12.5)
-    runs-on: macOS-11
+    name: Carthage (Xcode 14.0)
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -29,8 +29,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
+      - name: Use Xcode 14.0
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -47,16 +47,16 @@ jobs:
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
-    name: SPM (Xcode 12.5)
-    runs-on: macOS-11
+    name: SPM (Xcode 14)
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,15 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
@@ -23,30 +23,30 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeSEPADirectDebit
   * Update nonce to pull in ibanLastFour and customerID as expected
+* Remove unused `presentationContextProvider` (fixes #854)
+  * Adds support for Xcode 14 and iOS 16 
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* Adds support for Xcode 14 and iOS 16 
 * BraintreeSEPADirectDebit
   * Update nonce to pull in ibanLastFour and customerID as expected
-* Remove unused `presentationContextProvider` (fixes #854)
-  * Adds support for Xcode 14 and iOS 16 
+  * Remove unused `presentationContextProvider` (fixes #854)
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/Demo/Application/Features/Fraud Protection - BTDataCollector/BraintreeDemoBTDataCollectorViewController.m
+++ b/Demo/Application/Features/Fraud Protection - BTDataCollector/BraintreeDemoBTDataCollectorViewController.m
@@ -101,7 +101,14 @@
 }
 
 - (IBAction)tappedRequestLocationAuthorization:(__unused id)sender {
-    switch ([CLLocationManager authorizationStatus]) {
+    CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
+    if (@available(iOS 14, *)) {
+        locationStatus = [CLLocationManager new].authorizationStatus;
+    } else {
+        locationStatus = [CLLocationManager authorizationStatus];
+    }
+    
+    switch (locationStatus) {
         case kCLAuthorizationStatusNotDetermined:
             [self.locationManager requestWhenInUseAuthorization];
             break;

--- a/Demo/Application/Features/SEPA Direct Debit/BraintreeDemoSEPADirectDebitViewController.swift
+++ b/Demo/Application/Features/SEPA Direct Debit/BraintreeDemoSEPADirectDebitViewController.swift
@@ -56,7 +56,7 @@ class BraintreeDemoSEPADirectDebitViewController: BraintreeDemoBaseViewControlle
 
         let sepaDirectDebitRequest = BTSEPADirectDebitRequest()
         sepaDirectDebitRequest.accountHolderName = "John Doe"
-        sepaDirectDebitRequest.iban = "FR7618106000321234566666608"
+        sepaDirectDebitRequest.iban = "FR7630006000014829011031512"
         sepaDirectDebitRequest.customerID = generateRandomCustomerID()
         sepaDirectDebitRequest.mandateType = .oneOff
         sepaDirectDebitRequest.billingAddress = billingAddress

--- a/Demo/Application/Features/SEPA Direct Debit/BraintreeDemoSEPADirectDebitViewController.swift
+++ b/Demo/Application/Features/SEPA Direct Debit/BraintreeDemoSEPADirectDebitViewController.swift
@@ -37,8 +37,14 @@ class BraintreeDemoSEPADirectDebitViewController: BraintreeDemoBaseViewControlle
 
     @available(iOS 13.0, *)
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-      let window = UIApplication.shared.windows.first { $0.isKeyWindow }
-      return window ?? ASPresentationAnchor()
+        if #available(iOS 15, *) {
+            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let window = firstScene?.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        } else {
+            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        }
     }
 
     // MARK: - SEPA Direct Debit implementation

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, BTDataCollectorEnvironment) {
     BTDataCollectorEnvironmentProduction
 };
 
-@interface BTDataCollector () <CLLocationManagerDelegate>
+@interface BTDataCollector ()
 
 @property (nonatomic, copy) NSString *fraudMerchantID;
 @property (nonatomic, copy) BTAPIClient *apiClient;
@@ -33,8 +33,6 @@ typedef NS_ENUM(NSInteger, BTDataCollectorEnvironment) {
 @implementation BTDataCollector
 
 static Class PayPalDataCollectorClass;
-
-CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
 
 #pragma mark - Initialization and setup
 
@@ -48,10 +46,6 @@ CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
     if (self = [super init]) {
         [self setUpKountWithDebugOn:NO];
         _apiClient = apiClient;
-        if (@available(iOS 14, *)) {
-            _locationManager = [CLLocationManager new];
-            _locationManager.delegate = self;
-        }
     }
     
     return self;
@@ -61,18 +55,16 @@ CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
     self.kount = [KDataCollector sharedCollector];
     self.kount.debug = debugLogging;
 
-    if ((locationStatus != kCLAuthorizationStatusAuthorizedWhenInUse && locationStatus != kCLAuthorizationStatusAuthorizedAlways) || ![CLLocationManager locationServicesEnabled]) {
-        self.kount.locationCollectorConfig = KLocationCollectorConfigSkip;
-    }
-}
+    CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
 
-#pragma mark - CLLocationManagerDelegate
-
-- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
     if (@available(iOS 14, *)) {
-        locationStatus = manager.authorizationStatus;
+        locationStatus = [CLLocationManager new].authorizationStatus;
     } else {
         locationStatus = [CLLocationManager authorizationStatus];
+    }
+
+    if ((locationStatus != kCLAuthorizationStatusAuthorizedWhenInUse && locationStatus != kCLAuthorizationStatusAuthorizedAlways) || ![CLLocationManager locationServicesEnabled]) {
+        self.kount.locationCollectorConfig = KLocationCollectorConfigSkip;
     }
 }
 

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -1,6 +1,5 @@
 #import "BTDataCollector_Internal.h"
 #import "KDataCollector.h"
-#import <CoreLocation/CoreLocation.h>
 
 #if __has_include(<Braintree/BraintreeDataCollector.h>)
 #import <Braintree/BTConfiguration+DataCollector.h>
@@ -24,7 +23,7 @@ typedef NS_ENUM(NSInteger, BTDataCollectorEnvironment) {
     BTDataCollectorEnvironmentProduction
 };
 
-@interface BTDataCollector ()
+@interface BTDataCollector () <CLLocationManagerDelegate>
 
 @property (nonatomic, copy) NSString *fraudMerchantID;
 @property (nonatomic, copy) BTAPIClient *apiClient;
@@ -47,6 +46,10 @@ static Class PayPalDataCollectorClass;
     if (self = [super init]) {
         [self setUpKountWithDebugOn:NO];
         _apiClient = apiClient;
+        if (@available(iOS 14, *)) {
+            _locationManager = [CLLocationManager new];
+            _locationManager.delegate = self;
+        }
     }
     
     return self;
@@ -55,7 +58,11 @@ static Class PayPalDataCollectorClass;
 - (void)setUpKountWithDebugOn:(BOOL)debugLogging {
     self.kount = [KDataCollector sharedCollector];
     self.kount.debug = debugLogging;
+}
 
+#pragma mark - CLLocationManagerDelegate
+
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
     CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
     if (@available(iOS 14, *)) {
         locationStatus = [CLLocationManager new].authorizationStatus;

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -72,7 +72,7 @@ CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
     if (@available(iOS 14, *)) {
         locationStatus = manager.authorizationStatus;
     } else {
-        locationStatus = [manager authorizationStatus];
+        locationStatus = [CLLocationManager authorizationStatus];
     }
 }
 

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -34,6 +34,8 @@ typedef NS_ENUM(NSInteger, BTDataCollectorEnvironment) {
 
 static Class PayPalDataCollectorClass;
 
+CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
+
 #pragma mark - Initialization and setup
 
 + (void)load {
@@ -58,20 +60,19 @@ static Class PayPalDataCollectorClass;
 - (void)setUpKountWithDebugOn:(BOOL)debugLogging {
     self.kount = [KDataCollector sharedCollector];
     self.kount.debug = debugLogging;
+
+    if ((locationStatus != kCLAuthorizationStatusAuthorizedWhenInUse && locationStatus != kCLAuthorizationStatusAuthorizedAlways) || ![CLLocationManager locationServicesEnabled]) {
+        self.kount.locationCollectorConfig = KLocationCollectorConfigSkip;
+    }
 }
 
 #pragma mark - CLLocationManagerDelegate
 
 - (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
-    CLAuthorizationStatus locationStatus = kCLAuthorizationStatusNotDetermined;
     if (@available(iOS 14, *)) {
-        locationStatus = [CLLocationManager new].authorizationStatus;
+        locationStatus = manager.authorizationStatus;
     } else {
-        locationStatus = [CLLocationManager authorizationStatus];
-    }
-
-    if ((locationStatus != kCLAuthorizationStatusAuthorizedWhenInUse && locationStatus != kCLAuthorizationStatusAuthorizedAlways) || ![CLLocationManager locationServicesEnabled]) {
-        self.kount.locationCollectorConfig = KLocationCollectorConfigSkip;
+        locationStatus = [manager authorizationStatus];
     }
 }
 

--- a/Sources/BraintreeDataCollector/BTDataCollector_Internal.h
+++ b/Sources/BraintreeDataCollector/BTDataCollector_Internal.h
@@ -14,8 +14,5 @@
 */
 @property (nonatomic, strong, nonnull) KDataCollector *kount;
 
-// TODO: Annotation for only needed for iOS 14
-@property (nonatomic, strong, nonnull) CLLocationManager *locationManager;
-
 @end
 

--- a/Sources/BraintreeDataCollector/BTDataCollector_Internal.h
+++ b/Sources/BraintreeDataCollector/BTDataCollector_Internal.h
@@ -1,3 +1,4 @@
+#import <CoreLocation/CoreLocation.h>
 #if __has_include(<Braintree/BraintreeDataCollector.h>)
 #import <Braintree/BTDataCollector.h>
 #else
@@ -12,6 +13,9 @@
  The Kount SDK device collector, exposed internally for testing
 */
 @property (nonatomic, strong, nonnull) KDataCollector *kount;
+
+// TODO: Annotation for only needed for iOS 14
+@property (nonatomic, strong, nonnull) CLLocationManager *locationManager;
 
 @end
 

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
@@ -23,6 +23,7 @@ import BraintreeCore
         self.webAuthenticationSession =  WebAuthenticationSession()
     }
     
+    /// Internal for testing.
     init(apiClient: BTAPIClient, webAuthenticationSession: WebAuthenticationSession, sepaDirectDebitAPI: SEPADirectDebitAPI) {
         self.apiClient = apiClient
         self.webAuthenticationSession = webAuthenticationSession

--- a/Sources/BraintreeSEPADirectDebit/WebAuthenticationSession.swift
+++ b/Sources/BraintreeSEPADirectDebit/WebAuthenticationSession.swift
@@ -4,9 +4,6 @@ import AuthenticationServices
 class WebAuthenticationSession: NSObject {
 
     var authenticationSession: ASWebAuthenticationSession?
-    
-    @available(iOS 13.0, *)
-    private(set) lazy var presentationContextProvider: ASWebAuthenticationPresentationContextProviding? = nil
 
     @available(iOS 13.0, *)
     func start(


### PR DESCRIPTION
### Summary of changes

- Add support for Xcode 14 & iOS 16
- Tested all flows on device running iOS 16
- Removed deprecation warnings in Xcode 14

Note: These updates do not drop bitcode support - once we bump the minimum Xcode version to Xcode 14 for merchants, we will drop bitcode support.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo @mattwylder @jaxdesmarais 
