### PR TITLE
Bumping Native Checkout SDK version to 0.106.0

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '~> 0.100.0'
+    s.dependency "PayPalCheckout", '~> 0.106.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * BraintreeSEPADirectDebit
   * Update `BTSEPADirectDebitNonce` to pull in `ibanLastFour` and `customerID` as expected
   * Remove unused `presentationContextProvider` (fixes #854)
+* BraintreePayPalNativeCheckout (BETA)
+  * Update NativeCheckout version from `0.100.0` to `0.106.0`
+  * This version update allows US based customers with a confirmed phone number to log into their PayPal account using a one time passcode sent via SMS without needing to authenticate through a webview. 
+
 
 ## 5.11.0 (2022-07-20)
 * BraintreeSEPADirectDebit

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-3-xcframework-only-update
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.0
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.100.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.106.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" "2.2.5-3-xcframework-only-update"
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" "5.4.0"
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" "0.100.0"
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" "0.106.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/paypal/paypalcheckout-ios",
         "state": {
           "branch": null,
-          "revision": "122a8a67f30b55768321e3cb3d30ce6792585063",
-          "version": "0.100.0"
+          "revision": "089fdcd1a7968cb27b66d100d3268119b92ce246",
+          "version": "0.106.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.100.0"))
+        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.106.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- This PR increments the version of native checkout included in the Braintree SDK to 0.106.0. The biggest change in this version is the support for one time passcode login. Documentation around testing that flow in sandbox exists on the NXO SDK github (https://github.com/paypal/paypalcheckout-ios/blob/main/README.md#otp-support), and will be released in merchant facing developer documentation later today. 

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- jonathajones
