### PR TITLE
Update CocoaPods to pin NXO version

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '~> 0.100.0'
+    s.dependency "PayPalCheckout", '= 0.100.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Fix CocoaPods integrations to pin exact `PayPalCheckout` version `0.100.0` to match Swift Package Manager
+
 ## 5.12.0 (2022-09-07)
 * Adds support for Xcode 14 and iOS 16 
 * BraintreeSEPADirectDebit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPalNativeCheckout (BETA)
-  * Fix CocoaPods integrations to pin exact `PayPalCheckout` version `0.100.0` to match Swift Package Manager
+  * Fix CocoaPods integrations to pin exact `PayPalCheckout` version `0.100.0`
 
 ## 5.12.0 (2022-09-07)
 * Adds support for Xcode 14 and iOS 16 


### PR DESCRIPTION
### Background

- For SPM integrations, we pin each version release of `braintree_ios` to the exact version of NXO ([see Package.swift](https://github.com/braintree/braintree_ios/blob/7da79965033cfdf95c9261aeefd973d90db38a05/Package.swift#L64)).
- From talking with the NXO team, this is because they aren't on SemVer yet and new releases aren't guaranteed to be non-breaking.

### Changes
- This PR updates CocoaPods to use the same NXO dependency resolution behavior as SPM - exact version pinning.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
