### PR TITLE
Add Apple Pay UI test

### DIFF
--- a/Demo/Application/Base/BraintreeDemoAppDelegate.m
+++ b/Demo/Application/Base/BraintreeDemoAppDelegate.m
@@ -80,6 +80,10 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.De
     }else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-ClientTokenVersion3"]) {
         [[NSUserDefaults standardUserDefaults] setObject:@"3" forKey:@"BraintreeDemoSettingsClientTokenVersionDefaultsKey"];
     }
+    
+    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-SkipApplePayContactFields"]) {
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"BraintreeDemoRequireApplePayContactFields"];
+    }
     // End checking for testing arguments
     
     

--- a/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
+++ b/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
@@ -77,6 +77,11 @@ class BraintreeDemoSettings: NSObject {
     static var threeDSecureRequiredStatus: BraintreeDemoThreeDSecureRequiredSetting {
         return BraintreeDemoThreeDSecureRequiredSetting(rawValue: UserDefaults.standard.integer(forKey: ThreeDSecureRequiredDefaultsKey)) ?? .requiredIfAttempted
     }
+    
+    @objc
+    static var requireApplePayContactFields: Bool {
+        return UserDefaults.standard.bool(forKey: "BraintreeDemoRequireApplePayContactFields")
+    }
 
     @objc
     static var customerPresent: Bool {

--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -176,6 +176,22 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
+			<string>Apple Pay</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Require Contact Fields</string>
+			<key>Key</key>
+			<string>BraintreeDemoRequireApplePayContactFields</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
 			<string>Client Token Version</string>
 		</dict>
 		<dict>

--- a/Demo/Application/Features/Apple Pay - PassKit/BraintreeDemoApplePayPassKitViewController.m
+++ b/Demo/Application/Features/Apple Pay - PassKit/BraintreeDemoApplePayPassKitViewController.m
@@ -1,4 +1,5 @@
 #import "BraintreeDemoApplePayPassKitViewController.h"
+#import "Demo-Swift.h"
 @import BraintreeApplePay;
 
 @interface BraintreeDemoApplePayPassKitViewController () <PKPaymentAuthorizationViewControllerDelegate>
@@ -56,7 +57,10 @@
 
         // Requiring PKAddressFieldPostalAddress crashes Simulator
         //paymentRequest.requiredBillingAddressFields = PKAddressFieldName|PKAddressFieldPostalAddress;
-        paymentRequest.requiredBillingContactFields = [NSSet setWithObjects:PKContactFieldName, nil];
+        if ([BraintreeDemoSettings requireApplePayContactFields]) {
+            paymentRequest.requiredBillingContactFields = [NSSet setWithObjects:PKContactFieldName, nil];
+            paymentRequest.requiredShippingContactFields = [NSSet setWithObjects:PKContactFieldName, PKContactFieldPhoneNumber, PKContactFieldEmailAddress, nil];
+        }
 
         PKShippingMethod *shippingMethod1 = [PKShippingMethod summaryItemWithLabel:@"✈️ Fast Shipping" amount:[NSDecimalNumber decimalNumberWithString:@"4.99"]];
         shippingMethod1.detail = @"Fast but expensive";
@@ -68,7 +72,6 @@
         shippingMethod3.detail = @"It will make Apple Pay fail";
         shippingMethod3.identifier = @"fail";
         paymentRequest.shippingMethods = @[shippingMethod1, shippingMethod2, shippingMethod3];
-        paymentRequest.requiredShippingContactFields = [NSSet setWithObjects:PKContactFieldName, PKContactFieldPhoneNumber, PKContactFieldEmailAddress, nil];
         paymentRequest.paymentSummaryItems = @[
                                                [PKPaymentSummaryItem summaryItemWithLabel:@"SOME ITEM" amount:[NSDecimalNumber decimalNumberWithString:@"10"]],
                                                [PKPaymentSummaryItem summaryItemWithLabel:@"SHIPPING" amount:shippingMethod1.amount],

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574D425FA6CAC008B3681 /* AppSwitcher.swift */; };
 		42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */; };
 		42D47A152554679D0012BAF1 /* BraintreeDemoSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */; };
+		4C74E0FC28CB5122003C1C52 /* ApplePay_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C74E0FA28CB5101003C1C52 /* ApplePay_UITests.swift */; };
 		57108A152832E789004EB870 /* BraintreeDemoPayPalNativeCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57108A142832E789004EB870 /* BraintreeDemoPayPalNativeCheckoutViewController.swift */; };
 		57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; };
 		57108A182832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -147,6 +148,7 @@
 		42D47A132554679D0012BAF1 /* BraintreeDemoSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BraintreeDemoSceneDelegate.h; sourceTree = "<group>"; };
 		42D47A142554679D0012BAF1 /* BraintreeDemoSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BraintreeDemoSceneDelegate.m; sourceTree = "<group>"; };
 		42F3F6DB2603B83100401B0D /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../Frameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
+		4C74E0FA28CB5101003C1C52 /* ApplePay_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePay_UITests.swift; sourceTree = "<group>"; };
 		57108A142832E789004EB870 /* BraintreeDemoPayPalNativeCheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraintreeDemoPayPalNativeCheckoutViewController.swift; sourceTree = "<group>"; };
 		57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreePayPalNativeCheckout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -294,6 +296,14 @@
 				42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */,
 			);
 			path = "American Express UI Tests";
+			sourceTree = "<group>";
+		};
+		4C74E0F928CB50E5003C1C52 /* Apple Pay UI Tests */ = {
+			isa = PBXGroup;
+			children = (
+				4C74E0FA28CB5101003C1C52 /* ApplePay_UITests.swift */,
+			);
+			path = "Apple Pay UI Tests";
 			sourceTree = "<group>";
 		};
 		57108A132832E704004EB870 /* PayPal - Native Checkout */ = {
@@ -557,6 +567,7 @@
 			isa = PBXGroup;
 			children = (
 				42C5BDD425A4CE2E00E8FF40 /* American Express UI Tests */,
+				4C74E0F928CB50E5003C1C52 /* Apple Pay UI Tests */,
 				42456E3B25474B620018374E /* Helpers */,
 				A9B5ABE224EB2A2200A4E1C8 /* Info.plist */,
 				A9C4E07624EC2889002F6FF2 /* PayPal UI Tests */,
@@ -868,6 +879,7 @@
 				A9C4E07F24EC2A0C002F6FF2 /* ThreeDSecure_UITests_Extensions.swift in Sources */,
 				42456E3F25474B620018374E /* DateGenerator.swift in Sources */,
 				A9C4E07924EC28F7002F6FF2 /* PayPal_Checkout_UITests.swift in Sources */,
+				4C74E0FC28CB5122003C1C52 /* ApplePay_UITests.swift in Sources */,
 				80581A5F2553170000006F53 /* Venmo_UITests.swift in Sources */,
 				A9C4E07B24EC290F002F6FF2 /* PayPal_Vault_UITests.swift in Sources */,
 				A9C4E07D24EC297F002F6FF2 /* ThreeDSecure_V2_UITests.swift in Sources */,

--- a/Demo/UI Tests/Apple Pay UI Tests/ApplePay_UITests.swift
+++ b/Demo/UI Tests/Apple Pay UI Tests/ApplePay_UITests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+class ApplePay_UITests: XCTestCase {
+
+    var app: XCUIApplication!
+    var walletApp = XCUIApplication(bundleIdentifier: "com.apple.PassbookUIService")
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-ClientToken")
+        app.launchArguments.append("-SkipApplePayContactFields")
+        app.launchArguments.append("-Integration:BraintreeDemoApplePayPassKitViewController")
+        app.launch()
+    }
+
+    func testApplePayTokenizationReceivesNonce() {
+        let applePayButton = app.buttons["Buy with Apple Pay"]
+        waitForElementToBeHittable(applePayButton)
+        applePayButton.tap()
+        
+        // On iOS < 16, the Payment Method view must be opened
+        // so as to have the 'Pay with Passcode' button appear
+        if #unavailable(iOS 16) {
+            let cardPredicate = NSPredicate(format: "label CONTAINS '1234'")
+            let cardButton = walletApp.buttons.containing(cardPredicate).firstMatch
+            waitForElementToBeHittable(cardButton)
+            cardButton.tap()
+            
+            let paymentMethodLabel = walletApp.staticTexts["Payment Method"]
+            waitForElementToBeHittable(paymentMethodLabel)
+            
+            let closePredicate = NSPredicate(format: "label CONTAINS 'close'")
+            let closeButton = walletApp.buttons.containing(closePredicate).element(boundBy: 1)
+            closeButton.tap()
+        }
+        
+        if UIDevice.current.systemVersion == "16.0" {
+            XCTExpectFailure("PassbookUIService crashes on iOS 16.0 simulators")
+        }
+        
+        let confirmButton = walletApp.buttons["Pay with Passcode"]
+        waitForElementToBeHittable(confirmButton)
+        confirmButton.tap()
+        
+        XCTAssertTrue(app.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 15))
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Made the requirement of Apple Pay contact fields (`requiredBillingContactFields`, `requiredShippingContactFields`) optional via a settings toggle in the Demo app.
- Added `ApplePay_UITests.testApplePayTokenizationReceivesNonce()` to cover the Apple Pay flow.

The test implementation expects a failure on iOS 16.0, as it seems that the PassbookUIService.app systematically crashes upon tapping _Pay with Passcode_ due to an infinite recursion inside the `UIAccessibility` framework. This is resolved in iOS 16.1 beta 1.

### Checklist

- [ ] Added a changelog entry

### Authors

- @dmazzoni
