### PR TITLE
Disable PayPal Native Checkout Exit Survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * Remove `ENABLE_BITCODE` from framework target build settings
   * _The App Store no longer accepts bitcode submissions from Xcode 14_
+* BraintreePayPalNativeCheckout (BETA)
+  * Remove exit survey when canceling Native Checkout flow
 
 ## 5.13.0 (2022-09-16)
 * BraintreePayPalNativeCheckout (BETA)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -70,6 +70,7 @@ import PayPalCheckout
                     environment: order.environment
                 )
 
+                PayPalCheckout.Checkout.showsExitAlert = false
                 PayPalCheckout.Checkout.set(config: payPalNativeConfig)
                 PayPalCheckout.Checkout.start()
             case .failure(let error):


### PR DESCRIPTION
### Summary of changes

- Remove exit survey when canceling PayPal Native Checkout flow

### Visuals
| Before | After |
|-----|-----|
|![Simulator Screen Recording - iPhone 13 - 2022-09-29 at 08 20 49](https://user-images.githubusercontent.com/20733831/193042697-3e7b5aa5-cd92-4b6e-b040-fde8d0ad06e9.gif)|![Simulator Screen Recording - iPhone 13 - 2022-09-28 at 16 04 37](https://user-images.githubusercontent.com/20733831/193042752-450a9fa8-dac3-49f1-980d-6c6f401e3ae2.gif)|

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
