### PR TITLE
BraintreeSEPADirectDebit - Resolve Invalid Bundle with App Store Upload

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7074,7 +7074,6 @@
 		BEF3F17A27CE9EC600072467 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -7144,7 +7143,6 @@
 		BEF3F17B27CE9EC600072467 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * Remove `ENABLE_BITCODE` from framework target build settings
   * _The App Store no longer accepts bitcode submissions from Xcode 14_
+* BraintreeSEPADirectDebit
+  * Resolve Invalid Bundle error when uploading to the App Store
 
 ## 5.13.0 (2022-09-16)
 * BraintreePayPalNativeCheckout (BETA)


### PR DESCRIPTION
### Summary of changes

- Resolve Invalid Bundle error when uploading to the App Store

We were seeing the following error when uploading the app to TestFlight via App Store Connect:
```
Invalid Bundle. The bundle at 'Demo.app/Frameworks/BraintreeSEPADirectDebit.framework' contains disallowed file 'Frameworks'
```

This was due to `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` being set to `YES` in the `BraintreeSEPADirectDebit` module. Changing this value to `NO` allowed us to upload the Demo App to TestFlight as expected as suggested in [this Apple Forum thread](https://developer.apple.com/forums/thread/17732).

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
