### PR TITLE
Moving `correlationId` and `merchant_account_id` up one level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Braintree iOS SDK Release Notes
 
-## Unreleased
-* Fixed the nesting of two keys in the `getBaseParameters` dictionary in the BraintreePayPalNativecheckout module
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Fixed the nesting of two keys in the `getBaseParameters` dictionary in the BraintreePayPalNativecheckout module
 
 ## 5.14.0 (2022-10-05)
 * Remove `ENABLE_BITCODE` from framework target build settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## Unreleased
+* Fixed the nesting of two keys in the `getBaseParameters` dictionary in the BraintreePayPalNativecheckout module
+
 ## 5.14.0 (2022-10-05)
 * Remove `ENABLE_BITCODE` from framework target build settings
   * _The App Store no longer accepts bitcode submissions from Xcode 14_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPalNativeCheckout (BETA)
-  * Fixed the nesting of two keys in the `getBaseParameters` dictionary in the BraintreePayPalNativecheckout module
+  * Fix `merchant_account_id` and `correlation_id` keys to be nested at the top level of the internal create order request
 
 ## 5.14.0 (2022-10-05)
 * Remove `ENABLE_BITCODE` from framework target build settings

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -27,16 +27,17 @@ extension BTPayPalNativeRequest where Self: BTPayPalRequest {
             "no_shipping": !isShippingAddressRequired,
             "brand_name": displayName ?? configuration.json["paypal"]["displayName"].asString(),
             "locale_code": localeCode,
-            "merchant_account_id": merchantAccountID,
-            "correlation_id": riskCorrelationId,
             "address_override": shippingAddressOverride != nil ? !isShippingAddressEditable : false
         ]
-
-        return [// Base values from BTPayPalRequest
-            "line_items": lineItemsArray,
-            "return_url": String(format: "%@://%@success", callbackURLScheme, callbackHostAndPath),
-            "cancel_url": String(format: "%@://%@cancel", callbackURLScheme, callbackHostAndPath),
-            "experience_profile": experienceProfile.compactMapValues { $0 },
+        let baseParams: [AnyHashable: Any?] = [
+          // Base values from BTPayPalRequest
+          "correlation_id": riskCorrelationId,
+          "merchant_account_id": merchantAccountID,
+          "line_items": lineItemsArray,
+          "return_url": String(format: "%@://%@success", callbackURLScheme, callbackHostAndPath),
+          "cancel_url": String(format: "%@://%@cancel", callbackURLScheme, callbackHostAndPath),
+          "experience_profile": experienceProfile.compactMapValues { $0 },
         ]
+        return baseParams.compactMapValues { $0 }
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -24,7 +24,7 @@ class BTPayPalNativeTokenizationClient {
 
         let tokenizationRequest = BTPayPalNativeTokenizationRequest(
           request: request,
-          correlationID: State.correlationIDs.riskCorrelationID ?? ""
+          correlationID: request.riskCorrelationId ?? State.correlationIDs.riskCorrelationID ?? ""
         )
 
         apiClient.post(

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
@@ -69,13 +69,13 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
         // Assert that the return and cancel URLs are correct
         XCTAssertEqual(baseParameters["cancel_url"] as? String, "sdk.ios.braintree://onetouch/v1/cancel")
         XCTAssertEqual(baseParameters["return_url"] as? String, "sdk.ios.braintree://onetouch/v1/success")
+        XCTAssertEqual(baseParameters["merchant_account_id"] as? String, request.merchantAccountID)
+        XCTAssertEqual(baseParameters["correlation_id"] as? String, request.riskCorrelationId)
 
         let profile = try XCTUnwrap(baseParameters["experience_profile"] as? [AnyHashable: Any])
         XCTAssertEqual(profile["no_shipping"] as? Bool, !request.isShippingAddressRequired)
         XCTAssertEqual(profile["brand_name"] as? String, request.displayName)
         XCTAssertEqual(profile["locale_code"] as? String, request.localeCode)
-        XCTAssertEqual(profile["merchant_account_id"] as? String, request.merchantAccountID)
-        XCTAssertEqual(profile["correlation_id"] as? String, request.riskCorrelationId)
         XCTAssertEqual(profile["address_override"] as? Bool, !request.isShippingAddressEditable)
     }
 

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
@@ -42,12 +42,16 @@ class BTPayPalNativeVaultRequest_Tests: XCTestCase {
         request.shippingAddressOverride = shippingAddress
         request.isShippingAddressEditable = true
         request.offerCredit = true
+        request.riskCorrelationId = "risk ID"
+        request.merchantAccountID = "merchant ID"
         
         let parameters = request.parameters(with: configuration)
         
         XCTAssertEqual(parameters["description"] as? String, "desc")
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)
-        
+        XCTAssertEqual(parameters["correlation_id"] as? String, "risk ID")
+        XCTAssertEqual(parameters["merchant_account_id"] as? String, "merchant ID")
+
         guard let shippingParams = parameters["shipping_address"] as? [String:String] else { XCTFail(); return }
         
         XCTAssertEqual(shippingParams["line1"], "123 Main")


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

### Summary of changes

-  This PR fixes the nesting of two keys in the Native Checkout module. Previously, the `getBaseParameters` function returned a dictionary where two keys were mapped at an incorrect depth. This PR fixes that, and correctly moves `correlation_id` and `merchant_account_id` up one level in the parameters dictionary.

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jonathajones 
