### PR TITLE
Update Release Workflow to Update SDK Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           today=$(date +'%Y-%m-%d')
           sed -i '' 's/## unreleased.*/## '"${{ github.event.inputs.version }}"' ('"$today"')/' CHANGELOG.md
           sed -i '' 's/\(s\.version *= *\).*/\1"'"${{ github.event.inputs.version }}"'\"/' Braintree.podspec
-          sed -i '' 's/\(#define BRAINTREE_VERSION (@\).*/\1"'"${{ github.event.inputs.version }}"'\")/' Sources/BraintreeCore/Braintree-Version.h
+          sed -i '' 's/braintreeSDKVersion: String =.*/braintreeSDKVersion: String = "${{ github.event.inputs.version }}"/' Sources/BraintreeCore/BTCoreConstants.swift
           plutil -replace CFBundleVersion -string ${{ github.event.inputs.version }} -- 'Demo/Application/Supporting Files/Braintree-Demo-Info.plist'
           plutil -replace CFBundleShortVersionString -string ${{ github.event.inputs.version }} -- 'Demo/Application/Supporting Files/Braintree-Demo-Info.plist'
           plutil -replace CFBundleVersion -string ${{ github.event.inputs.version }} -- 'Sources/BraintreeCore/Info.plist'


### PR DESCRIPTION
### Summary of changes

- Update github release workflow to update SDK version during the release process

Can test locally by pulling down this branch and running the following in root directory of the project:
```
sed -i '' 's/braintreeSDKVersion: String =.*/braintreeSDKVersion: String = "MY_SUPER_COOL_SDK_VERSION"/' Sources/BraintreeCore/BTCoreConstants.swift
```

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
