### PR TITLE
Deprecate Kount and UnionPay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
   * Rename `nativeRequest` to `request` internally in `tokenizePayPalAccount`
   * `tokenizePayPalAccount` now takes in a `request` of type `BTPayPalNativeRequest` instead of a `nativeRequest` of type `BTPayPalRequest`
 
-
 ## 5.16.0 (2022-10-27)
 * BraintreePayPalDataCollector
   * Update PPRiskMagnes with a version of 5.4.0 with `ENABLE_BITCODE` removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Deprecate Kount custom integrations
+* Deprecate Kount Custom integrations
 * Deprecate the `BraintreeUnionPay` module and containing classes
   * UnionPay cards can now be processed as regular cards (through the `BraintreeCard` module) due to their partnership with Discover
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Deprecate Kount custom integrations
+* Deprecate the `BraintreeUnionPay` module and containing classes
+  * UnionPay cards can now be processed as regular cards (through the `BraintreeCard` module) due to their partnership with Discover
+
 ## 5.16.0 (2022-10-27)
 * BraintreePayPalDataCollector
   * Update PPRiskMagnes with a version of 5.4.0 with `ENABLE_BITCODE` removed

--- a/Demo/Application/Features/UnionPay/BraintreeDemoUnionPayViewController.m
+++ b/Demo/Application/Features/UnionPay/BraintreeDemoUnionPayViewController.m
@@ -123,7 +123,10 @@
                 
                 self.progressBlock(@"Tokenizing card");
                 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 [self.cardClient tokenizeCard:request options:nil completion:^(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error) {
+#pragma clang diagnostic pop
                     if (error) {
                         self.progressBlock([NSString stringWithFormat:@"Error tokenizing card: %@", error.localizedDescription]);
                         return;
@@ -135,8 +138,11 @@
             
             [self presentViewController:alertController animated:YES completion:nil];
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [self.cardClient tokenizeCard:request options:nil completion:^(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error) {
                 if (error) {
+#pragma clang diagnostic pop
                     NSMutableString *errorMessage = [NSMutableString stringWithFormat:@"Error tokenizing card: %@", error.localizedDescription];
                     if (error.localizedFailureReason) {
                         [errorMessage appendString:[NSString stringWithFormat:@". %@", error.localizedFailureReason]];
@@ -181,8 +187,11 @@
 #pragma mark - Private methods
 
 - (void)fetchCapabilities:(NSString *)cardNumber {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.cardClient fetchCapabilities:cardNumber completion:^(BTCardCapabilities * _Nullable cardCapabilities, NSError * _Nullable error) {
         if (error) {
+#pragma clang diagnostic pop
             self.progressBlock([NSString stringWithFormat:@"Error fetching capabilities: %@", error.localizedDescription]);
             return;
         }

--- a/IntegrationTests/BraintreeUnionPay_IntegrationTests.m
+++ b/IntegrationTests/BraintreeUnionPay_IntegrationTests.m
@@ -24,7 +24,10 @@
 
 - (void)pendFetchCapabilities_returnsCardCapabilities {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback invoked"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.cardClient fetchCapabilities:@"6212345678901232" completion:^(BTCardCapabilities * _Nullable cardCapabilities, NSError * _Nullable error) {
+#pragma clang diagnostic pop
         XCTAssertNil(error);
         XCTAssertFalse(cardCapabilities.isDebit);
         XCTAssertTrue(cardCapabilities.isUnionPay);
@@ -104,7 +107,10 @@
     [self waitForExpectationsWithTimeout:5 handler:nil];
 
     expectation = [self expectationWithDescription:@"Callback invoked"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.cardClient tokenizeCard:request options:nil completion:^(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error) {
+#pragma clang diagnostic pop
         XCTAssertNil(error);
         XCTAssertTrue([tokenizedCard.nonce isANonce]);
         XCTAssertEqual(tokenizedCard.cardNetwork, BTCardNetworkUnionPay);

--- a/Sources/BraintreeCard/BTCardClient.m
+++ b/Sources/BraintreeCard/BTCardClient.m
@@ -55,7 +55,10 @@ NSString *const BTCardClientGraphQLTokenizeFeature = @"tokenize_credit_cards";
 
 - (void)tokenizeCard:(BTCard *)card completion:(void (^)(BTCardNonce *tokenizedCard, NSError *error))completion {
     BTCardRequest *request = [[BTCardRequest alloc] initWithCard:card];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self tokenizeCard:request options:nil completion:completion];
+#pragma clang diagnostic pop
 }
 
 

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
@@ -68,7 +68,8 @@ typedef NS_ENUM(NSInteger, BTCardClientErrorType) {
 */
 - (void)tokenizeCard:(BTCardRequest *)request
              options:(nullable NSDictionary *)options
-          completion:(void (^)(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error))completion DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.");
+          completion:(void (^)(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error))completion
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.");
 
 @end
 

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, BTCardClientErrorType) {
 */
 - (void)tokenizeCard:(BTCardRequest *)request
              options:(nullable NSDictionary *)options
-          completion:(void (^)(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error))completion;
+          completion:(void (^)(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error))completion DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.");
 
 @end
 

--- a/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
+++ b/Sources/BraintreeCard/Public/BraintreeCard/BTCardClient.h
@@ -69,7 +69,7 @@ typedef NS_ENUM(NSInteger, BTCardClientErrorType) {
 - (void)tokenizeCard:(BTCardRequest *)request
              options:(nullable NSDictionary *)options
           completion:(void (^)(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error))completion
-DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.");
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `BTCardClient.tokenizeCard(card: completion:)`.");
 
 @end
 

--- a/Sources/BraintreeDataCollector/BTDataCollector.m
+++ b/Sources/BraintreeDataCollector/BTDataCollector.m
@@ -87,6 +87,8 @@ static Class PayPalDataCollectorClass;
 
         dispatch_group_t collectorDispatchGroup = dispatch_group_create();
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if (configuration.isKountEnabled) {
             BTDataCollectorEnvironment btEnvironment = [self environmentFromString:configuration.environment];
             [self setCollectorEnvironment:[self collectorEnvironment:btEnvironment]];
@@ -102,7 +104,8 @@ static Class PayPalDataCollectorClass;
                 dispatch_group_leave(collectorDispatchGroup);
             }];
         }
-        
+#pragma clang diagnostic pop
+
         BOOL isSandbox = [configuration.environment isEqualToString:@"sandbox"];
         
         NSString *payPalClientMetadataID = [BTDataCollector generatePayPalClientMetadataID:isSandbox];

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTConfiguration+DataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTConfiguration+DataCollector.h
@@ -12,11 +12,13 @@
 /**
  Indicates whether Kount is enabled for the merchant account.
 */
-@property (nonatomic, readonly, assign) BOOL isKountEnabled DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
+@property (nonatomic, readonly, assign) BOOL isKountEnabled
+DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 /**
  Returns the Kount merchant id set in the Gateway
 */
-@property (nonatomic, readonly, assign) NSString *kountMerchantID DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
+@property (nonatomic, readonly, assign) NSString *kountMerchantID
+DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 @end

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTConfiguration+DataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTConfiguration+DataCollector.h
@@ -12,11 +12,11 @@
 /**
  Indicates whether Kount is enabled for the merchant account.
 */
-@property (nonatomic, readonly, assign) BOOL isKountEnabled;
+@property (nonatomic, readonly, assign) BOOL isKountEnabled DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 /**
  Returns the Kount merchant id set in the Gateway
 */
-@property (nonatomic, readonly, assign) NSString *kountMerchantID;
+@property (nonatomic, readonly, assign) NSString *kountMerchantID DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 @end

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param fraudMerchantID The fraudMerchantID you have established with your Braintree account manager.
 */
-- (void)setFraudMerchantID:(NSString *)fraudMerchantID;
+- (void)setFraudMerchantID:(NSString *)fraudMerchantID DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 @end
 

--- a/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
+++ b/Sources/BraintreeDataCollector/Public/BraintreeDataCollector/BTDataCollector.h
@@ -36,7 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param fraudMerchantID The fraudMerchantID you have established with your Braintree account manager.
 */
-- (void)setFraudMerchantID:(NSString *)fraudMerchantID DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
+- (void)setFraudMerchantID:(NSString *)fraudMerchantID
+DEPRECATED_MSG_ATTRIBUTE("Kount Custom support will be removed in the next major version. Use `PPDataCollector.collectPayPalDeviceData()`.");
 
 @end
 

--- a/Sources/BraintreeUnionPay/BTCardCapabilities.m
+++ b/Sources/BraintreeUnionPay/BTCardCapabilities.m
@@ -4,7 +4,10 @@
 #import <BraintreeUnionPay/BTCardCapabilities.h>
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 @implementation BTCardCapabilities
+#pragma clang diagnostic pop
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"%@ isUnionPay = %@, isDebit = %@, isSupported = %@, supportsTwoStepAuthAndCapture = %@", [super description], @(self.isUnionPay), @(self.isDebit), @(self.isSupported), @(self.supportsTwoStepAuthAndCapture)];

--- a/Sources/BraintreeUnionPay/BTCardClient+UnionPay.m
+++ b/Sources/BraintreeUnionPay/BTCardClient+UnionPay.m
@@ -27,10 +27,15 @@
 
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 @implementation BTCardClient (UnionPay)
+#pragma clang diagnostic pop
 
 #pragma mark - Public methods
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)fetchCapabilities:(NSString *)cardNumber
                completion:(void (^)(BTCardCapabilities * _Nullable, NSError * _Nullable))completion {
     [self.apiClient fetchOrReturnRemoteConfiguration:^(BTConfiguration * _Nullable configuration, NSError * _Nullable error) {
@@ -65,6 +70,7 @@
          }];
     }];
 }
+#pragma clang diagnostic pop
 
 - (void)enrollCard:(BTCardRequest *)request
         completion:(nonnull void (^)(NSString * _Nullable, BOOL, NSError * _Nullable))completion {

--- a/Sources/BraintreeUnionPay/BTConfiguration+UnionPay.m
+++ b/Sources/BraintreeUnionPay/BTConfiguration+UnionPay.m
@@ -4,7 +4,10 @@
 #import <BraintreeUnionPay/BTConfiguration+UnionPay.h>
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 @implementation BTConfiguration (UnionPay)
+#pragma clang diagnostic pop
 
 - (BOOL)isUnionPayEnabled {
     return [self.json[@"unionPay"][@"enabled"] isTrue];

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
@@ -3,12 +3,14 @@
 /**
  Contains information about a card's capabilities
  */
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
 @interface BTCardCapabilities : NSObject
 
 /**
  Indicates whether the card is Union Pay.
  */
 @property (nonatomic, assign) BOOL isUnionPay;
+
 
 /**
  Indicates whether the card is debit.

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
@@ -3,7 +3,7 @@
 /**
  Contains information about a card's capabilities
  */
-DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `BTCardClient.tokenizeCard(card: completion:)`.")
 @interface BTCardCapabilities : NSObject
 
 /**

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardCapabilities.h
@@ -11,7 +11,6 @@ DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPa
  */
 @property (nonatomic, assign) BOOL isUnionPay;
 
-
 /**
  Indicates whether the card is debit.
  */

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardClient+UnionPay.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardClient+UnionPay.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  BTCardClient category for UnionPay
  */
-DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `BTCardClient.tokenizeCard(card: completion:)`.")
 @interface BTCardClient (UnionPay)
 
 /**

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardClient+UnionPay.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTCardClient+UnionPay.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  BTCardClient category for UnionPay
  */
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
 @interface BTCardClient (UnionPay)
 
 /**

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTConfiguration+UnionPay.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTConfiguration+UnionPay.h
@@ -7,6 +7,7 @@
 /**
  BTConfiguration category for UnionPay
  */
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
 @interface BTConfiguration (UnionPay)
 
 /**

--- a/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTConfiguration+UnionPay.h
+++ b/Sources/BraintreeUnionPay/Public/BraintreeUnionPay/BTConfiguration+UnionPay.h
@@ -7,7 +7,7 @@
 /**
  BTConfiguration category for UnionPay
  */
-DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `CardClient.tokenizeCard(card: completion:)`.")
+DEPRECATED_MSG_ATTRIBUTE("The UnionPay SMS integration is deprecated, as UnionPay can now be processed as a credit card through their partnership with Discover. Use `BTCardClient.tokenizeCard(card: completion:)`.")
 @interface BTConfiguration (UnionPay)
 
 /**


### PR DESCRIPTION
 ### Summary of changes

- Deprecate Kount related methods
- Deprecate all UnionPay classes
- Silence deprecation warnings throughout project and demo using pragma marks
    - _Side note: sadly, there is no equivalent to this once we're in Swift_
- Add helpful messaging in `DEPRECATED_MSG_ATTRIBUTE` to provide merchant alternative solution

![giphy](https://user-images.githubusercontent.com/35243507/202729607-5e87ff3d-914d-4e49-9b5c-7889d7c2c756.gif)


### Checklist

- [X] Added a changelog entry

### Authors
@scannillo
