### PR TITLE
Fix Subclassing CocoaPods Bug in Native Checkout Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPalNativeCheckout (BETA)
-  * Fix CocoaPods bug emitting "Cannot find interface declaration" error
+  * Fix CocoaPods bug emitting "Cannot find interface declaration" error ([CocoaPods issue #11672](https://github.com/CocoaPods/CocoaPods/issues/11672))
   * Rename `riskCorrelationId` to `riskCorrelationID`
   * Rename `nativeRequest` to `request` internally in `tokenizePayPalAccount`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPalNativeCheckout (BETA)
-  * Fix CocoaPods bug emiting "Cannot find interface declaration" error
+  * Fix CocoaPods bug emitting "Cannot find interface declaration" error
   * Rename `riskCorrelationId` to `riskCorrelationID`
 
 ## 5.16.0 (2022-10-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Fix CocoaPods bug emiting "Cannot find interface declaration" error
+  * Rename `riskCorrelationId` to `riskCorrelationID`
+
 ## 5.16.0 (2022-10-27)
 * BraintreePayPalDataCollector
   * Update PPRiskMagnes with a version of 5.4.0 with `ENABLE_BITCODE` removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * BraintreePayPalNativeCheckout (BETA)
   * Fix CocoaPods bug emitting "Cannot find interface declaration" error
   * Rename `riskCorrelationId` to `riskCorrelationID`
+  * Rename `nativeRequest` to `request` internally in `tokenizePayPalAccount`
 
 ## 5.16.0 (2022-10-27)
 * BraintreePayPalDataCollector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fix CocoaPods bug emitting "Cannot find interface declaration" error ([CocoaPods issue #11672](https://github.com/CocoaPods/CocoaPods/issues/11672))
   * Rename `riskCorrelationId` to `riskCorrelationID`
   * Rename `nativeRequest` to `request` internally in `tokenizePayPalAccount`
+  * `tokenizePayPalAccount` now takes in a `request` of type `BTPayPalNativeRequest` instead of a `nativeRequest` of type `BTPayPalRequest`
 
 ## 5.16.0 (2022-10-27)
 * BraintreePayPalDataCollector

--- a/Demo/Application/Features/PayPal - Native Checkout/BraintreeDemoPayPalNativeCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPal - Native Checkout/BraintreeDemoPayPalNativeCheckoutViewController.swift
@@ -52,7 +52,6 @@ class BraintreeDemoPayPalNativeCheckoutViewController: BraintreeDemoPaymentButto
         sender.isEnabled = false
 
         let request = BTPayPalNativeVaultRequest()
-        request.activeWindow = self.view.window
 
         payPalNativeCheckoutClient.tokenizePayPalAccount(with: request) { nonce, error in
             sender.isEnabled = true

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -24,7 +24,7 @@ import PayPalCheckout
     /// `BTPayPalNativeCheckoutAccountNonce`. On failure or user cancelation you will receive an error. If the user cancels
     /// out of the flow, the error code will equal `BTPayPalNativeError.canceled.rawValue`.
     /// - Parameters:
-    ///   - nativeRequest: Either a BTPayPalNativeCheckoutRequest or a BTPayPalNativeVaultRequest
+    ///   - request: Either a BTPayPalNativeCheckoutRequest or a BTPayPalNativeVaultRequest
     ///   - completion: The completion will be invoked exactly once: when tokenization is complete or an error occurs.
     @objc(tokenizePayPalAccountWithPayPalRequest:completion:)
     public func tokenizePayPalAccount(

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -28,15 +28,10 @@ import PayPalCheckout
     ///   - completion: The completion will be invoked exactly once: when tokenization is complete or an error occurs.
     @objc(tokenizePayPalAccountWithPayPalRequest:completion:)
     public func tokenizePayPalAccount(
-        with nativeRequest: BTPayPalRequest,
+        with request: BTPayPalNativeRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
         apiClient.sendAnalyticsEvent("ios.paypal-native.tokenize.started")
-        guard let request = nativeRequest as? (BTPayPalRequest & BTPayPalNativeRequest) else {
-            apiClient.sendAnalyticsEvent("ios.paypal-native.tokenize.invalid-request.failed")
-            completion(nil, BTPayPalNativeError.invalidRequest)
-            return
-        }
 
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
         orderCreationClient.createOrder(with: request) { [weak self] result in
@@ -83,7 +78,7 @@ import PayPalCheckout
         }
     }
 
-    private func tokenize(approval: PayPalCheckout.Approval, request: BTPayPalRequest, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void) {
+    private func tokenize(approval: PayPalCheckout.Approval, request: BTPayPalNativeRequest, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void) {
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: apiClient)
         tokenizationClient.tokenize(request: request, returnURL: approval.data.returnURL!.absoluteString) { result in
             switch result {

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -22,7 +22,8 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalNativeRequest {
     
     // MARK: - Public Properties
-    // NEXT_MAJOR_VERSION: subclass BTPayPalCheckoutRequest once BraintreePayPal is in Swift.
+    // NEXT_MAJOR_VERSION: subclass BTPayPalCheckoutRequest once BraintreePayPal is in Swift as this contains duplicate logic of BTPayPalRequest.
+    // We should remove this duplication and subclass directly once BraintreePayPal is converted to Swift.
 
     /// Used for a one-time payment.
     ///

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -22,17 +22,17 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalNativeRequest {
     
     // MARK: - Public Properties
-    // next_major_version: subclass BTPayPalCheckoutRequest once BraintreePayPal is in Swift.
+    // NEXT_MAJOR_VERSION: subclass BTPayPalCheckoutRequest once BraintreePayPal is in Swift.
 
-    /// Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
-    public var intent: BTPayPalNativeRequestIntent
-    
     /// Used for a one-time payment.
     ///
     /// Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
     public let amount: String
-    
-    /// Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
+
+    /// Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
+    public var intent: BTPayPalNativeRequestIntent
+
+    /// Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
     public var offerPayLater: Bool
     
     /// Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
@@ -40,10 +40,10 @@ import BraintreePayPal
     /// - Note: See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
     public var currencyCode: String?
     
-    /// Optional: If set to true, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
+    /// Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
     public var requestBillingAgreement: Bool
 
-    /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set requestBillingAgreement to true on your BTPayPalCheckoutRequest.
+    /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set `requestBillingAgreement` to `true` on your `BTPayPalNativeVaultRequest`.
     public var billingAgreementDescription: String?
 
     // MARK: - Internal Properties
@@ -60,17 +60,28 @@ import BraintreePayPal
     }
     
     // MARK: - Initializer
-    
+
+    /// Initializes a PayPal Native Checkout request
+    /// - Parameters:
+    ///   - amount: Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.'
+    ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
+    ///   and is limited to 7 digits before the decimal point.
+    ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
+    ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
+    ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
+    ///   - requestBillingAgreement: Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
+    ///   - billingAgreementDescription: Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also
+    ///   set `requestBillingAgreement` to `true` on your `BTPayPalNativeVaultRequest`.
     public init(
-        intent: BTPayPalNativeRequestIntent = .authorize,
         amount: String,
+        intent: BTPayPalNativeRequestIntent = .authorize,
         offerPayLater: Bool = false,
         currencyCode: String? = nil,
         requestBillingAgreement: Bool = false,
         billingAgreementDescription: String? = nil
     ) {
-        self.intent = intent
         self.amount = amount
+        self.intent = intent
         self.offerPayLater = offerPayLater
         self.currencyCode = currencyCode
         self.requestBillingAgreement = requestBillingAgreement

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -3,8 +3,33 @@ import BraintreePayPal
 #endif
 
 /// Options for the PayPal Checkout and PayPal Checkout with Vault flows.
-@objc public class BTPayPalNativeCheckoutRequest: BTPayPalCheckoutRequest, BTPayPalNativeRequest {
+@objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalRequest, BTPayPalNativeRequest {
+    
+    // MARK: - Public Properties
+    
+    // next_major_version: obtain the public properties below by subclassing BTPayPalCheckoutRequest once it is converted to Swift.
+    
+    /// Optional: Payment intent. Defaults to BTPayPalRequestIntentAuthorize. Only applies to PayPal Checkout.
+    public var intent: BTPayPalRequestIntent = .authorize
+    
+    /// Used for a one-time payment.
+    ///
+    /// Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
+    public let amount: String
+    
+    /// Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
+    public var offerPayLater: Bool = false
+    
+    /// Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
+    ///
+    /// - Note: See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
+    public let currencyCode: String?
+    
+    /// Optional: If set to true, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
+    public var requestBillingAgreement: Bool = false
 
+    // MARK: - Internal Properties
+    
     let paymentType: BTPayPalPaymentType = .checkout
 
     let hermesPath: String = "v1/paypal_hermes/create_payment_resource"
@@ -19,6 +44,24 @@ import BraintreePayPal
             return "authorize"
         }
     }
+    
+    // MARK: - Initializer
+    
+    public init(
+        intent: BTPayPalRequestIntent = .authorize,
+        amount: String,
+        offerPayLater: Bool = false,
+        currencyCode: String? = nil,
+        requestBillingAgreement: Bool = false
+    ) {
+        self.intent = intent
+        self.amount = amount
+        self.offerPayLater = offerPayLater
+        self.currencyCode = currencyCode
+        self.requestBillingAgreement = requestBillingAgreement
+    }
+    
+    // MARK: - Internal Methods
 
     func parameters(with configuration: BTConfiguration) -> [AnyHashable: Any] {
         let baseParams = getBaseParameters(with: configuration)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -18,13 +18,12 @@ import BraintreePayPal
     case order
 }
 
-/// Options for the PayPal Checkout and PayPal Checkout with Vault flows.
+/// Options for the PayPal Checkout flow.
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalNativeRequest {
     
     // MARK: - Public Properties
-    
-    // next_major_version: obtain the public properties below by subclassing BTPayPalCheckoutRequest once it is converted to Swift.
-    
+    // next_major_version: subclass BTPayPalCheckoutRequest once BraintreePayPal is in Swift.
+
     /// Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
     public var intent: BTPayPalNativeRequestIntent
     

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -10,7 +10,7 @@ import BraintreePayPal
     // next_major_version: obtain the public properties below by subclassing BTPayPalCheckoutRequest once it is converted to Swift.
     
     /// Optional: Payment intent. Defaults to BTPayPalRequestIntentAuthorize. Only applies to PayPal Checkout.
-    public var intent: BTPayPalRequestIntent = .authorize
+    public var intent: BTPayPalRequestIntent
     
     /// Used for a one-time payment.
     ///
@@ -18,15 +18,15 @@ import BraintreePayPal
     public let amount: String
     
     /// Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to false. Only available with PayPal Checkout.
-    public var offerPayLater: Bool = false
+    public var offerPayLater: Bool
     
     /// Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
     ///
     /// - Note: See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
-    public let currencyCode: String?
+    public var currencyCode: String?
     
     /// Optional: If set to true, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout.
-    public var requestBillingAgreement: Bool = false
+    public var requestBillingAgreement: Bool
 
     // MARK: - Internal Properties
     

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -2,6 +2,22 @@
 import BraintreePayPal
 #endif
 
+///  Payment intent.
+///
+///  - Note: Must be set to `.sale` for immediate payment, `.authorize` to authorize a payment for capture later, or `.order` to create an order. Defaults to `authorize`.
+///  - SeeAlso: see https://developer.paypal.com/docs/integration/direct/payments/capture-payment/ Capture payments later
+///  - SeeAlso: https://developer.paypal.com/docs/integration/direct/payments/create-process-order/ Create and process orders
+@objc public enum BTPayPalNativeRequestIntent: Int {
+    /// Authorize
+    case authorize
+
+    /// Sale
+    case sale
+
+    /// Order
+    case order
+}
+
 /// Options for the PayPal Checkout and PayPal Checkout with Vault flows.
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalRequest, BTPayPalNativeRequest {
     
@@ -10,7 +26,7 @@ import BraintreePayPal
     // next_major_version: obtain the public properties below by subclassing BTPayPalCheckoutRequest once it is converted to Swift.
     
     /// Optional: Payment intent. Defaults to BTPayPalRequestIntentAuthorize. Only applies to PayPal Checkout.
-    public var intent: BTPayPalRequestIntent
+    public var intent: BTPayPalNativeRequestIntent
     
     /// Used for a one-time payment.
     ///
@@ -48,7 +64,7 @@ import BraintreePayPal
     // MARK: - Initializer
     
     public init(
-        intent: BTPayPalRequestIntent = .authorize,
+        intent: BTPayPalNativeRequestIntent = .authorize,
         amount: String,
         offerPayLater: Bool = false,
         currencyCode: String? = nil,

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -23,7 +23,7 @@ class BTPayPalNativeOrderCreationClient {
     }
 
     func createOrder(
-        with request: BTPayPalRequest & BTPayPalNativeRequest,
+        with request: BTPayPalNativeRequest,
         completion: @escaping (Result<BTPayPalNativeOrder, BTPayPalNativeError>) -> Void
     ) {
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
@@ -61,7 +61,7 @@ class BTPayPalNativeOrderCreationClient {
 
             self.apiClient.post(
                 request.hermesPath,
-                parameters: request.parameters(with: config)
+                parameters: request.constructParameters(from: config, withRequest: request)
             ) { json, response, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -6,17 +6,164 @@ import BraintreeCore
 import BraintreePayPal
 #endif
 
-protocol BTPayPalNativeRequest {
-    var hermesPath: String { get }
-    var paymentType: BTPayPalPaymentType { get }
+@objcMembers public class BTPayPalNativeRequest: NSObject {
 
-    func parameters(with configuration: BTConfiguration) -> [AnyHashable: Any]
-}
+    // MARK: - Public Properties
 
-/// Since Swift types do not have access to the Objective-c internal headers of the other Braintree modules,
-/// We use this protocol extension to provide a shared implementation of the `parameters(with: BTConfiguration)`
-/// function on the `BTPayPalRequest` type
-extension BTPayPalNativeRequest where Self: BTPayPalRequest {
+    /// Optional: The line items for this transaction. It can include up to 249 line items.
+    public var lineItems: [BTPayPalLineItem]?
+
+    /// Defaults to false. When set to true, the shipping address selector will be displayed.
+    public var isShippingAddressRequired: Bool
+
+    /// Optional: The merchant name displayed inside of the PayPal flow; defaults to the company name on your Braintree account
+    public var displayName: String?
+
+    ///  Optional: A locale code to use for the transaction.
+    ///  - Note: Supported locales are:
+    ///
+    /// `da_DK`,
+    /// `de_DE`,
+    /// `en_AU`,
+    /// `en_GB`,
+    /// `en_US`,
+    /// `es_ES`,
+    /// `es_XC`,
+    /// `fr_CA`,
+    /// `fr_FR`,
+    /// `fr_XC`,
+    /// `id_ID`,
+    /// `it_IT`,
+    /// `ja_JP`,
+    /// `ko_KR`,
+    /// `nl_NL`,
+    /// `no_NO`,
+    /// `pl_PL`,
+    /// `pt_BR`,
+    /// `pt_PT`,
+    /// `ru_RU`,
+    /// `sv_SE`,
+    /// `th_TH`,
+    /// `tr_TR`,
+    /// `zh_CN`,
+    /// `zh_HK`,
+    /// `zh_TW`,
+    /// `zh_XC`.
+    public var localeCode: String?
+
+    /// Defaults to false. Set to true to enable user editing of the shipping address.
+    /// - Note: Only applies when `shippingAddressOverride` is set.
+    public var isShippingAddressEditable: Bool
+
+    /// Optional: A valid shipping address to be displayed in the transaction flow. An error will occur if this address is not valid.
+    public var shippingAddressOverride: BTPostalAddress?
+
+    /// Optional: A risk correlation ID created with Set Transaction Context on your server.
+    public var riskCorrelationID: String?
+
+    /// Optional: A non-default merchant account to use for tokenization.
+    public var merchantAccountID: String?
+
+    // MARK: - Internal Properties
+
+    var hermesPath: String
+
+    var paymentType: BTPayPalPaymentType
+
+    // MARK: - Initializer
+
+    init(
+        hermesPath: String,
+        paymentType: BTPayPalPaymentType,
+        lineItems: [BTPayPalLineItem]? = nil,
+        isShippingAddressRequired: Bool = false,
+        displayName: String? = nil,
+        localeCode: String? = nil,
+        isShippingAddressEditable: Bool = false,
+        shippingAddressOverride: BTPostalAddress? = nil,
+        riskCorrelationID: String? = nil,
+        merchantAccountID: String? = nil
+    ) {
+        self.hermesPath = hermesPath
+        self.paymentType = paymentType
+        self.lineItems = lineItems
+        self.isShippingAddressRequired = isShippingAddressRequired
+        self.displayName = displayName
+        self.localeCode = localeCode
+        self.isShippingAddressEditable = isShippingAddressEditable
+        self.shippingAddressOverride = shippingAddressOverride
+        self.riskCorrelationID = riskCorrelationID
+        self.merchantAccountID = merchantAccountID
+    }
+
+    // MARK: - Internal Methods
+
+    func constructParameters(from configuration: BTConfiguration, withRequest request: Any) -> [AnyHashable: Any] {
+        let baseParameters = getBaseParameters(with: configuration)
+
+        switch paymentType {
+        case .checkout:
+            guard let request = request as? BTPayPalNativeCheckoutRequest else { return [:] }
+
+            var billingAgreementDictionary: [AnyHashable: Any]? = [:]
+
+            if request.billingAgreementDescription != nil {
+                billingAgreementDictionary?["description"] = request.billingAgreementDescription
+            } else {
+                billingAgreementDictionary = nil
+            }
+
+            let checkoutParameters = [
+                // Values from BTPayPalCheckoutRequest
+                "intent": request.intentAsString,
+                "amount": request.amount,
+                "offer_pay_later": request.offerPayLater,
+                "currency_iso_code": request.currencyCode ?? configuration.json["paypal"]["currencyIsoCode"].asString(),
+                "request_billing_agreement": request.requestBillingAgreement ? true : nil,
+                "billing_agreement_details": request.requestBillingAgreement ? billingAgreementDictionary : nil,
+                "line1": shippingAddressOverride?.streetAddress,
+                "line2": shippingAddressOverride?.extendedAddress,
+                "city": shippingAddressOverride?.locality,
+                "state": shippingAddressOverride?.region,
+                "postal_code": shippingAddressOverride?.postalCode,
+                "country_code": shippingAddressOverride?.countryCodeAlpha2,
+                "recipient_name": shippingAddressOverride?.recipientName,
+            ].compactMapValues { $0 }
+
+            return baseParameters.merging(checkoutParameters) { $1 }
+        case .vault:
+            guard let request = request as? BTPayPalNativeVaultRequest else { return [:] }
+
+            // Should only include shipping params if they exist
+            var shippingParams: [AnyHashable: Any?]? = [:]
+            if shippingAddressOverride != nil {
+                shippingParams = [
+                    "line1": request.shippingAddressOverride?.streetAddress,
+                    "line2": request.shippingAddressOverride?.extendedAddress,
+                    "city": request.shippingAddressOverride?.locality,
+                    "state": request.shippingAddressOverride?.region,
+                    "postal_code": request.shippingAddressOverride?.postalCode,
+                    "country_code": request.shippingAddressOverride?.countryCodeAlpha2,
+                    "recipient_name": request.shippingAddressOverride?.recipientName,
+                  ]
+            } else {
+                shippingParams = nil
+            }
+
+            let params: [AnyHashable : Any?] = [
+              "description": request.billingAgreementDescription,
+              "offer_paypal_credit": request.offerCredit,
+              "shipping_address": shippingParams,
+            ]
+
+            let vaultParameters = params.compactMapValues { $0 }
+
+            return baseParameters.merging(vaultParameters) { $1 }
+        @unknown default:
+            return [:]
+        }
+    }
+
     func getBaseParameters(with configuration: BTConfiguration) -> [AnyHashable: Any] {
         let callbackHostAndPath = "onetouch/v1/"
         let callbackURLScheme = "sdk.ios.braintree"
@@ -29,15 +176,17 @@ extension BTPayPalNativeRequest where Self: BTPayPalRequest {
             "locale_code": localeCode,
             "address_override": shippingAddressOverride != nil ? !isShippingAddressEditable : false
         ]
+
         let baseParams: [AnyHashable: Any?] = [
-          // Base values from BTPayPalRequest
-          "correlation_id": riskCorrelationId,
+          // Base values from BTPayPalNativeRequest
+          "correlation_id": riskCorrelationID,
           "merchant_account_id": merchantAccountID,
           "line_items": lineItemsArray,
           "return_url": String(format: "%@://%@success", callbackURLScheme, callbackHostAndPath),
           "cancel_url": String(format: "%@://%@cancel", callbackURLScheme, callbackHostAndPath),
-          "experience_profile": experienceProfile.compactMapValues { $0 },
+          "experience_profile": experienceProfile.compactMapValues { $0 }
         ]
+
         return baseParams.compactMapValues { $0 }
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -9,6 +9,7 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeRequest: NSObject {
 
     // MARK: - Public Properties
+    // next_major_version: subclass BTPayPalRequest once BraintreePayPal is in Swift.
 
     /// Optional: The line items for this transaction. It can include up to 249 line items.
     public var lineItems: [BTPayPalLineItem]?
@@ -114,7 +115,7 @@ import BraintreePayPal
             }
 
             let checkoutParameters = [
-                // Values from BTPayPalCheckoutRequest
+                // Values from BTPayPalNativeCheckoutRequest
                 "intent": request.intentAsString,
                 "amount": request.amount,
                 "offer_pay_later": request.offerPayLater,
@@ -145,18 +146,17 @@ import BraintreePayPal
                     "postal_code": request.shippingAddressOverride?.postalCode,
                     "country_code": request.shippingAddressOverride?.countryCodeAlpha2,
                     "recipient_name": request.shippingAddressOverride?.recipientName,
-                  ]
+                ]
             } else {
                 shippingParams = nil
             }
 
-            let params: [AnyHashable : Any?] = [
-              "description": request.billingAgreementDescription,
-              "offer_paypal_credit": request.offerCredit,
-              "shipping_address": shippingParams,
-            ]
-
-            let vaultParameters = params.compactMapValues { $0 }
+            // Values from BTPayPalNativeVaultRequest
+            let vaultParameters = [
+                "description": request.billingAgreementDescription ?? "",
+                "offer_paypal_credit": request.offerCredit,
+                "shipping_address": shippingParams ?? [:],
+            ].compactMapValues { $0 }
 
             return baseParameters.merging(vaultParameters) { $1 }
         @unknown default:

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -17,14 +17,14 @@ class BTPayPalNativeTokenizationClient {
     }
 
     func tokenize(
-        request: BTPayPalRequest,
+        request: BTPayPalNativeRequest,
         returnURL: String,
         completion: @escaping (Result<BTPayPalNativeCheckoutAccountNonce, BTPayPalNativeError>) -> Void)
     {
 
         let tokenizationRequest = BTPayPalNativeTokenizationRequest(
           request: request,
-          correlationID: request.riskCorrelationId ?? State.correlationIDs.riskCorrelationID ?? ""
+          correlationID: request.riskCorrelationID ?? State.correlationIDs.riskCorrelationID ?? ""
         )
 
         apiClient.post(

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
@@ -10,10 +10,10 @@ import PayPalCheckout
 
 class BTPayPalNativeTokenizationRequest {
 
-    private let request: BTPayPalRequest
+    private let request: BTPayPalNativeRequest
     private let correlationID: String
 
-    init(request: BTPayPalRequest, correlationID: String) {
+    init(request: BTPayPalNativeRequest, correlationID: String) {
         self.request = request
         self.correlationID = correlationID
     }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -6,9 +6,9 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeVaultRequest: BTPayPalNativeRequest {
 
     // MARK: - Public Properties
+    // next_major_version: subclass BTPayPalVaultRequest once BraintreePayPal is in Swift.
 
     /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to false.
-    // next_major_version: subclass BTPayPalVaultRequest once BTPayPal is in Swift.
     public var offerCredit: Bool
 
     /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set requestBillingAgreement to true on your BTPayPalCheckoutRequest.

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -3,8 +3,12 @@ import BraintreePayPal
 #endif
 
 /// Options for the PayPal Vault flow.
-@objc public class BTPayPalNativeVaultRequest: BTPayPalVaultRequest, BTPayPalNativeRequest {
+@objcMembers public class BTPayPalNativeVaultRequest: BTPayPalRequest, BTPayPalNativeRequest {
 
+    /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to false.
+    // next_major_version: subclass BTPayPalVaultRequest once BTPayPal is in Swift.
+    public var offerCredit: Bool = false
+    
     let hermesPath: String = "v1/paypal_hermes/setup_billing_agreement"
     let paymentType: BTPayPalPaymentType = .vault
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -6,16 +6,21 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeVaultRequest: BTPayPalNativeRequest {
 
     // MARK: - Public Properties
-    // next_major_version: subclass BTPayPalVaultRequest once BraintreePayPal is in Swift.
+    // NEXT_MAJOR_VERSION: subclass BTPayPalVaultRequest once BraintreePayPal is in Swift.
 
-    /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to false.
+    /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     public var offerCredit: Bool
 
-    /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set requestBillingAgreement to true on your BTPayPalCheckoutRequest.
+    /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set `requestBillingAgreement` to `true` on your `BTPayPalCheckoutRequest`.
     public var billingAgreementDescription: String?
 
     // MARK: - Initializer
 
+    /// Initializes a PayPal Native Vault request
+    /// - Parameters:
+    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    ///   - billingAgreementDescription: Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set
+    ///   `requestBillingAgreement` to `true` on your `BTPayPalCheckoutRequest`.
     public init(
         offerCredit: Bool = false,
         billingAgreementDescription: String? = nil

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -3,46 +3,26 @@ import BraintreePayPal
 #endif
 
 /// Options for the PayPal Vault flow.
-@objcMembers public class BTPayPalNativeVaultRequest: BTPayPalRequest, BTPayPalNativeRequest {
+@objcMembers public class BTPayPalNativeVaultRequest: BTPayPalNativeRequest {
+
+    // MARK: - Public Properties
 
     /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to false.
     // next_major_version: subclass BTPayPalVaultRequest once BTPayPal is in Swift.
-    public var offerCredit: Bool = false
-    
-    let hermesPath: String = "v1/paypal_hermes/setup_billing_agreement"
-    let paymentType: BTPayPalPaymentType = .vault
+    public var offerCredit: Bool
 
-    func parameters(with configuration: BTConfiguration) -> [AnyHashable : Any] {
+    /// Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set requestBillingAgreement to true on your BTPayPalCheckoutRequest.
+    public var billingAgreementDescription: String?
 
-        let baseParams = getBaseParameters(with: configuration)
+    // MARK: - Initializer
 
-        // Should only include shipping params if they exist
-        let shippingParams: [AnyHashable: Any?]? = {
-            if let shippingOverride = shippingAddressOverride {
-                return [
-                  "line1": shippingOverride.streetAddress,
-                  "line2": shippingOverride.extendedAddress,
-                  "city": shippingOverride.locality,
-                  "state": shippingOverride.region,
-                  "postal_code": shippingOverride.postalCode,
-                  "country_code": shippingOverride.countryCodeAlpha2,
-                  "recipient_name": shippingOverride.recipientName,
-                ]
-            } else {
-                return nil
-            }
-        }()
+    public init(
+        offerCredit: Bool = false,
+        billingAgreementDescription: String? = nil
+    ) {
+        self.offerCredit = offerCredit
+        self.billingAgreementDescription = billingAgreementDescription
 
-        let params: [AnyHashable : Any?] = [
-          "description": self.billingAgreementDescription,
-          "offer_paypal_credit": offerCredit,
-          "shipping_address": shippingParams,
-        ]
-
-        let prunedParams = params.compactMapValues { $0 }
-
-        // Combining the base parameters with the parameters defined here - if there is a conflict,
-        // choose the values defined here
-        return baseParams.merging(prunedParams) {_, new in new }
+        super.init(hermesPath: "v1/paypal_hermes/setup_billing_agreement", paymentType: .vault)
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -6,7 +6,8 @@ import BraintreePayPal
 @objcMembers public class BTPayPalNativeVaultRequest: BTPayPalNativeRequest {
 
     // MARK: - Public Properties
-    // NEXT_MAJOR_VERSION: subclass BTPayPalVaultRequest once BraintreePayPal is in Swift.
+    // NEXT_MAJOR_VERSION: subclass BTPayPalVaultRequest once BraintreePayPal is in Swift as this contains duplicate logic of BTPayPalRequest.
+    // We should remove this duplication and subclass directly once BraintreePayPal is converted to Swift.
 
     /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     public var offerCredit: Bool

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -12,16 +12,6 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         apiClient = MockAPIClient(authorization: "development_client_key")
     }
 
-    func testInvalidRequest_ReturnsCorrectError() {
-        let checkoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
-
-        checkoutClient.tokenizePayPalAccount(with: BTPayPalRequest()) { nonce, error in
-            XCTAssertNil(nonce)
-            XCTAssertEqual(error as? BTPayPalNativeError, .invalidRequest)
-            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.tokenize.invalid-request.failed")
-        }
-    }
-
     func testInvalidConfiguration_ReturnsCorrectError() {
         let environment = "sandbox"
         apiClient.cannedConfigurationResponseBody = BTJSON(value: [

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
@@ -53,7 +53,7 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
         request.isShippingAddressRequired = true
         request.displayName = "Test Request"
         request.merchantAccountID = "Merchant Acct ID"
-        request.riskCorrelationId = "Risk Correlation ID"
+        request.riskCorrelationID = "Risk Correlation ID"
         request.shippingAddressOverride = BTPostalAddress()
         request.isShippingAddressEditable = true
         let baseParameters = request.getBaseParameters(with: configuration)
@@ -70,7 +70,7 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(baseParameters["cancel_url"] as? String, "sdk.ios.braintree://onetouch/v1/cancel")
         XCTAssertEqual(baseParameters["return_url"] as? String, "sdk.ios.braintree://onetouch/v1/success")
         XCTAssertEqual(baseParameters["merchant_account_id"] as? String, request.merchantAccountID)
-        XCTAssertEqual(baseParameters["correlation_id"] as? String, request.riskCorrelationId)
+        XCTAssertEqual(baseParameters["correlation_id"] as? String, request.riskCorrelationID)
 
         let profile = try XCTUnwrap(baseParameters["experience_profile"] as? [AnyHashable: Any])
         XCTAssertEqual(profile["no_shipping"] as? Bool, !request.isShippingAddressRequired)
@@ -98,7 +98,7 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
         request.shippingAddressOverride = shippingAddress
         request.isShippingAddressEditable = true
 
-        let parameters = request.parameters(with: configuration)
+        let parameters = request.constructParameters(from: configuration, withRequest: request)
 
         XCTAssertEqual(parameters["intent"] as? String, "sale")
         XCTAssertEqual(parameters["amount"] as? String, "1")

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
@@ -28,12 +28,13 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
         mockClient.cannedResponseBody = BTJSON(data: responseData)
 
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: mockClient)
+        let nativeRequest = BTPayPalNativeRequest(hermesPath: "", paymentType: .checkout)
 
         // Our mock does not care about the specific request, but we want to make sure
         // a successful response is vended through the completion handler
         // We don't need to use `waitForExpectations` here because the mock will vend a response
         // synchronously
-        tokenizationClient.tokenize(request: BTPayPalRequest(), returnURL: "a-fake-return-url") { result in
+        tokenizationClient.tokenize(request: nativeRequest, returnURL: "a-fake-return-url") { result in
             switch result {
             case .success(let account):
                 XCTAssertEqual(account.nonce, mockNonce)
@@ -66,8 +67,9 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
         """.data(using: .utf8))
         mockClient.cannedResponseBody = BTJSON(data: responseData)
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: mockClient)
+        let nativeRequest = BTPayPalNativeRequest(hermesPath: "", paymentType: .vault)
 
-        tokenizationClient.tokenize(request: BTPayPalRequest(), returnURL: "a-fake-return-url") { result in
+        tokenizationClient.tokenize(request: nativeRequest, returnURL: "a-fake-return-url") { result in
             switch result {
             case .success:
                 XCTFail("A response without a nonce string should be a failure")

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
@@ -42,10 +42,10 @@ class BTPayPalNativeVaultRequest_Tests: XCTestCase {
         request.shippingAddressOverride = shippingAddress
         request.isShippingAddressEditable = true
         request.offerCredit = true
-        request.riskCorrelationId = "risk ID"
+        request.riskCorrelationID = "risk ID"
         request.merchantAccountID = "merchant ID"
         
-        let parameters = request.parameters(with: configuration)
+        let parameters = request.constructParameters(from: configuration, withRequest: request)
         
         XCTAssertEqual(parameters["description"] as? String, "desc")
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)


### PR DESCRIPTION
### Summary of changes

- Fix subclassing bug where merchants using CocoaPods were seeing the error "Cannot find interface declaration" with subclassed Obj-C class modules in Swift modules ([CocoaPods issue #11672](https://github.com/CocoaPods/CocoaPods/issues/11672))
- Rename `riskCorrelationId` to `riskCorrelationID`
- This fix was tested in a local cocoapods project pointing to the latest commit of this branch - the project now builds as expected without emitting any "Cannot find interface declaration" errors

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder @jaxdesmarais