### PR TITLE
Remove `Bundle.main.bundleIdentifier` inspection from SEPA module

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		800FC544257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */; };
 		8016A87D2509185C00DB5EF3 /* BTPaymentFlow_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8016A87C2509185C00DB5EF3 /* BTPaymentFlow_Tests.swift */; };
 		80252BD627299FE0002E0D84 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4226B30AA600F0A559 /* PPRiskMagnes.xcframework */; };
+		804E6288293866AD004B9FEF /* BTSEPADirectDebitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E6287293866AD004B9FEF /* BTSEPADirectDebitConstants.swift */; };
 		80581A8C25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */; };
 		80581B1D2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */; };
 		80A79DD625CA04CB00A9E9A2 /* BTVenmoRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A79DD425CA04CB00A9E9A2 /* BTVenmoRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -922,6 +923,7 @@
 		8016A87E2509221F00DB5EF3 /* BraintreePaymentFlowTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BraintreePaymentFlowTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		801FD8E32231B4F000014DB0 /* BTThreeDSecureAdditionalInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTThreeDSecureAdditionalInformation.m; sourceTree = "<group>"; };
 		801FD8E72231C34500014DB0 /* BTThreeDSecureAdditionalInformation_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTThreeDSecureAdditionalInformation_Internal.h; sourceTree = "<group>"; };
+		804E6287293866AD004B9FEF /* BTSEPADirectDebitConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitConstants.swift; sourceTree = "<group>"; };
 		80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BTConfiguration+ThreeDSecure_Tests.swift"; sourceTree = "<group>"; };
 		80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLHTTP_SSLPinning_IntegrationTests.swift; sourceTree = "<group>"; };
 		805FD35B2331780F0000B514 /* BTPostalAddress_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPostalAddress_Tests.swift; sourceTree = "<group>"; };
@@ -2314,6 +2316,7 @@
 			isa = PBXGroup;
 			children = (
 				BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */,
+				804E6287293866AD004B9FEF /* BTSEPADirectDebitConstants.swift */,
 				BE642D8927D00F1300694A5B /* BTSEPADirectDebitMandateType.swift */,
 				BE642D8727D0094600694A5B /* BTSEPADirectDebitNonce.swift */,
 				BE642D8527D0047800694A5B /* BTSEPADirectDebitRequest.swift */,
@@ -3940,6 +3943,7 @@
 				BEF3F17E27CE9EDF00072467 /* BTSEPADirectDebitClient.swift in Sources */,
 				BE0B163F27E0CD7C00868C77 /* SEPADirectDebitAPI.swift in Sources */,
 				9C67362E27E3DAB90089BD99 /* SEPADirectDebitError.swift in Sources */,
+				804E6288293866AD004B9FEF /* BTSEPADirectDebitConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitConstants.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitConstants.swift
@@ -1,0 +1,5 @@
+enum BTSEPADirectDebitConstants {
+    
+    // NEXT_MAJOR_VERSION: - move this to BTCoreConstants.swift for use across modules that also use this scheme (ex: PayPal)
+    static let callbackURLScheme: String = "sdk.ios.braintree"
+}

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
@@ -24,10 +24,6 @@ import BraintreeCore
 
     /// Optional. A non-default merchant account to use for tokenization.
     public var merchantAccountID: String?
-    
-    var cancelURL: String
-    
-    var returnURL: String
 
     /// Initialize a new SEPA Direct Debit request.
     /// - Parameters:
@@ -52,10 +48,5 @@ import BraintreeCore
         self.mandateType = mandateType
         self.billingAddress = billingAddress
         self.merchantAccountID = merchantAccountID
-        
-        let bundleID = Bundle.main.bundleIdentifier ?? ""
-
-        self.cancelURL = bundleID.appending("://sepa/cancel")
-        self.returnURL = bundleID.appending("://sepa/success")
     }
 }

--- a/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
@@ -33,8 +33,8 @@ class SEPADirectDebitAPI {
                 ]
             ],
             "merchant_account_id": sepaDirectDebitRequest.merchantAccountID ?? "",
-            "cancel_url": sepaDirectDebitRequest.cancelURL,
-            "return_url": sepaDirectDebitRequest.returnURL
+            "cancel_url": BTSEPADirectDebitConstants.callbackURLScheme + "://sepa/cancel",
+            "return_url": BTSEPADirectDebitConstants.callbackURLScheme + "://sepa/success"
         ]
 
         apiClient.post("v1/sepa_debit", parameters: json) { body, response, error in

--- a/Sources/BraintreeSEPADirectDebit/WebAuthenticationSession.swift
+++ b/Sources/BraintreeSEPADirectDebit/WebAuthenticationSession.swift
@@ -13,7 +13,7 @@ class WebAuthenticationSession: NSObject {
     ) {
         self.authenticationSession = ASWebAuthenticationSession(
             url: url,
-            callbackURLScheme: Bundle.main.bundleIdentifier,
+            callbackURLScheme: BTSEPADirectDebitConstants.callbackURLScheme,
             completionHandler: completion
         )
 


### PR DESCRIPTION
### Reason for changes

- We don't need to access the app's `Bundle.main.bundleIdentifier` for `ASWebAuthenticationSession` flows 🎉 

### Summary of changes

- Replace `Bundle.main.bundleIdentifier` inspection with custom SDK scheme (re-used the same scheme that we already use in BraintreePayPal and BraintreePayPalNativeCheckout)
- Added missing test for the URL and POST body of the request to `"v1/sepa_debit"`

### Questions
Jax, I know you mentioned there is difficulty testing this. I was able to go through the sandbox flow successfully. Let me know if there is anything else I should be testing.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo