### PR TITLE
Update native checkout110

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '0.110.0'
+    s.dependency "PayPalCheckout", '0.108.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '0.108.0'
+    s.dependency "PayPalCheckout", '0.110.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7488,7 +7488,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 0.108.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7488,7 +7488,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.108.0;
+				version = 0.110.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Braintree iOS SDK Release Notes
 
-## unreleased
-* BraintreePayPalNativeCheckout (BETA)
-  * Update NativeCheckout version from 0.108.0 to 0.110.0
-  * Fix issues with using multiple clientIDs falling back to web
-  
 ## 5.18.0 (2022-12-13)
 * Deprecate Kount Custom integrations
 * Deprecate the `BraintreeUnionPay` module and containing classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Update NativeCheckout version from 0.108.0 to 0.110.0
+  * Fix issue with multiple clientIDs causing incorrect web fallback
+  
 ## 5.18.0 (2022-12-13)
 * Deprecate Kount Custom integrations
 * Deprecate the `BraintreeUnionPay` module and containing classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Update NativeCheckout version from 0.108.0 to 0.110.0
+  * Fix issues with using multiple clientIDs falling back to web
+  
 ## 5.18.0 (2022-12-13)
 * Deprecate Kount Custom integrations
 * Deprecate the `BraintreeUnionPay` module and containing classes

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-3-xcframework-only-update
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.0-no-bitcode-fixed
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.108.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.110.0

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -1244,7 +1244,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 0.108.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -1244,7 +1244,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.108.0;
+				version = 0.110.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.swift
+++ b/Package.swift
@@ -106,8 +106,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PayPalCheckout",
-            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.110.0/PayPalCheckout.xcframework.zip",
-            checksum: "e9895c202b090a7bde5c47685e96aef68b6f334e3f3798a79dd49b32c81fe130"
+            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.108.0/PayPalCheckout.xcframework.zip",
+            checksum: "f186036ec1b180f9cb84a48ea00ca5835a3fce3af8d112b1e3067fa9d56dcf78"
         ),
         .target(
             name: "BraintreeSEPADirectDebit",

--- a/Package.swift
+++ b/Package.swift
@@ -106,8 +106,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PayPalCheckout",
-            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.108.0/PayPalCheckout.xcframework.zip",
-            checksum: "f186036ec1b180f9cb84a48ea00ca5835a3fce3af8d112b1e3067fa9d56dcf78"
+            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.110.0/PayPalCheckout.xcframework.zip",
+            checksum: "e9895c202b090a7bde5c47685e96aef68b6f334e3f3798a79dd49b32c81fe130"
         ),
         .target(
             name: "BraintreeSEPADirectDebit",


### PR DESCRIPTION
### Summary of changes

- This PR increments the version of native checkout included in the Braintree SDK to 0.110.0. The biggest change in this version is the support for multiple clientIDs not causing a web fallback.


### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- vradopp
