### PR TITLE
Remove Xcode 12 note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ pod 'Braintree/DataCollector'
 pod 'Braintree/Venmo'
 ```
 
-*Note:* If you are using version 4.x.x of the Braintree iOS SDK in Xcode 12, you may see the warning `The iOS Simulator deployment target is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99`. This will not prevent your app from compiling. This is a [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/7314) with a known workaround.
-
 ### Carthage
 Add `github "braintree/braintree_ios"` to your `Cartfile`, and [add the frameworks to your project](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 


### PR DESCRIPTION
### Summary of changes

- Xcode 12 was deprecated in April and devs can no longer upload Apps with it.
- Since Apple doesn't support it, I don't think we need to keep this comment around for Xcode 12.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo
- 
