### PR TITLE
Amend CHANGELOG entry for 5.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
     * _The App Store no longer accepts bitcode submissions from Xcode 14_
     * This version of PPRiskMagnes drops support for Xcode 12 and requires Swift 5.5+
       * [As of April 25, 2022 Apple requires all apps to be submitted with Xcode 13+](https://developer.apple.com/news/upcoming-requirements/?id=04252022a)
+    * This version of the PPRiskMagnes framework is dynamic. This reverts a breaking change that was introduced in minor version 5.8.0 (See GitHub issue #920).
 
 ## 5.15.0 (2022-10-26)
 * BraintreePayPalNativeCheckout (BETA)


### PR DESCRIPTION
### Summary of changes

- This PR amends the CHANGELOG for v5.16.0 to call out that it reverts a "bug" that was introduced in v5.8.0, when we switched from dynamic to static Magnes, which is technically a breaking change.
- I called out in [GH Issue #920 ](https://github.com/braintree/braintree_ios/issues/920)that major version V6 is where we will migrate both binaries (Cardinal and Magnes) to static frameworks.

### Notes
- This go-forward plan was based on our discussions in Slack.
- Let me know what y'all think!
- If this PR gets approved, I can manually update the release notes associated with the 5.16.0 tag.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo