### PR TITLE
Update SEPA and NXO Test Schemes

### DIFF
--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -294,6 +294,28 @@
                ReferencedContainer = "container:../Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9CE5179A282D54030013C740"
+               BuildableName = "BraintreePayPalNativeCheckoutTests.xctest"
+               BlueprintName = "BraintreePayPalNativeCheckoutTests"
+               ReferencedContainer = "container:../Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BE642D8E27D0132A00694A5B"
+               BuildableName = "BraintreeSEPADirectDebitTests.xctest"
+               BlueprintName = "BraintreeSEPADirectDebitTests"
+               ReferencedContainer = "container:../Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
### Summary of changes

This is very much a quality of like fix that has been annoying me. The test schemes for NXO and SEPA were always greyed out in the Demo scheme unlike the other tests which can be run from the Demo scheme. In order to run the NXO and SEPA tests you'd have to switch to the UnitTest scheme - not a huge deal but annoying enough. Now we can run these tests from the same scheme as the others.

| Before | After |
|-----|-----|
|![Screen Shot 2023-01-19 at 8 59 15 AM](https://user-images.githubusercontent.com/20733831/213486277-4b8ba17d-59ab-4117-b7cf-419f2193d6ea.png)|![Screen Shot 2023-01-19 at 8 31 21 AM](https://user-images.githubusercontent.com/20733831/213486333-a92fb85a-2964-46ad-8fb3-89c1724b6299.png)|

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
