### PR TITLE
Update Release Workflow (5.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,9 @@ jobs:
       - name: Publish reference docs
         run: |
           gem install jazzy
-          brew install sourcekitten
+          brew tap-new $USER/local-sourcekitten
+          brew extract --version=0.33.1 sourcekitten $USER/local-sourcekitten
+          brew install sourcekitten@0.33.1
 
           # run sourcekitten on each Swift module individually
           sourcekitten doc -- -workspace Braintree.xcworkspace -scheme PayPalDataCollector -destination 'name=iPhone 11,platform=iOS Simulator' > pay-pal-data-collector.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,8 @@ jobs:
       - name: Publish reference docs
         run: |
           gem install jazzy
-          brew tap-new $USER/local-sourcekitten
-          brew extract --version=0.33.1 sourcekitten $USER/local-sourcekitten
-          brew install sourcekitten@0.33.1
+          sudo xcode-select -switch /Applications/Xcode_14.0.app
+          brew install sourcekitten
 
           # run sourcekitten on each Swift module individually
           sourcekitten doc -- -workspace Braintree.xcworkspace -scheme PayPalDataCollector -destination 'name=iPhone 11,platform=iOS Simulator' > pay-pal-data-collector.json


### PR DESCRIPTION
### Summary of changes

During the 5.x release today the [release blew up on the last step](https://github.com/braintree/braintree_ios/actions/runs/3998282595/jobs/6860714412) (womp womp). We got the following error:
```
sourcekitten: A full installation of Xcode.app 14.0 is required to compile
this software. Installing just the Command Line Tools is not sufficient.

Xcode 14.0 cannot be installed on macOS 11.
You must upgrade your version of macOS.
```
tl;dr is that [Sourcekitten released a new version](https://github.com/jpsim/SourceKitten/releases/tag/0.34.0) with the following requirement: "SourceKitten now requires Swift 5.7 or higher to build.". 

Our CI for version 5.x uses Xcode 13. We went on an adventure and found out that it's actually quite difficult to specify an old version with Homebrew (more womp womp). We found [this article](https://cmichel.io/how-to-install-an-old-package-version-with-brew/) and tested locally to confirm it is working as expected. [Homebrew discussions](https://github.com/Homebrew/discussions/discussions/3251) confirms pulling in the latest version of a package is expected behavior and `brew extract` is how you specify an older version. 

**Note:** we do not need to pick up this change in `master` as it uses Xcode 14 + MacOS 12. We can use the normal `brew install sourcekitten` on that branch.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder @jaxdesmarais 