### PR TITLE
Remove Nested Dictionary Construction

### DIFF
--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -25,8 +25,7 @@ import BraintreeCore
     ///   if it fails, `rewardsBalance` will be `nil` and `error` will describe the failure.
     ///  - Note: If the nonce is associated with an ineligible card or a card with insufficient points, the rewardsBalance will contain this information as `errorMessage` and `errorCode`.
     public func getRewardsBalance(forNonce nonce: String, currencyIsoCode: String, completion: @escaping (BTAmericanExpressRewardsBalance?, Error?) -> Void) {
-        let parameters = ["currencyIsoCode": currencyIsoCode,
-                          "paymentMethodNonce": nonce]
+        let parameters = ["currencyIsoCode": currencyIsoCode, "paymentMethodNonce": nonce]
         apiClient.sendAnalyticsEvent("ios.amex.rewards-balance.start")
 
         apiClient.get("v1/payment_methods/amex_rewards_balance", parameters: parameters) { [weak self] body, response, error in

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -383,16 +383,18 @@ import BraintreeDataCollector
         if let action = action(from: url), action == "cancel" {
             return nil
         }
+
+        let clientDictionary: [String: String] = [
+            "platform": "iOS",
+            "product_name": "PayPal",
+            "paypal_sdk_version": "version"
+        ]
+
+        let responseDictionary: [String: String] = ["webURL": url.absoluteString]
         
         return [
-            "client": [
-                "platform": "iOS",
-                "product_name": "PayPal",
-                "paypal_sdk_version": "version"
-            ],
-            "response": [
-                "webURL": url.absoluteString
-            ],
+            "client": clientDictionary,
+            "response": responseDictionary,
             "response_type": "web"
         ]
     }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
@@ -21,15 +21,16 @@ class BTPayPalNativeTokenizationRequest {
     // The return URL is vended from the Native Checkout SDK and is consumed
     // by the Braintree Gateway to consume payment details
     func parameters(returnURL: String?) -> [String : Any] {
+        let clientDictionary: [String: String] = [
+            "platform": "iOS",
+            "product_name": "PayPal",
+            "paypal_sdk_version": "version"
+        ]
+
+        let responseDictionary: [String: String?] = ["webURL": returnURL ?? ""]
         var account: [String : Any] = [
-            "client": [
-                "platform": "iOS",
-                "product_name": "PayPal",
-                "paypal_sdk_version": "version"
-            ],
-            "response": [
-                "webURL": returnURL ?? "",
-            ],
+            "client": clientDictionary,
+            "response": responseDictionary,
             "response_type": "web",
             "correlation_id": correlationID,
         ]

--- a/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
@@ -18,21 +18,26 @@ class SEPADirectDebitAPI {
         completion: @escaping (CreateMandateResult?, Error?) -> Void
     ) {
         let billingAddress = sepaDirectDebitRequest.billingAddress
+
+        let billingAddressDictionary: [String: String?] = [
+            "address_line_1": billingAddress?.streetAddress,
+            "address_line_2": billingAddress?.extendedAddress,
+            "admin_area_1": billingAddress?.locality,
+            "admin_area_2": billingAddress?.region,
+            "postal_code": billingAddress?.postalCode,
+            "country_code": billingAddress?.countryCodeAlpha2
+        ]
+
+        let sepaDebitDictionary: [String: Any] = [
+            "merchant_or_partner_customer_id": sepaDirectDebitRequest.customerID ?? "",
+            "mandate_type": sepaDirectDebitRequest.mandateType?.description ?? "",
+            "account_holder_name": sepaDirectDebitRequest.accountHolderName ?? "",
+            "iban": sepaDirectDebitRequest.iban ?? "",
+            "billing_address": billingAddressDictionary
+        ]
+
         let json: [String: Any] = [
-            "sepa_debit": [
-                "merchant_or_partner_customer_id": sepaDirectDebitRequest.customerID ?? "",
-                "mandate_type": sepaDirectDebitRequest.mandateType?.description ?? "",
-                "account_holder_name": sepaDirectDebitRequest.accountHolderName ?? "",
-                "iban": sepaDirectDebitRequest.iban ?? "",
-                "billing_address": [
-                    "address_line_1": billingAddress?.streetAddress,
-                    "address_line_2": billingAddress?.extendedAddress,
-                    "admin_area_1": billingAddress?.locality,
-                    "admin_area_2": billingAddress?.region,
-                    "postal_code": billingAddress?.postalCode,
-                    "country_code": billingAddress?.countryCodeAlpha2
-                ]
-            ],
+            "sepa_debit": sepaDebitDictionary,
             "merchant_account_id": sepaDirectDebitRequest.merchantAccountID ?? "",
             "cancel_url": BTCoreConstants.callbackURLScheme + "://sepa/cancel",
             "return_url": BTCoreConstants.callbackURLScheme + "://sepa/success"
@@ -59,14 +64,14 @@ class SEPADirectDebitAPI {
     }
 
     func tokenize(createMandateResult: CreateMandateResult, completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void) {
-        let json: [String: Any] = [
-            "sepa_debit_account": [
-                "last_4": createMandateResult.ibanLastFour,
-                "merchant_or_partner_customer_id": createMandateResult.customerID,
-                "bank_reference_token": createMandateResult.bankReferenceToken,
-                "mandate_type": createMandateResult.mandateType
-            ]
+        let sepaDebitAccountDictionary: [String: String?] = [
+            "last_4": createMandateResult.ibanLastFour,
+            "merchant_or_partner_customer_id": createMandateResult.customerID,
+            "bank_reference_token": createMandateResult.bankReferenceToken,
+            "mandate_type": createMandateResult.mandateType
         ]
+
+        let json: [String: Any] = ["sepa_debit_account": sepaDebitAccountDictionary]
 
         apiClient.post("v1/payment_methods/sepa_debit_accounts", parameters: json) { body, response, error in
             self.apiClient.sendAnalyticsEvent("ios.sepa-direct-debit.api-request.tokenize.started")


### PR DESCRIPTION
## Summary of changes

- Using Xcode's timeline tool, we saw that a few files were taking 1+ second to compile. This is due to how [Swift/Xcode compiles nested dictionaries](https://github.com/apple/swift/issues/47007) - tl;dr much slower.
- This PR extracts nested dictionaries into their own constants to speed up this compile time.
- As an example, the update here to the dictionaries in `SEPADirectDebitAPI` saves us a whopping second of compile time!
- **Note for future us:** we should look into if SwiftLint has the ability to check for this anti-pattern _or_ add a custom regex rule for this - can also likely add this to our style guide

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder @jaxdesmarais 
