### PR TITLE
Fix NXO Dictionary Construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Fix bug where some request dictionaries were being constructed incorrectly
+  * Fix bug where passing `BTPayPalNativeVaultRequest.shippingAddressOverride` as `nil` was incorrectly throwing an error
+
 ## 5.20.0 (2023-01-24)
 * BraintreeThreeDSecure
   * Add `requestedExemptionType` to `BTThreeDSecureRequest`

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -145,15 +145,15 @@ import BraintreePayPal
             }
 
             // Should only include shipping params if they exist
-            if let shippingAddressOverride {
+            if shippingAddressOverride != nil {
                 let shippingAddressParameters: [String: String?] = [
-                    "line1": shippingAddressOverride.streetAddress,
-                    "line2": shippingAddressOverride.extendedAddress,
-                    "city": shippingAddressOverride.locality,
-                    "state": shippingAddressOverride.region,
-                    "postal_code": shippingAddressOverride.postalCode,
-                    "country_code": shippingAddressOverride.countryCodeAlpha2,
-                    "recipient_name": shippingAddressOverride.recipientName,
+                    "line1": shippingAddressOverride?.streetAddress,
+                    "line2": shippingAddressOverride?.extendedAddress,
+                    "city": shippingAddressOverride?.locality,
+                    "state": shippingAddressOverride?.region,
+                    "postal_code": shippingAddressOverride?.postalCode,
+                    "country_code": shippingAddressOverride?.countryCodeAlpha2,
+                    "recipient_name": shippingAddressOverride?.recipientName,
                 ]
 
                 vaultParameters["shipping_address"] = shippingAddressParameters

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -111,9 +111,7 @@ import BraintreePayPal
                 "offer_pay_later": request.offerPayLater
             ]
 
-            let currencyCode = request.currencyCode ?? configuration.json["paypal"]["currencyIsoCode"].asString()
-
-            if currencyCode != nil {
+            if let currencyCode = request.currencyCode ?? configuration.json["paypal"]["currencyIsoCode"].asString() {
                 checkoutParameters["currency_iso_code"] = currencyCode
             }
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -111,7 +111,7 @@ import BraintreePayPal
                 "offer_pay_later": request.offerPayLater
             ]
 
-            let currencyCode = request.currencyCode != nil ? request.currencyCode : configuration.json["paypal"]["currencyIsoCode"].asString()
+            let currencyCode = request.currencyCode ?? configuration.json["paypal"]["currencyIsoCode"].asString()
 
             if currencyCode != nil {
                 checkoutParameters["currency_iso_code"] = currencyCode

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeRequest.swift
@@ -105,58 +105,59 @@ import BraintreePayPal
         switch paymentType {
         case .checkout:
             guard let request = request as? BTPayPalNativeCheckoutRequest else { return [:] }
-
-            var billingAgreementDictionary: [AnyHashable: Any]? = [:]
-
-            if request.billingAgreementDescription != nil {
-                billingAgreementDictionary?["description"] = request.billingAgreementDescription
-            } else {
-                billingAgreementDictionary = nil
-            }
-
-            let checkoutParameters = [
-                // Values from BTPayPalNativeCheckoutRequest
+            var checkoutParameters: [String: Any] = [
                 "intent": request.intentAsString,
                 "amount": request.amount,
-                "offer_pay_later": request.offerPayLater,
-                "currency_iso_code": request.currencyCode ?? configuration.json["paypal"]["currencyIsoCode"].asString(),
-                "request_billing_agreement": request.requestBillingAgreement ? true : nil,
-                "billing_agreement_details": request.requestBillingAgreement ? billingAgreementDictionary : nil,
-                "line1": shippingAddressOverride?.streetAddress,
-                "line2": shippingAddressOverride?.extendedAddress,
-                "city": shippingAddressOverride?.locality,
-                "state": shippingAddressOverride?.region,
-                "postal_code": shippingAddressOverride?.postalCode,
-                "country_code": shippingAddressOverride?.countryCodeAlpha2,
-                "recipient_name": shippingAddressOverride?.recipientName,
-            ].compactMapValues { $0 }
+                "offer_pay_later": request.offerPayLater
+            ]
+
+            let currencyCode = request.currencyCode != nil ? request.currencyCode : configuration.json["paypal"]["currencyIsoCode"].asString()
+
+            if currencyCode != nil {
+                checkoutParameters["currency_iso_code"] = currencyCode
+            }
+
+            if request.requestBillingAgreement != false {
+                checkoutParameters["request_billing_agreement"] = request.requestBillingAgreement
+
+                if request.billingAgreementDescription != nil {
+                    checkoutParameters["billing_agreement_details"] = ["description": request.billingAgreementDescription]
+                }
+            }
+
+            if shippingAddressOverride != nil {
+                checkoutParameters["line1"] = shippingAddressOverride?.streetAddress
+                checkoutParameters["line2"] = shippingAddressOverride?.extendedAddress
+                checkoutParameters["city"] = shippingAddressOverride?.locality
+                checkoutParameters["state"] = shippingAddressOverride?.region
+                checkoutParameters["postal_code"] = shippingAddressOverride?.postalCode
+                checkoutParameters["country_code"] = shippingAddressOverride?.countryCodeAlpha2
+                checkoutParameters["recipient_name"] = shippingAddressOverride?.recipientName
+            }
 
             return baseParameters.merging(checkoutParameters) { $1 }
         case .vault:
             guard let request = request as? BTPayPalNativeVaultRequest else { return [:] }
+            var vaultParameters: [String: Any] = ["offer_paypal_credit": request.offerCredit]
 
-            // Should only include shipping params if they exist
-            var shippingParams: [AnyHashable: Any?]? = [:]
-            if shippingAddressOverride != nil {
-                shippingParams = [
-                    "line1": request.shippingAddressOverride?.streetAddress,
-                    "line2": request.shippingAddressOverride?.extendedAddress,
-                    "city": request.shippingAddressOverride?.locality,
-                    "state": request.shippingAddressOverride?.region,
-                    "postal_code": request.shippingAddressOverride?.postalCode,
-                    "country_code": request.shippingAddressOverride?.countryCodeAlpha2,
-                    "recipient_name": request.shippingAddressOverride?.recipientName,
-                ]
-            } else {
-                shippingParams = nil
+            if request.billingAgreementDescription != nil {
+                vaultParameters["description"] = request.billingAgreementDescription
             }
 
-            // Values from BTPayPalNativeVaultRequest
-            let vaultParameters = [
-                "description": request.billingAgreementDescription ?? "",
-                "offer_paypal_credit": request.offerCredit,
-                "shipping_address": shippingParams ?? [:],
-            ].compactMapValues { $0 }
+            // Should only include shipping params if they exist
+            if let shippingAddressOverride {
+                let shippingAddressParameters: [String: String?] = [
+                    "line1": shippingAddressOverride.streetAddress,
+                    "line2": shippingAddressOverride.extendedAddress,
+                    "city": shippingAddressOverride.locality,
+                    "state": shippingAddressOverride.region,
+                    "postal_code": shippingAddressOverride.postalCode,
+                    "country_code": shippingAddressOverride.countryCodeAlpha2,
+                    "recipient_name": shippingAddressOverride.recipientName,
+                ]
+
+                vaultParameters["shipping_address"] = shippingAddressParameters
+            }
 
             return baseParameters.merging(vaultParameters) { $1 }
         @unknown default:

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
@@ -120,4 +120,13 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
 
         XCTAssertEqual(billingAgreementDetails["description"], "description")
     }
+
+    func testVaultParameters_withShippingAddressOverrideNil_doesNotPassShippingAddress() {
+        let request = BTPayPalNativeVaultRequest()
+        request.shippingAddressOverride = nil
+
+        let parameters = request.constructParameters(from: configuration, withRequest: request)
+
+        XCTAssertNil(parameters["shipping_address"])
+    }
 }


### PR DESCRIPTION
### Summary of changes

- A merchant reported an error where setting `BTPayPalNativeVaultRequest.shippingAddressOverride` as `nil` was throwing an error. Looking at the dictionary construction we were incorrectly constructing the dictionaries in this case resulting in an empty dictionary being passed as the "shipping_address" which is invalid.
- There were some other dictionaries where we weren't checking for `nil` first so made some updates in both the `BTPayPalNativeVaultRequest` and BTPayPalNativeCheckoutRequest` to ensure the dictionaries were constructed as appropriate for the values in the requests.
- Added a unit tests for the specific `request.shippingAddressOverride = nil` case initially reported

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
