### PR TITLE
Remove duplicate CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,6 @@
   * BraintreeSEPADirectDebit
     * The `tokenize` method no longer takes in a `context` parameter
     * Merchants no longer need to conform to the `ASWebAuthenticationPresentationContextProviding` protocol
-  * BraintreeUnionPay
-    * Remove `BraintreeUnionPay` module
-      * UnionPay cards can now be processed as regular cards (through the BraintreeCard module) due to their partnership with Discover
 
 ## 5.20.0 (2023-01-24)
 * BraintreeThreeDSecure


### PR DESCRIPTION
### Summary of changes

- Looks like a duplicate for `BraintreeUnionPay` made it's way into the CHANGELOG

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
