### PR TITLE
[WIP] Move Publish Docs to Own Action/Workflow

### DIFF
--- a/.github/actions/release_docs/action.yml
+++ b/.github/actions/release_docs/action.yml
@@ -1,0 +1,51 @@
+name: Publish reference docs
+description: 'Publish reference docs to GitHub Pages'
+inputs:
+  version:
+    description: "Version of the reference docs to release"
+    required: true
+runs:
+  using: actions/runner-images@macOS12
+  steps:
+    - name: Use Xcode 14
+      run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+
+    - name: Publish reference docs
+      run: |
+          gem install jazzy
+          brew install sourcekitten
+
+          # run sourcekitten on each Swift module individually
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme PayPalDataCollector -destination 'name=iPhone 11,platform=iOS Simulator' > pay-pal-data-collector.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPalNativeCheckout -destination 'name=iPhone 11,platform=iOS Simulator' > braintree-pay-pal-native-checkout.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeSEPADirectDebit -destination 'name=iPhone 11,platform=iOS Simulator' > braintree-sepa-direct-debit.json
+
+          # merge sourcekitten output
+          jq -s '.[0] + .[1] + .[2]' pay-pal-data-collector.json braintree-pay-pal-native-checkout.json braintree-sepa-direct-debit.json > swiftDoc.json
+
+          sourcekitten doc --objc Docs/Braintree-Umbrella-Header.h -- \
+            -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) \
+            -I $(pwd)/Sources/BraintreeAmericanExpress/Public \
+            -I $(pwd)/Sources/BraintreeApplePay/Public \
+            -I $(pwd)/Sources/BraintreeCard/Public \
+            -I $(pwd)/Sources/BraintreeCore/Public \
+            -I $(pwd)/Sources/BraintreeDataCollector/Public \
+            -I $(pwd)/Sources/BraintreePaymentFlow/Public \
+            -I $(pwd)/Sources/BraintreePayPal/Public \
+            -I $(pwd)/Sources/BraintreeThreeDSecure/Public \
+            -I $(pwd)/Sources/BraintreeUnionPay/Public \
+            -I $(pwd)/Sources/BraintreeVenmo/Public \
+            > objcDoc.json
+          jazzy \
+            --sourcekitten-sourcefile swiftDoc.json,objcDoc.json \
+            --author Braintree \
+            --author_url http://braintreepayments.com \
+            --github_url https://github.com/braintree/braintree_ios \
+            --github-file-prefix https://github.com/braintree/braintree_ios/tree/${{ inputs.version }} \
+            --theme fullwidth \
+            --output ${{ inputs.version }}
+          git checkout gh-pages
+          ln -sfn ${{ inputs.version }} current
+          git add current ${{ inputs.version }}
+          git commit -m "Publish ${{ inputs.version }} docs to github pages"
+          git push

--- a/.github/actions/release_docs/action.yml
+++ b/.github/actions/release_docs/action.yml
@@ -1,11 +1,11 @@
-name: Publish reference docs
+name: Publish Reference Docs
 description: 'Publish reference docs to GitHub Pages'
 inputs:
   version:
     description: "Version of the reference docs to release"
     required: true
 runs:
-  using: actions/runner-images@macOS12
+  using: actions/runner-images@macOS-12
   steps:
     - name: Use Xcode 14
       run: sudo xcode-select -switch /Applications/Xcode_14.0.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,42 +113,5 @@ jobs:
         run: pod trunk push Braintree.podspec
 
       - name: Publish reference docs
-        run: |
-          gem install jazzy
-          sudo xcode-select -switch /Applications/Xcode_14.0.app
-          brew install sourcekitten
-
-          # run sourcekitten on each Swift module individually
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme PayPalDataCollector -destination 'name=iPhone 11,platform=iOS Simulator' > pay-pal-data-collector.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPalNativeCheckout -destination 'name=iPhone 11,platform=iOS Simulator' > braintree-pay-pal-native-checkout.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeSEPADirectDebit -destination 'name=iPhone 11,platform=iOS Simulator' > braintree-sepa-direct-debit.json
-
-          # merge sourcekitten output
-          jq -s '.[0] + .[1] + .[2]' pay-pal-data-collector.json braintree-pay-pal-native-checkout.json braintree-sepa-direct-debit.json > swiftDoc.json
-
-          sourcekitten doc --objc Docs/Braintree-Umbrella-Header.h -- \
-            -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) \
-            -I $(pwd)/Sources/BraintreeAmericanExpress/Public \
-            -I $(pwd)/Sources/BraintreeApplePay/Public \
-            -I $(pwd)/Sources/BraintreeCard/Public \
-            -I $(pwd)/Sources/BraintreeCore/Public \
-            -I $(pwd)/Sources/BraintreeDataCollector/Public \
-            -I $(pwd)/Sources/BraintreePaymentFlow/Public \
-            -I $(pwd)/Sources/BraintreePayPal/Public \
-            -I $(pwd)/Sources/BraintreeThreeDSecure/Public \
-            -I $(pwd)/Sources/BraintreeUnionPay/Public \
-            -I $(pwd)/Sources/BraintreeVenmo/Public \
-            > objcDoc.json
-          jazzy \
-            --sourcekitten-sourcefile swiftDoc.json,objcDoc.json \
-            --author Braintree \
-            --author_url http://braintreepayments.com \
-            --github_url https://github.com/braintree/braintree_ios \
-            --github-file-prefix https://github.com/braintree/braintree_ios/tree/${{ github.event.inputs.version }} \
-            --theme fullwidth \
-            --output ${{ github.event.inputs.version }}
-          git checkout gh-pages
-          ln -sfn ${{ github.event.inputs.version }} current
-          git add current ${{ github.event.inputs.version }}
-          git commit -m "Publish ${{ github.event.inputs.version }} docs to github pages"
-          git push
+        run: ./.github/actions/release_docs
+        with: ${{ github.event.inputs.version }}

--- a/.github/workflows/release_docs.yml
+++ b/.github/workflows/release_docs.yml
@@ -1,4 +1,4 @@
-name: Publish reference docs
+name: Publish Reference Docs
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release_docs.yml
+++ b/.github/workflows/release_docs.yml
@@ -1,0 +1,14 @@
+name: Publish reference docs
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Reference docs version to release"
+        required: true
+jobs:
+  release:
+    name: Publish reference docs
+    steps:
+      - name: Publish reference docs
+        run: ./.github/actions/release_docs
+        with: ${{ github.event.inputs.version }}


### PR DESCRIPTION
DRAFT/DISCUSSION PR

### Summary of changes

The 5.x [publish reference docs step](https://github.com/braintree/braintree_ios/actions/runs/4055780046/jobs/6979378871) failed again. 😭 We were doing the following: `sudo xcode-select -switch /Applications/Xcode_14.0.app` but have the runner set to `macOS-11` which [does not support Xcode 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode). We will need to be in the [MacOS-12 runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) for Xcode 14 support.

Matt and I were talking and since we have had docs failures as part of the 6.x-beta's and now on 5.x due to changes to sourcekitten we thought it could be a good idea to separate the docs release into it's own action. This will allow us to:
1. Publish the reference docs as usual during the release process
2. Publish the docs independent of the release process if needed - this would be done in the same workflow section but selecting "publish docs" instead of release (this will _not_ show in GH Actions tab until we merge this change in and merge the 5.x branch into `master`)

This PR is currently a draft because we wanted to discuss with the team their thoughts on moving this to it's own workflow.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder @jaxdesmarais  
