### PR TITLE
[DRAFT] Remove 3DSecure Subclassing of PaymentFlow

### DIFF
--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -193,7 +193,7 @@
 
         request.v2UICustomization = ui;
 
-        [self.paymentFlowClient startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
+        [self.paymentFlowClient startPaymentFlow:request completion:^(NSObject * _Nonnull result, NSError * _Nonnull error) {
             self.callbackCount++;
             [self updateCallbackCount];
             if (error) {

--- a/Demo/Application/Features/Ideal/BraintreeDemoIdealViewController.m
+++ b/Demo/Application/Features/Ideal/BraintreeDemoIdealViewController.m
@@ -68,7 +68,7 @@
     request.shippingAddressRequired = NO;
     request.localPaymentFlowDelegate = self;
 
-    void (^paymentFlowCompletionBlock)(BTPaymentFlowResult *, NSError *) = ^(BTPaymentFlowResult * _Nullable result, NSError * _Nullable error) {
+    void (^paymentFlowCompletionBlock)(NSObject *, NSError *) = ^(NSObject * _Nullable result, NSError * _Nullable error) {
         if (error) {
             if (error.code == BTPaymentFlowErrorTypeCanceled) {
                 self.progressBlock(@"Canceled 🎲");

--- a/Sources/BraintreePaymentFlow/BTPaymentFlowClient.m
+++ b/Sources/BraintreePaymentFlow/BTPaymentFlowClient.m
@@ -38,7 +38,7 @@
 
 @interface BTPaymentFlowClient () <SFSafariViewControllerDelegate, BTAppContextSwitchClient>
 
-@property (nonatomic, copy) void (^paymentFlowCompletionBlock)(BTPaymentFlowResult *, NSError *);
+@property (nonatomic, copy) void (^paymentFlowCompletionBlock)(NSObject *, NSError *);
 @property (nonatomic, strong, nullable) SFSafariViewController *safariViewController;
 @property (nonatomic, strong, nullable) id<BTPaymentFlowRequestDelegate> paymentFlowRequestDelegate;
 @property (nonatomic, copy, nonnull) NSString *returnURLScheme;
@@ -70,13 +70,13 @@ static BTPaymentFlowClient *paymentFlowClient;
     return nil;
 }
 
-- (void)startPaymentFlow:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(BTPaymentFlowResult * _Nullable, NSError * _Nullable))completionBlock {
+- (void)startPaymentFlow:(NSObject<BTPaymentFlowRequestDelegate> * _Nonnull)request completion:(void (^)(NSObject * _Nullable, NSError * _Nullable))completionBlock {
     [self setupPaymentFlow:request completion:completionBlock];
     [self.apiClient sendAnalyticsEvent:[NSString stringWithFormat:@"ios.%@.start-payment.selected", [self.paymentFlowRequestDelegate paymentFlowName]]];
     [self.paymentFlowRequestDelegate handleRequest:request client:self.apiClient paymentClientDelegate:self];
 }
 
-- (void)setupPaymentFlow:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(BTPaymentFlowResult * _Nullable, NSError * _Nullable))completionBlock {
+- (void)setupPaymentFlow:(NSObject<BTPaymentFlowRequestDelegate> * _Nonnull)request completion:(void (^)(NSObject * _Nullable, NSError * _Nullable))completionBlock {
     paymentFlowClient = self;
     self.paymentFlowCompletionBlock = completionBlock;
     self.paymentFlowRequestDelegate = request;
@@ -150,7 +150,7 @@ static BTPaymentFlowClient *paymentFlowClient;
     paymentFlowClient = nil;
 }
 
-- (void)onPaymentComplete:(BTPaymentFlowResult *)result error:(NSError *)error {
+- (void)onPaymentComplete:(NSObject *)result error:(NSError *)error {
     self.paymentFlowCompletionBlock(result, error);
     paymentFlowClient = nil;
 }

--- a/Sources/BraintreePaymentFlow/BTPaymentFlowClient_Internal.h
+++ b/Sources/BraintreePaymentFlow/BTPaymentFlowClient_Internal.h
@@ -15,7 +15,7 @@
  @param request A BTPaymentFlowRequest to set on the BTPaymentFlow
  @param completionBlock This completion will be invoked exactly once when the payment flow is complete or an error occurs.
  */
-- (void)setupPaymentFlow:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *_Nonnull)request completion:(void (^_Nullable)(BTPaymentFlowResult * _Nullable, NSError * _Nullable))completionBlock;
+- (void)setupPaymentFlow:(NSObject<BTPaymentFlowRequestDelegate> * _Nonnull)request completion:(void (^_Nullable)(NSObject * _Nullable, NSError * _Nullable))completionBlock;
 
 /**
  Exposed for testing - instantiates the SFSafariViewController to be presented

--- a/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTPaymentFlowClient.h
+++ b/Sources/BraintreePaymentFlow/Public/BraintreePaymentFlow/BTPaymentFlowClient.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, BTPaymentFlowErrorType) {
  @param result The BTPaymentFlowResult of the payment flow.
  @param error NSError containing details of the error.
  */
-- (void)onPaymentComplete:(BTPaymentFlowResult * _Nullable)result error:(NSError * _Nullable)error;
+- (void)onPaymentComplete:(NSObject * _Nullable)result error:(NSError * _Nullable)error;
 
 /**
  Returns the base return URL scheme used by the client.
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, BTPaymentFlowErrorType) {
  @param request A BTPaymentFlowRequest request.
  @param delegate The BTPaymentFlowClientDelegate to handle response.
  */
-- (void)handleRequest:(BTPaymentFlowRequest *)request client:(BTAPIClient *)apiClient paymentClientDelegate:(id<BTPaymentFlowClientDelegate>)delegate;
+- (void)handleRequest:(NSObject *)request client:(BTAPIClient *)apiClient paymentClientDelegate:(NSObject<BTPaymentFlowClientDelegate>* )delegate NS_SWIFT_NAME(handle(_:client:paymentClientDelegate:));
 
 /**
  Check if this BTPaymentFlowRequestDelegate can handle the return URL
@@ -136,7 +136,7 @@ typedef NS_ENUM(NSInteger, BTPaymentFlowErrorType) {
  @param request A BTPaymentFlowRequest request.
  @param completionBlock This completion will be invoked exactly once when the payment flow is complete or an error occurs.
  */
-- (void)startPaymentFlow:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)( BTPaymentFlowResult * _Nullable result,  NSError * _Nullable error))completionBlock;
+- (void)startPaymentFlow:(NSObject<BTPaymentFlowRequestDelegate> *)request completion:(void (^)( NSObject * _Nullable result,  NSError * _Nullable error))completionBlock;
 
 /**
  A required delegate to control the presentation and dismissal of view controllers.

--- a/Sources/BraintreeThreeDSecure/BTPaymentFlowClient+ThreeDSecure.m
+++ b/Sources/BraintreeThreeDSecure/BTPaymentFlowClient+ThreeDSecure.m
@@ -158,7 +158,7 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
     }];
 }
 
-- (void)prepareLookup:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(NSString * _Nullable, NSError * _Nullable))completionBlock {
+- (void)prepareLookup:(BTThreeDSecureRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(NSString * _Nullable, NSError * _Nullable))completionBlock {
     BTThreeDSecureRequest *threeDSecureRequest = (BTThreeDSecureRequest *)request;
     NSError *integrationError;
 
@@ -208,8 +208,8 @@ NSString * const BTThreeDSecureFlowValidationErrorsKey = @"com.braintreepayments
 }
 
 - (void)initializeChallengeWithLookupResponse:(NSString *)lookupResponse
-                                      request:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request
-                                   completion:(void (^)(BTPaymentFlowResult * _Nullable, NSError * _Nullable))completionBlock {
+                                      request:(BTThreeDSecureRequest<BTPaymentFlowRequestDelegate> *)request
+                                   completion:(void (^)(NSObject * _Nullable, NSError * _Nullable))completionBlock {
     [self setupPaymentFlow:request completion:completionBlock];
 
     BTJSON *jsonResponse = [[BTJSON alloc] initWithData:[lookupResponse dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:NO]];

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -59,7 +59,6 @@
 @implementation BTThreeDSecureRequest
 
 - (instancetype)init {
-    self = [super init];
     if (self) {
         _versionRequested = BTThreeDSecureVersion2;
     }
@@ -125,7 +124,7 @@
     }
 }
 
-- (void)handleRequest:(BTPaymentFlowRequest *)request
+- (void)handleRequest:(BTThreeDSecureRequest *)request
                client:(BTAPIClient *)apiClient
 paymentClientDelegate:(id<BTPaymentFlowClientDelegate>)delegate {
     self.paymentFlowClientDelegate = delegate;
@@ -205,7 +204,7 @@ paymentClientDelegate:(id<BTPaymentFlowClientDelegate>)delegate {
     }];
 }
 
-- (void)startRequest:(BTPaymentFlowRequest *)request configuration:(BTConfiguration *)configuration {
+- (void)startRequest:(BTThreeDSecureRequest *)request configuration:(BTConfiguration *)configuration {
     BTThreeDSecureRequest *threeDSecureRequest = (BTThreeDSecureRequest *)request;
     BTAPIClient *apiClient = [self.paymentFlowClientDelegate apiClient];
     BTPaymentFlowClient *paymentFlowClient = [[BTPaymentFlowClient alloc] initWithAPIClient:apiClient];

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTPaymentFlowClient+ThreeDSecure.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTPaymentFlowClient+ThreeDSecure.h
@@ -1,7 +1,9 @@
 #if __has_include(<Braintree/BraintreeThreeDSecure.h>)
 #import <Braintree/BTPaymentFlowClient.h>
+#import <Braintree/BTThreeDSecureRequest.h>
 #else
 #import <BraintreePaymentFlow/BTPaymentFlowClient.h>
+#import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -39,7 +41,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureFlowErrorType) {
  @param request The BTThreeDSecureRequest object where prepareLookup was called.
  @param completionBlock This completion will be invoked exactly once with the client payload string or an error.
  */
-- (void)prepareLookup:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(NSString * _Nullable lookupPayload, NSError * _Nullable error))completionBlock;
+- (void)prepareLookup:(BTThreeDSecureRequest<BTPaymentFlowRequestDelegate> * _Nullable)request completion:(void (^)(NSString * _Nullable lookupPayload, NSError * _Nullable error))completionBlock;
 
 /**
  Initialize a challenge from a server side lookup call.
@@ -48,7 +50,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureFlowErrorType) {
  @param request The BTThreeDSecureRequest object where prepareLookup was called.
  @param completionBlock This completion will be invoked exactly once when the payment flow is complete or an error occurs.
  */
-- (void)initializeChallengeWithLookupResponse:(NSString *)lookupResponse request:(BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(BTPaymentFlowResult * _Nullable result, NSError * _Nullable error))completionBlock;
+- (void)initializeChallengeWithLookupResponse:(NSString *)lookupResponse request:(BTThreeDSecureRequest<BTPaymentFlowRequestDelegate> *)request completion:(void (^)(NSObject * _Nullable result, NSError * _Nullable error))completionBlock;
 
 @end
 

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -107,7 +107,7 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureRequestedExemptionType) {
 /**
  Used to initialize a 3D Secure payment flow
  */
-@interface BTThreeDSecureRequest : BTPaymentFlowRequest <BTPaymentFlowRequestDelegate>
+@interface BTThreeDSecureRequest : NSObject <BTPaymentFlowRequestDelegate>
 
 /**
  A nonce to be verified by ThreeDSecure

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureResult.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureResult.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The result of a 3D Secure payment flow
  */
-@interface BTThreeDSecureResult : BTPaymentFlowResult
+@interface BTThreeDSecureResult : NSObject
 
 /**
  The `BTCardNonce` resulting from the 3D Secure flow

--- a/UnitTests/BraintreePaymentFlowTests/MockPaymentFlowClientDelegate.swift
+++ b/UnitTests/BraintreePaymentFlowTests/MockPaymentFlowClientDelegate.swift
@@ -3,12 +3,12 @@ import BraintreePaymentFlow
 import BraintreeCore
 @testable import BraintreeTestShared
 
-class MockPaymentFlowClientDelegate: BTPaymentFlowClientDelegate {
+class MockPaymentFlowClientDelegate: NSObject, BTPaymentFlowClientDelegate {
     var _returnURLScheme = ""
 
     var onPaymentWithURLHandler: ((URL?, Error?) -> Void)?
     var onPaymentCancelHandler: (() -> Void)?
-    var onPaymentCompleteHandler: ((BTPaymentFlowResult?, Error?) -> Void)?
+    var onPaymentCompleteHandler: ((NSObject?, Error?) -> Void)?
 
     func onPayment(with url: URL?, error: Error?) {
         onPaymentWithURLHandler?(url, error)
@@ -18,7 +18,7 @@ class MockPaymentFlowClientDelegate: BTPaymentFlowClientDelegate {
         onPaymentCancelHandler?()
     }
 
-    func onPaymentComplete(_ result: BTPaymentFlowResult?, error: Error?) {
+    func onPaymentComplete(_ result: NSObject?, error: Error?) {
         onPaymentCompleteHandler?(result, error)
     }
 

--- a/UnitTests/BraintreeThreeDSecureTests/MockDelegates.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/MockDelegates.swift
@@ -4,12 +4,12 @@ import XCTest
 @testable import BraintreePaymentFlow
 @testable import BraintreeTestShared
 
-class MockPaymentFlowClientDelegate: BTPaymentFlowClientDelegate {
+class MockPaymentFlowClientDelegate: NSObject, BTPaymentFlowClientDelegate {
     var _returnURLScheme = ""
 
     var onPaymentWithURLHandler: ((URL?, Error?) -> Void)?
     var onPaymentCancelHandler: (() -> Void)?
-    var onPaymentCompleteHandler: ((BTPaymentFlowResult?, Error?) -> Void)?
+    var onPaymentCompleteHandler: ((NSObject?, Error?) -> Void)?
 
     func onPayment(with url: URL?, error: Error?) {
         onPaymentWithURLHandler?(url, error)
@@ -19,7 +19,7 @@ class MockPaymentFlowClientDelegate: BTPaymentFlowClientDelegate {
         onPaymentCancelHandler?()
     }
 
-    func onPaymentComplete(_ result: BTPaymentFlowResult?, error: Error?) {
+    func onPaymentComplete(_ result: NSObject?, error: Error?) {
         onPaymentCompleteHandler?(result, error)
     }
 


### PR DESCRIPTION
### Summary of changes

While looking at the next conversion to Swift (PaymentFlow) we realized that we were doing some subclassing that we would not be able to do if PaymentFlow was in Swift and 3DSecure was in Obj-C (technical limitation of the languages that can go the other way but not the direction we would need). We discussed as the iOS group that we wanted to spike out the changes needed to make this work and see if we would like to move forward.

As a note the classes being subclassed today: `BTPaymentFlowRequest` and `BTPaymentMethodResult` are empty in their implementation and are solely used to inherit their superclass of `NSObject`

#### Changes covered in this PR
- Update completion blocks to use `NSObject`
- Update `startPaymentFlow` and `setupPaymentFlow` to take in and return an `NSObject` (this is the underlying type of the classes `BTPaymentFlowRequest` and `BTPaymentMethodResult` used previously
- Update `onPaymentComplete` to return an `NSObject`
- Update `setupPaymentFlow` to use an `NSObject` conforming to `BTPaymentFlowRequestDelegate` and return an `NSObject` in the completion
- `prepareLookup` now takes a `BTThreeDSecureRequest`
- `initializeChallengeWithLookupResponse` now take a `BTThreeDSecureRequest` and returns an `NSObject` in the completion
- `BTThreeDSecureRequest` and` BTThreeDSecureResult` now subclass `NSObject` directly

#### Changes not covered in this PR
Another limitation would be that the 3DS module has a category/extension on `BTPaymentFlowClient` - during the conversion we would likely need to move that extension into a public extension on `BTPaymentFlowClient` instead of in the 3DS module. This would be similar to what we needed to do for the `BTConfiguration` extensions. We could then move this back into the 3DS module when we convert it to Swift in v7. From a merchant perspective they would have the same exposure to the objects and methods in this extension that they do now.

### Testing
All tests are passing - additionally going through both flows in the Demo app is working just as it was previously.

### Checklist

Will add a changelog if we decide to move forward with this approach

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @jaxdesmarais 
