### PR TITLE
GitHub Actions Release Update to use MacOS-12 for Reference Docs (5.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,19 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push Braintree.podspec
 
+  docs:
+    name: Publish Reference Docs
+    runs-on: macOS-12
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+
       - name: Publish reference docs
         run: |
           gem install jazzy
-          sudo xcode-select -switch /Applications/Xcode_14.0.app
           brew install sourcekitten
 
           # run sourcekitten on each Swift module individually


### PR DESCRIPTION
### Summary of changes

The 5.x [publish reference docs step](https://github.com/braintree/braintree_ios/actions/runs/4055780046/jobs/6979378871) failed again. 😭 We were doing the following: sudo xcode-select -switch /Applications/Xcode_14.0.app but have the runner set to macOS-11 which [does not support Xcode 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode). We will need to be in the [MacOS-12 runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) for Xcode 14 support.

This PR separates the docs publishing into it's own job ([we do something similar in Android release](https://github.com/braintree/braintree_android/blob/master/.github/workflows/release.yml) and the [iOS build](https://github.com/braintree/braintree_ios/blob/master/.github/workflows/build.yml)). This way we can control the macOS version used for this step. As we look into potentially moving things to Fastlane or something similar as well as potentially moving to DocC we can evaluate if it makes sense to move the docs into their own runnable job (though the local development of DocC I've been playing with may make this specific issue we've been running into irrelevant). 

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 