### PR TITLE
Mark v4 as unsupported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This SDK abides by our Client SDK Deprecation Policy. For more information on th
 | -------------------- | ------ | -------- | ---------- | ----------- |
 | 6.x.x | Beta | TBA | TBA | TBA |
 | 5.x.x | Active | February 2021 | TBA | TBA |
-| 4.x.x | Inactive | November 2015 | February 2022 | February 2023 |
+| 4.x.x | Unsupported | November 2015 | February 2022 | February 2023 |
 
 Versions 4.9.6 and below use outdated SSL certificates and are unsupported.
 


### PR DESCRIPTION

### Summary of changes

- V4 is officially "unsupported" based on our timelines. We have gotten a few inbounds about this, and our README was out of date.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo