### PR TITLE
Update SEPA Docstring

### DIFF
--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
@@ -33,7 +33,7 @@ import BraintreeCore
     /// Initiates an `ASWebAuthenticationSession` to display a mandate to the user. Upon successful mandate creation, tokenizes the payment method and returns a result
     /// - Parameters:
     ///   - request: a BTSEPADebitRequest
-    ///   - context: the ASWebAuthenticationPresentationContextProviding protocol conforming ViewController
+    ///   - completion: This completion will be invoked exactly once when tokenization is complete or an error occurs
     public func tokenize(
         request: BTSEPADirectDebitRequest,
         completion:  @escaping (BTSEPADirectDebitNonce?, Error?) -> Void


### PR DESCRIPTION
### Summary of changes

- Doing some testing earlier I noticed we missed a docstring with the ASWeb changes to remove context from the client. We no longer pass in a context and were missing docs on returning a completion.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
