### PR TITLE
Xcode 14.3 Import Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Remove `iosBaseSDK`, `iosDeploymentTarget`, `iosIdentifierForVendor`, `deviceAppGeneratedPersistentUuid`, and `deviceScreenOrientation` from `BTAnalyticsMetadata`
+* Fixes error `@objcMembers attribute used without importing module 'Foundation'` in Xcode 14.3+
 * Breaking Changes
   * BraintreePaymentFlow
     * Replaced `SFSafariViewController` with `ASWebAuthenticationSession`

--- a/Sources/BraintreeCore/BTMutableClientMetadata.swift
+++ b/Sources/BraintreeCore/BTMutableClientMetadata.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // NEXT_MAJOR_VERSION (v7): Explore removing this once BraintreeVenmo is in Swift
 /// Required for Objective-C compatibility. Necessary behavior is provided by the swift version.
 @objcMembers public class BTMutableClientMetadata: BTClientMetadata { }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if canImport(BraintreeCore)
 import BraintreeCore
 #endif

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if canImport(BraintreeCore)
 import BraintreeCore
 #endif


### PR DESCRIPTION
### Summary of changes

- Doing some testing in Xcode 14.3 we see the error `Fixes error `@objcMembers attribute used without importing module 'Foundation'` in Xcode 14.3+` - we need to import Foundation in these places to avoid this error.

From [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3-release-notes):
> An explicit import of Foundation is now required if APIs from Foundation are used in a manifest. 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
