### PR TITLE
`BTPayPalNativeCheckoutAccountNonce` Updates

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		BE642DAB27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */; };
 		BE9F444427C6C75E00A117D5 /* BTCacheDateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9F444327C6C75E00A117D5 /* BTCacheDateValidator.m */; };
 		BE9F444627C6C78A00A117D5 /* BTCacheDateValidator_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = BE9F444527C6C78A00A117D5 /* BTCacheDateValidator_Internal.h */; };
+		BEDB820629B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */; };
 		BEE2E4B72900436600C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B62900436600C03FDD /* PayPalCheckout */; };
 		BEE2E4B9290043A200C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B8290043A200C03FDD /* PayPalCheckout */; };
 		BEF3F17E27CE9EDF00072467 /* BTSEPADirectDebitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */; };
@@ -1158,6 +1159,7 @@
 		BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitNonce_Tests.swift; sourceTree = "<group>"; };
 		BE9F444327C6C75E00A117D5 /* BTCacheDateValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTCacheDateValidator.m; sourceTree = "<group>"; };
 		BE9F444527C6C78A00A117D5 /* BTCacheDateValidator_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTCacheDateValidator_Internal.h; sourceTree = "<group>"; };
+		BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutAccountNonce_Tests.swift; sourceTree = "<group>"; };
 		BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitClient.swift; sourceTree = "<group>"; };
 		BEF3F17C27CE9EC600072467 /* BraintreeSEPADirectDebit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreeSEPADirectDebit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEFE6DA327E26399002BE9C8 /* SEPADirectDebitAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADirectDebitAPI_Tests.swift; sourceTree = "<group>"; };
@@ -1876,12 +1878,13 @@
 		9CE5179C282D54030013C740 /* BraintreePayPalNativeCheckoutTests */ = {
 			isa = PBXGroup;
 			children = (
-				3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */,
-				3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */,
-				3DAB593A286BD865003A7BC5 /* BTPayPalNativeOrderCreationClient_Tests.swift */,
+				BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */,
 				3DAB593E286CB967003A7BC5 /* BTPayPalNativeCheckoutClient_Tests.swift */,
-				3DAB593C286C032B003A7BC5 /* BTPayPalNativeTokenizationRequest_Tests.swift */,
 				3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */,
+				3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */,
+				3DAB593A286BD865003A7BC5 /* BTPayPalNativeOrderCreationClient_Tests.swift */,
+				3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */,
+				3DAB593C286C032B003A7BC5 /* BTPayPalNativeTokenizationRequest_Tests.swift */,
 				3DF4B4C9285A74200072DC60 /* BTPayPalNativeVaultRequest_Tests.swift */,
 				57108A0C282D5E23004EB870 /* Info.plist */,
 			);
@@ -3654,6 +3657,7 @@
 				3DAB5939286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift in Sources */,
 				3DAB593D286C032B003A7BC5 /* BTPayPalNativeTokenizationRequest_Tests.swift in Sources */,
 				3DAB5937286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift in Sources */,
+				BEDB820629B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift in Sources */,
 				3DF4B4CA285A74200072DC60 /* BTPayPalNativeVaultRequest_Tests.swift in Sources */,
 				3DAB5933286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift in Sources */,
 			);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 * Add missed deprecation warnings to `BTCardRequest` Union Pay properties
+* BraintreePayPalNativeCheckout (BETA)
+  * Expose `payerID` property publicly
+  * Expose all properties on `BTPayPalNativeCheckoutAccountNonce` to Objective-C
 
 ## 5.20.1 (2023-01-31)
 * BraintreePayPalNativeCheckout (BETA)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * Add missed deprecation warnings to `BTCardRequest` Union Pay properties
 * BraintreePayPalNativeCheckout (BETA)
-  * Expose `payerID` property publicly
+  * Expose `payerID` property on `BTPayPalNativeCheckoutAccountNonce` publicly
   * Expose all properties on `BTPayPalNativeCheckoutAccountNonce` to Objective-C
 
 ## 5.20.1 (2023-01-31)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
@@ -3,7 +3,9 @@ import BraintreePayPal
 #endif
 
 /// Contains information about a PayPal payment method.
-@objc public class BTPayPalNativeCheckoutAccountNonce: NSObject {
+@objcMembers public class BTPayPalNativeCheckoutAccountNonce: NSObject {
+
+    // MARK: - Public Properties
 
     public let type: String = "PayPal"
     public let nonce: String
@@ -32,7 +34,9 @@ import BraintreePayPal
 
     /// Optional. Payer id associated with this transaction.
     /// Will be provided for Vault and Checkout.
-    let payerID: String?
+    public let payerID: String?
+
+    // MARK: - Initializer
 
     init?(json: BTJSON) {
         let paypalAccounts = json["paypalAccounts"][0]
@@ -60,6 +64,8 @@ import BraintreePayPal
         let billingAddressJSON = details["payerInfo"]["billingAddress"]
         billingAddress = Self.addressFromJSON(billingAddressJSON)
     }
+
+    // MARK: - Private Methods
 
     private static func addressFromJSON(_ addressJSON: BTJSON) -> BTPostalAddress? {
         guard addressJSON.isObject else {

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import BraintreeCore
+@testable import BraintreePayPalNativeCheckout
+
+final class BTPayPalNativeCheckoutAccountNonce_Tests: XCTestCase {
+
+    func testPayPalNativeCheckoutNonce_withAllJSON_createsPayPalNativeCheckoutNonce_withAllValues() {
+        let nativeCheckoutJSON = BTJSON(
+            value: [
+                "paypalAccounts": [
+                    [
+                        "nonce": "a-nonce",
+                        "description": "A description",
+                        "default": "true",
+                        "details": [
+                            "correlationId": "a-fake-clientMetadataID",
+                            "email": "hello@world.com",
+                            "payerInfo": [
+                                "firstName": "Some",
+                                "lastName": "Dude",
+                                "phone": "867-5309",
+                                "payerId": "FAKE-PAYER-ID",
+                                "accountAddress": [
+                                    "street1": "1 Foo Ct",
+                                    "street2": "Apt Bar",
+                                    "city": "Fubar",
+                                    "state": "FU",
+                                    "postalCode": "42",
+                                    "country": "USA"
+                                ],
+                                "billingAddress": [
+                                    "recipientName": "Bar Foo",
+                                    "line1": "2 Foo Ct",
+                                    "line2": "Apt Foo",
+                                    "city": "Barfoo",
+                                    "state": "BF",
+                                    "postalCode": "24",
+                                    "countryCode": "ASU"
+                                ],
+                                "shippingAddress": [
+                                    "recipientName": "Some Dude",
+                                    "line1": "3 Foo Ct",
+                                    "line2": "Apt 5",
+                                    "city": "Dudeville",
+                                    "state": "CA",
+                                    "postalCode": "24",
+                                    "countryCode": "US"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        )
+
+        let payPalNativeCheckoutNonce = BTPayPalNativeCheckoutAccountNonce(json: nativeCheckoutJSON)
+        XCTAssertNotNil(payPalNativeCheckoutNonce)
+        XCTAssertEqual(payPalNativeCheckoutNonce?.nonce, "a-nonce")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.isDefault, "false")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.clientMetadataID, "a-fake-clientMetadataID")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.email, "hello@world.com")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.firstName, "Some")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.lastName, "Dude")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.phone, "867-5309")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.payerID, "FAKE-PAYER-ID")
+
+        let billingAddress = payPalNativeCheckoutNonce?.billingAddress
+        XCTAssertNotNil(billingAddress)
+        XCTAssertEqual(billingAddress?.recipientName, "Bar Foo")
+        XCTAssertEqual(billingAddress?.streetAddress, "2 Foo Ct")
+        XCTAssertEqual(billingAddress?.extendedAddress, "Apt Foo")
+        XCTAssertEqual(billingAddress?.locality, "Barfoo")
+        XCTAssertEqual(billingAddress?.region, "BF")
+        XCTAssertEqual(billingAddress?.postalCode, "24")
+        XCTAssertEqual(billingAddress?.countryCodeAlpha2, "ASU")
+
+        let shippingAddress = payPalNativeCheckoutNonce?.shippingAddress!
+        XCTAssertNotNil(shippingAddress)
+        XCTAssertEqual(shippingAddress?.recipientName, "Some Dude")
+        XCTAssertEqual(shippingAddress?.streetAddress, "3 Foo Ct")
+        XCTAssertEqual(shippingAddress?.extendedAddress, "Apt 5")
+        XCTAssertEqual(shippingAddress?.locality, "Dudeville")
+        XCTAssertEqual(shippingAddress?.region, "CA")
+        XCTAssertEqual(shippingAddress?.postalCode, "24")
+        XCTAssertEqual(shippingAddress?.countryCodeAlpha2, "US")
+    }
+}

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
@@ -56,7 +56,7 @@ final class BTPayPalNativeCheckoutAccountNonce_Tests: XCTestCase {
         let payPalNativeCheckoutNonce = BTPayPalNativeCheckoutAccountNonce(json: nativeCheckoutJSON)
         XCTAssertNotNil(payPalNativeCheckoutNonce)
         XCTAssertEqual(payPalNativeCheckoutNonce?.nonce, "a-nonce")
-        XCTAssertEqual(payPalNativeCheckoutNonce?.isDefault, "false")
+        XCTAssertEqual(payPalNativeCheckoutNonce?.isDefault, false)
         XCTAssertEqual(payPalNativeCheckoutNonce?.clientMetadataID, "a-fake-clientMetadataID")
         XCTAssertEqual(payPalNativeCheckoutNonce?.email, "hello@world.com")
         XCTAssertEqual(payPalNativeCheckoutNonce?.firstName, "Some")

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
@@ -4,7 +4,7 @@ import BraintreeCore
 
 final class BTPayPalNativeCheckoutAccountNonce_Tests: XCTestCase {
 
-    func testPayPalNativeCheckoutNonce_withAllJSON_createsPayPalNativeCheckoutNonce_withAllValues() {
+    func testInit_withAllJSON_createsPayPalNativeCheckoutNonceWithAllValues() {
         let nativeCheckoutJSON = BTJSON(
             value: [
                 "paypalAccounts": [


### PR DESCRIPTION
### Summary of changes

- Expose `payerID` property on `BTPayPalNativeCheckoutAccountNonce` publicly
- Expose all properties on `BTPayPalNativeCheckoutAccountNonce` to Objective-C
- Add test file for `BTPayPalNativeCheckoutAccountNonce`

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
