### PR TITLE
[V6] Add M1 CocoaPods workaround to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ Versions 4.9.6 and below use outdated SSL certificates and are unsupported.
 ## Demo
 
 A demo app is included in the project. To run it you will need to do the following:
-    1. You will need to install [CocoaPods](http://cocoapods.org/) version 1.11.3 to run the Demo
-    2. Run `pod install`
-    3. Resolve the Swift Package Manager packages if needed: `File` > `Packages` > `Resolve Package Versions` or by running `swift package resolve` in Terminal
-    4. Open `Braintree.xcworkspace` in Xcode. 
+
+1. Run `pod install`
+    * There is a known M1 mac issue with CocoaPods. See [this solution](https://github.com/CocoaPods/CocoaPods/issues/10220#issuecomment-730963835) to resolve `ffi` dependency issues.
+2. Resolve the Swift Package Manager packages if needed: `File` > `Packages` > `Resolve Package Versions` or by running `swift package resolve` in Terminal
+3. Open `Braintree.xcworkspace` in Xcode
 
 Xcode 14+ is required to run the demo app.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A demo app is included in the project. To run it you will need to do the followi
     * There is a known M1 mac issue with CocoaPods. See [this solution](https://github.com/CocoaPods/CocoaPods/issues/10220#issuecomment-730963835) to resolve `ffi` dependency issues.
 2. Resolve the Swift Package Manager packages if needed: `File` > `Packages` > `Resolve Package Versions` or by running `swift package resolve` in Terminal
 3. Open `Braintree.xcworkspace` in Xcode
+4. Select the `Demo` scheme, and then run
 
 Xcode 14+ is required to run the demo app.
 


### PR DESCRIPTION
### Summary of changes

- Add link to required M1 Mac workaround for running `pod install`
- Fix indentation of numeric list under `# Demo` header
- Add additional step for selecting the `Demo` target

### Checklist

- ~Added a changelog entry~
- PR for adding these changes to V5 (#973)

### Authors
@scannillo 