### PR TITLE
Add address, amount and line item fields to Venmo createPaymentContext

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0917F6E42A27BDC700ACED2E /* BTVenmoLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */; };
+		09357DCB2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09357DCA2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift */; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
@@ -595,6 +596,7 @@
 		035A59D91EA5DE97002960C8 /* BTLocalPaymentClient_UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentClient_UnitTests.swift; sourceTree = "<group>"; };
 		039A8BD91F9E993500D607E7 /* BTAmericanExpressRewardsBalance_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressRewardsBalance_Tests.swift; sourceTree = "<group>"; };
 		03F921C1200EBB200076CD80 /* BTThreeDSecurePostalAddress_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecurePostalAddress_Tests.swift; sourceTree = "<group>"; };
+		09357DCA2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoLineItem_Tests.swift; sourceTree = "<group>"; };
 		096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoLineItem.swift; sourceTree = "<group>"; };
 		162174E1192D9220008DC35D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		16CD2E9E1B4077FC00E68495 /* BTJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON_Tests.swift; sourceTree = "<group>"; };
@@ -1596,8 +1598,9 @@
 				3B1C529529D637F400B68A58 /* BTVenmoAnalytics_Tests.swift */,
 				428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRedirectURL_Tests.swift */,
 				4245D668256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift */,
-				A71F7DE61B6180A3005DA1B0 /* BTVenmoClient_Tests.swift */,
 				4228D8682624E5C3001D2564 /* BTVenmoRequest_Tests.swift */,
+				09357DCA2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift */,
+				A71F7DE61B6180A3005DA1B0 /* BTVenmoClient_Tests.swift */,
 				A948D6F424FAC8F900F4F178 /* Info.plist */,
 			);
 			path = BraintreeVenmoTests;
@@ -2964,6 +2967,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9589DDA24FEA45C00AF4FF7 /* BTConfiguration+Venmo_Tests.swift in Sources */,
+				09357DCB2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift in Sources */,
 				3B1C529729D638D400B68A58 /* BTVenmoAnalytics_Tests.swift in Sources */,
 				4228D8692624E5C3001D2564 /* BTVenmoRequest_Tests.swift in Sources */,
 				428F48E42624C9B700EC8DB4 /* BTVenmoAppSwitchRedirectURL_Tests.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0917F6E42A27BDC700ACED2E /* BTVenmoLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
@@ -2802,10 +2803,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0917F6E42A27BDC700ACED2E /* BTVenmoLineItem.swift in Sources */,
 				BE98349E2A041AA600B6C3CC /* BTConfiguration+Venmo.swift in Sources */,
 				BEDB820829B675DC00075AF3 /* BTVenmoAccountNonce.swift in Sources */,
 				3B1C529429D5EB4E00B68A58 /* BTVenmoAnalytics.swift in Sources */,
-				096C6B2629CCDCEB00912863 /* BTVenmoLineItem.swift in Sources */,
 				BE0AF6BF29AFF13200245C2C /* BTVenmoRequest.swift in Sources */,
 				BEDB820A29B7A9E600075AF3 /* BTVenmoClient.swift in Sources */,
 				BE0AF6B929AFD50500245C2C /* BTVenmoAppSwitchReturnURL.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -1598,9 +1598,9 @@
 				3B1C529529D637F400B68A58 /* BTVenmoAnalytics_Tests.swift */,
 				428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRedirectURL_Tests.swift */,
 				4245D668256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift */,
+				A71F7DE61B6180A3005DA1B0 /* BTVenmoClient_Tests.swift */,
 				4228D8682624E5C3001D2564 /* BTVenmoRequest_Tests.swift */,
 				09357DCA2A2FBEC10096D449 /* BTVenmoLineItem_Tests.swift */,
-				A71F7DE61B6180A3005DA1B0 /* BTVenmoClient_Tests.swift */,
 				A948D6F424FAC8F900F4F178 /* Info.plist */,
 			);
 			path = BraintreeVenmoTests;

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		096C6B2629CCDCEB00912863 /* BTVenmoLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
@@ -594,6 +595,7 @@
 		035A59D91EA5DE97002960C8 /* BTLocalPaymentClient_UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentClient_UnitTests.swift; sourceTree = "<group>"; };
 		039A8BD91F9E993500D607E7 /* BTAmericanExpressRewardsBalance_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressRewardsBalance_Tests.swift; sourceTree = "<group>"; };
 		03F921C1200EBB200076CD80 /* BTThreeDSecurePostalAddress_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecurePostalAddress_Tests.swift; sourceTree = "<group>"; };
+		096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoLineItem.swift; sourceTree = "<group>"; };
 		162174E1192D9220008DC35D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		16CD2E9E1B4077FC00E68495 /* BTJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON_Tests.swift; sourceTree = "<group>"; };
 		2D941D381B59C76A0016EFB4 /* BraintreePayPal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreePayPal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1473,6 +1475,7 @@
 				BEDB820929B7A9E600075AF3 /* BTVenmoClient.swift */,
 				BE0AF6BA29AFD53300245C2C /* BTVenmoError.swift */,
 				BE0AF6BE29AFF13200245C2C /* BTVenmoRequest.swift */,
+				096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */,
 			);
 			path = BraintreeVenmo;
 			sourceTree = "<group>";
@@ -2803,6 +2806,7 @@
 				BE98349E2A041AA600B6C3CC /* BTConfiguration+Venmo.swift in Sources */,
 				BEDB820829B675DC00075AF3 /* BTVenmoAccountNonce.swift in Sources */,
 				3B1C529429D5EB4E00B68A58 /* BTVenmoAnalytics.swift in Sources */,
+				096C6B2629CCDCEB00912863 /* BTVenmoLineItem.swift in Sources */,
 				BE0AF6BF29AFF13200245C2C /* BTVenmoRequest.swift in Sources */,
 				BEDB820A29B7A9E600075AF3 /* BTVenmoClient.swift in Sources */,
 				BE0AF6B929AFD50500245C2C /* BTVenmoAppSwitchReturnURL.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		096C6B2629CCDCEB00912863 /* BTVenmoLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
@@ -1474,8 +1473,8 @@
 				BE0AF6B829AFD50500245C2C /* BTVenmoAppSwitchReturnURL.swift */,
 				BEDB820929B7A9E600075AF3 /* BTVenmoClient.swift */,
 				BE0AF6BA29AFD53300245C2C /* BTVenmoError.swift */,
-				BE0AF6BE29AFF13200245C2C /* BTVenmoRequest.swift */,
 				096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */,
+				BE0AF6BE29AFF13200245C2C /* BTVenmoRequest.swift */,
 			);
 			path = BraintreeVenmo;
 			sourceTree = "<group>";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@
 * Breaking Changes
   * All SDK error enums are now internal
   * See [list of new / updated error cases and codes](SDK_ERROR_CODES.md)
+* Add the following properties to `BTVenmoRequest`
+  * `collectCustomerBillingAddress`
+  * `collectCustomerShippingAddress`
+  * `totalAmount`
+  * `subTotalAmount`
+  * `discountAmount`
+  * `taxAmount`
+  * `shippingAmount`
+  * `lineItems`
   
 **Note:** Includes all changes in [6.0.0-beta4](#600-beta4-2023-06-01), [6.0.0-beta3](#600-beta3-2023-04-18), [6.0.0-beta2](#600-beta2-2023-01-30), and [6.0.0-beta1](#600-beta1-2022-12-13)
-
 ## 6.0.0-beta4 (2023-06-01)
 * Move from Braintree to PayPal analytics service
 * Make `BTConfiguration` extensions internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,21 @@
 * Breaking Changes
   * All SDK error enums are now internal
   * See [list of new / updated error cases and codes](SDK_ERROR_CODES.md)
-* Add the following properties to `BTVenmoRequest`
-  * `collectCustomerBillingAddress`
-  * `collectCustomerShippingAddress`
-  * `totalAmount`
-  * `subTotalAmount`
-  * `discountAmount`
-  * `taxAmount`
-  * `shippingAmount`
-  * `lineItems`
+* BraintreeVenmo
+  * Allow merchants to collect enriched customer data if enabled in the Braintree Control Panel
+  * Add the following properties to `BTVenmoRequest`
+    * `collectCustomerBillingAddress`
+    * `collectCustomerShippingAddress`
+    * `totalAmount`
+    * `subTotalAmount`
+    * `discountAmount`
+    * `taxAmount`
+    * `shippingAmount`
+    * `lineItems`
+  * Add new `isVenmoEnrichedCustomerDataEnabled` field to `BTConfiguration+Venmo`
   
 **Note:** Includes all changes in [6.0.0-beta4](#600-beta4-2023-06-01), [6.0.0-beta3](#600-beta3-2023-04-18), [6.0.0-beta2](#600-beta2-2023-01-30), and [6.0.0-beta1](#600-beta1-2022-12-13)
+
 ## 6.0.0-beta4 (2023-06-01)
 * Move from Braintree to PayPal analytics service
 * Make `BTConfiguration` extensions internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Braintree iOS SDK Release Notes
 
-## 6.0.0 (2023-06-20)
-* The Braintree SDK is now written in Swift
+## unreleased
 * BraintreeVenmo
   * Allow merchants to collect enriched customer data if enabled in the Braintree Control Panel
   * Add the following properties to `BTVenmoRequest`
@@ -13,6 +12,9 @@
     * `taxAmount`
     * `shippingAmount`
     * `lineItems`
+
+## 6.0.0 (2023-06-20)
+* The Braintree SDK is now written in Swift
 * Breaking Changes
   * All SDK error enums are now internal
   * See [list of new / updated error cases and codes](SDK_ERROR_CODES.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 6.0.0 (2023-06-20)
 * The Braintree SDK is now written in Swift
-* Breaking Changes
-  * All SDK error enums are now internal
-  * See [list of new / updated error cases and codes](SDK_ERROR_CODES.md)
 * BraintreeVenmo
   * Allow merchants to collect enriched customer data if enabled in the Braintree Control Panel
   * Add the following properties to `BTVenmoRequest`
@@ -16,7 +13,9 @@
     * `taxAmount`
     * `shippingAmount`
     * `lineItems`
-  * Add new `isVenmoEnrichedCustomerDataEnabled` field to `BTConfiguration+Venmo`
+* Breaking Changes
+  * All SDK error enums are now internal
+  * See [list of new / updated error cases and codes](SDK_ERROR_CODES.md)
   
 **Note:** Includes all changes in [6.0.0-beta4](#600-beta4-2023-06-01), [6.0.0-beta3](#600-beta3-2023-04-18), [6.0.0-beta2](#600-beta2-2023-01-30), and [6.0.0-beta1](#600-beta1-2022-12-13)
 

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -28,6 +28,15 @@
     self.progressBlock(@"Tapped Venmo - initiating Venmo auth");
     BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] initWithPaymentMethodUsage:BTVenmoPaymentMethodUsageMultiUse];
     [venmoRequest setVault:YES];
+    [venmoRequest setCollectCustomerShippingAddress:YES];
+    [venmoRequest setCollectCustomerBillingAddress:YES];
+    [venmoRequest setTotalAmount:@"30"];
+    [venmoRequest setTaxAmount:@"1.1"];
+    [venmoRequest setDiscountAmount:@"1.1"];
+    [venmoRequest setShippingAmount:@"0"];
+    BTVenmoLineItem *lineItem = [[BTVenmoLineItem alloc] initWithQuantity:1 unitAmount:@"30" name:@"item-1" kind: BTVenmoLineItemKindDebit];
+    [lineItem setUnitTaxAmount:@"1"];
+    [venmoRequest setLineItems:[NSArray arrayWithObject: lineItem]];
     [self.venmoClient tokenizeWithVenmoRequest:venmoRequest completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
         if (venmoAccount) {
             self.progressBlock(@"Got a nonce 💎!");

--- a/SDK_ERROR_CODES.md
+++ b/SDK_ERROR_CODES.md
@@ -135,3 +135,4 @@ See below for a comprehensive list of error types and codes thrown by each featu
     | BTVenmoError.invalidBodyReturned | 6 |
     | BTVenmoError.invalidRedirectURL | 7 |
     | BTVenmoError.fetchConfigurationFailed | 8 |
+    | BTVenmoError.enrichedCustomerDataDisabled | 9 |

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -207,7 +207,14 @@ class BTGraphQLHTTP: BTHTTP {
         let errorTree = BTGraphQLErrorTree(message: "Input is invalid")
 
         for errorJSON in body["errors"].asArray() ?? [] {
-            guard let inputPath = errorJSON["extensions"]["inputPath"].asStringArray() else { continue }
+            guard let inputPath = errorJSON["extensions"]["inputPath"].asStringArray() else {
+                if errorJSON["extensions"]["errorClass"].asString() == "VALIDATION" {
+                    if let message = errorJSON["message"].asString() {
+                        return BTGraphQLErrorTree(message: message).toDictionary()
+                    }
+                }
+                continue
+            }
             guard let field = inputPath.last else { continue }
             guard let message = errorJSON["message"].asString() else { continue }
             

--- a/Sources/BraintreeCore/BTJSON.swift
+++ b/Sources/BraintreeCore/BTJSON.swift
@@ -269,11 +269,11 @@ import Foundation
         guard self.isObject else { return nil }
         
         let address = BTPostalAddress()
-        address.recipientName = self["recipientName"].asString() // Likely to be nil
-        address.streetAddress = self["street1"].asString() ?? self["line1"].asString()
-        address.extendedAddress = self["street2"].asString() ?? self["line2"].asString()
-        address.locality = self["city"].asString()
-        address.region = self["state"].asString()
+        address.recipientName = self["recipientName"].asString() ?? self["fullName"].asString() // Likely to be nil
+        address.streetAddress = self["street1"].asString() ?? self["line1"].asString() ?? self["addressLine1"].asString()
+        address.extendedAddress = self["street2"].asString() ?? self["line2"].asString() ?? self["addressLine2"].asString()
+        address.locality = self["city"].asString() ?? self["adminArea2"].asString()
+        address.region = self["state"].asString() ?? self["adminArea1"].asString()
         address.postalCode = self["postalCode"].asString()
         address.countryCodeAlpha2 = self["country"].asString() ?? self["countryCode"].asString()
         return address

--- a/Sources/BraintreeVenmo/BTConfiguration+Venmo.swift
+++ b/Sources/BraintreeVenmo/BTConfiguration+Venmo.swift
@@ -28,7 +28,7 @@ extension BTConfiguration {
         json?["payWithVenmo"]["environment"].asString()
     }
 
-    /// Indicates whether ECD is enabled for the Venmo merchant.
+    /// Indicates whether Enriched Customer Data (ECD) is enabled for the Venmo merchant.
     var isVenmoEnrichedCustomerDataEnabled: Bool {
         json?["payWithVenmo"]["enrichedCustomerDataEnabled"].isTrue ?? false
     }

--- a/Sources/BraintreeVenmo/BTConfiguration+Venmo.swift
+++ b/Sources/BraintreeVenmo/BTConfiguration+Venmo.swift
@@ -27,4 +27,9 @@ extension BTConfiguration {
     var venmoEnvironment: String? {
         json?["payWithVenmo"]["environment"].asString()
     }
+
+    /// Indicates whether ECD is enabled for the Venmo merchant.
+    var isVenmoEnrichedCustomerDataEnabled: Bool {
+        json?["payWithVenmo"]["enrichedCustomerDataEnabled"].isTrue ?? false
+    }
 }

--- a/Sources/BraintreeVenmo/BTVenmoAccountNonce.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAccountNonce.swift
@@ -26,6 +26,12 @@ import BraintreeCore
 
     /// The username associated with the Venmo account
     public var username: String?
+    
+    /// The primary billing address associated with the Venmo account
+    public var billingAddress: BTPostalAddress?
+    
+    /// The primary shipping address associated with the Venmo account
+    public var shippingAddress: BTPostalAddress?
 
     // MARK: - Initializers
 
@@ -47,6 +53,8 @@ import BraintreeCore
         firstName = payerInfo["firstName"].asString()
         lastName = payerInfo["lastName"].asString()
         phoneNumber = payerInfo["phoneNumber"].asString()
+        billingAddress = payerInfo["billingAddress"].asAddress()
+        shippingAddress = payerInfo["shippingAddress"].asAddress()
     }
 
     // MARK: - Internal Methods

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -86,6 +86,12 @@ import BraintreeCore
                 return
             }
             
+            /// Merchants are not allowed to collect user addresses unless ECD (Enriched Customer Data) is enabled on the BT Control Panel.
+            if ((request.collectCustomerShippingAddress || request.collectCustomerBillingAddress) && !configuration.isVenmoEnrichedCustomerDataEnabled) {
+                completion(nil, BTVenmoError.ecdDisabled)
+                return
+            }
+            
             let merchantProfileID = request.profileID ?? configuration.venmoMerchantID
             let bundleDisplayName = self.bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -86,9 +86,9 @@ import BraintreeCore
                 return
             }
             
-            /// Merchants are not allowed to collect user addresses unless ECD (Enriched Customer Data) is enabled on the BT Control Panel.
+            // Merchants are not allowed to collect user addresses unless ECD (Enriched Customer Data) is enabled on the BT Control Panel.
             if ((request.collectCustomerShippingAddress || request.collectCustomerBillingAddress) && !configuration.isVenmoEnrichedCustomerDataEnabled) {
-                completion(nil, BTVenmoError.ecdDisabled)
+                completion(nil, BTVenmoError.enrichedCustomerDataDisabled)
                 return
             }
             
@@ -109,9 +109,10 @@ import BraintreeCore
                 inputParameters["displayName"] = displayName
             }
 
-            var paysheetDetails: [String: String] = [:]
-            paysheetDetails["collectCustomerBillingAddress"] = String(request.collectCustomerBillingAddress)
-            paysheetDetails["collectCustomerShippingAddress"] = String(request.collectCustomerShippingAddress)
+            var paysheetDetails: [String: String] = [
+                "collectCustomerBillingAddress": "\(request.collectCustomerBillingAddress)",
+                "collectCustomerShippingAddress": "\(request.collectCustomerShippingAddress)"
+            ]
             
             var transactionDetails: [String: String] = [:]
             if let subTotalAmount = request.subTotalAmount {
@@ -148,14 +149,14 @@ import BraintreeCore
             }
 
             if !transactionDetails.isEmpty {
-                if let jsonAmountData = try? JSONSerialization.data(withJSONObject: transactionDetails, options: []),
+                if let jsonAmountData = try? JSONSerialization.data(withJSONObject: transactionDetails),
                    let transactionDetailsString = String(data: jsonAmountData, encoding: .utf8) {
                     paysheetDetails["transactionDetails"] = transactionDetailsString
                 }
             }
             
             if !paysheetDetails.isEmpty {
-                if let paysheetDetailsData = try? JSONSerialization.data(withJSONObject: paysheetDetails, options: []),
+                if let paysheetDetailsData = try? JSONSerialization.data(withJSONObject: paysheetDetails),
                    let paysheetDetailsString = String(data: paysheetDetailsData, encoding: .utf8) {
                     inputParameters["paysheetDetails"] = paysheetDetailsString
                 }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -98,7 +98,7 @@ import BraintreeCore
             let metadata = self.apiClient.metadata
             metadata.source = .venmoApp
             
-            var inputParameters: [String: String?] = [
+            var inputParameters: [String: Any?] = [
                 "paymentMethodUsage": request.paymentMethodUsage.stringValue,
                 "merchantProfileId": merchantProfileID,
                 "customerClient": "MOBILE_APP",
@@ -109,28 +109,28 @@ import BraintreeCore
                 inputParameters["displayName"] = displayName
             }
 
-            var paysheetDetails: [String: String] = [
+            var paysheetDetails: [String: Any] = [
                 "collectCustomerBillingAddress": "\(request.collectCustomerBillingAddress)",
                 "collectCustomerShippingAddress": "\(request.collectCustomerShippingAddress)"
             ]
             
-            var transactionDetails: [String: String] = [:]
+            var transactionDetails: [String: Any] = [:]
             if let subTotalAmount = request.subTotalAmount {
                 transactionDetails["subTotalAmount"] = subTotalAmount
             }
-            
+
             if let discountAmount = request.discountAmount {
                 transactionDetails["discountAmount"] = discountAmount
             }
-            
+
             if let taxAmount = request.taxAmount {
                 transactionDetails["taxAmount"] = taxAmount
             }
-            
+
             if let shippingAmount = request.shippingAmount {
                 transactionDetails["shippingAmount"] = shippingAmount
             }
-            
+
             if let totalAmount = request.totalAmount {
                 transactionDetails["totalAmount"] = totalAmount
             }
@@ -142,25 +142,11 @@ import BraintreeCore
                     }
                 }
                 let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
-                if let jsonLineItemData = try? JSONSerialization.data(withJSONObject: lineItemsArray),
-                   let jsonLineItemString = String(data: jsonLineItemData, encoding: .utf8) {
-                    transactionDetails["lineItems"] = jsonLineItemString
-                }
+                transactionDetails["lineItems"] = lineItemsArray
             }
+            paysheetDetails["transactionDetails"] = transactionDetails
 
-            if !transactionDetails.isEmpty {
-                if let jsonAmountData = try? JSONSerialization.data(withJSONObject: transactionDetails),
-                   let transactionDetailsString = String(data: jsonAmountData, encoding: .utf8) {
-                    paysheetDetails["transactionDetails"] = transactionDetailsString
-                }
-            }
-            
-            if !paysheetDetails.isEmpty {
-                if let paysheetDetailsData = try? JSONSerialization.data(withJSONObject: paysheetDetails),
-                   let paysheetDetailsString = String(data: paysheetDetailsData, encoding: .utf8) {
-                    inputParameters["paysheetDetails"] = paysheetDetailsString
-                }
-            }
+            inputParameters["paysheetDetails"] = paysheetDetails
 
             let inputDictionary: [String: Any] = ["input": inputParameters]
             let graphQLParameters: [String: Any] = [

--- a/Sources/BraintreeVenmo/BTVenmoError.swift
+++ b/Sources/BraintreeVenmo/BTVenmoError.swift
@@ -55,6 +55,9 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
     /// 8. Failed to fetch Braintree configuration
     case fetchConfigurationFailed
 
+    /// 9. ECD is disabled
+    case ecdDisabled
+
     static var errorDomain: String {
         "com.braintreepayments.BTVenmoErrorDomain"
     }
@@ -79,6 +82,8 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
             return 7
         case .fetchConfigurationFailed:
             return 8
+        case .ecdDisabled:
+            return 9
         }
     }
 
@@ -102,6 +107,8 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
             return description
         case .fetchConfigurationFailed:
             return "Failed to fetch Braintree configuration."
+        case .ecdDisabled:
+            return "Cannot collect customer data when ECD is disabled."
         }
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoError.swift
+++ b/Sources/BraintreeVenmo/BTVenmoError.swift
@@ -55,8 +55,8 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
     /// 8. Failed to fetch Braintree configuration
     case fetchConfigurationFailed
 
-    /// 9. ECD is disabled
-    case ecdDisabled
+    /// 9. Enriched Customer Data is disabled
+    case enrichedCustomerDataDisabled
 
     static var errorDomain: String {
         "com.braintreepayments.BTVenmoErrorDomain"
@@ -82,7 +82,7 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
             return 7
         case .fetchConfigurationFailed:
             return 8
-        case .ecdDisabled:
+        case .enrichedCustomerDataDisabled:
             return 9
         }
     }
@@ -107,8 +107,8 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
             return description
         case .fetchConfigurationFailed:
             return "Failed to fetch Braintree configuration."
-        case .ecdDisabled:
-            return "Cannot collect customer data when ECD is disabled."
+        case .enrichedCustomerDataDisabled:
+            return "Cannot collect customer data when ECD is disabled. Enable this feature in the Control Panel to collect this data."
         }
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.swift
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.swift
@@ -1,0 +1,94 @@
+//
+//  BTVenmoLineItem.swift
+//  BraintreeVenmo
+//
+//  Created by Khushboo Mukesh Chandwani on 3/23/23.
+//
+
+import Foundation
+
+/// Use this option to specify whether a line item is a debit (sale) or credit (refund) to the customer.
+@objc public enum BTVenmoLineItemKind: Int {
+    /// Debit
+    case debit
+
+    /// Credit
+    case credit
+}
+
+/// A Venmo line item to be displayed in the Venmo Paysheet.
+@objcMembers public class BTVenmoLineItem: NSObject {
+
+    // MARK: - Public Properties
+    
+    /// Number of units of the item purchased. This value must be a whole number and can't be negative or zero.
+    public var quantity: Int
+
+    /// Per-unit price of the item. Can include up to 2 decimal places. This value can't be negative or zero.
+    public var unitAmount: String
+
+    /// Item name. Maximum 127 characters.
+    public var name: String
+
+    /// Indicates whether the line item is a debit (sale) or credit (refund) to the customer.
+    public var kind: BTVenmoLineItemKind
+
+    /// Optional: Per-unit tax price of the item. Can include up to 2 decimal places. This value can't be negative or zero.
+    public var unitTaxAmount: String? = nil
+
+    /// Optional: Item description. Maximum 127 characters.
+    public var itemDescription: String? = nil
+
+    /// Optional: Product or UPC code for the item. Maximum 127 characters.
+    public var productCode: String? = nil
+
+    /// Optional: The URL to product information.
+    public var url: URL? = nil
+
+    // MARK: - Public Initializer
+    
+    /// Initialize a BTVenmoLineItem
+    /// - Parameters:
+    ///   - quantity: Number of units of the item purchased. Can include up to 4 decimal places. This value can't be negative or zero.
+    ///   - unitAmount: Per-unit price of the item. Can include up to 4 decimal places. This value can't be negative or zero.
+    ///   - name: Item name. Maximum 127 characters.
+    ///   - kind: Indicates whether the line item is a debit (sale) or credit (refund) to the customer.
+    @objc(initWithQuantity:unitAmount:name:kind:)
+    public init(quantity: Int, unitAmount: String, name: String, kind: BTVenmoLineItemKind) {
+        self.quantity = quantity
+        self.unitAmount = unitAmount
+        self.name = name
+        self.kind = kind
+    }
+    
+    // MARK: - Public Methods
+
+    /// Returns the line item in a dictionary.
+    /// - Returns: A dictionary with the line item information formatted for a request.
+    public func requestParameters() -> [String: Any] {
+        var requestParameters = [
+            "quantity": quantity,
+            "unit_amount": unitAmount,
+            "name": name,
+            "kind": kind == .debit ? "debit" : "credit"
+        ] as [String : Any]
+
+        if let unitTaxAmount, unitTaxAmount != "" {
+            requestParameters["unit_tax_amount"] = unitTaxAmount
+        }
+
+        if let itemDescription, itemDescription != "" {
+            requestParameters["description"] = itemDescription
+        }
+
+        if let productCode, productCode != "" {
+            requestParameters["product_code"] = productCode
+        }
+
+        if let url, url != URL(string: "") {
+            requestParameters["url"] = url.absoluteString
+        }
+        
+        return requestParameters
+    }
+}

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.swift
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.swift
@@ -1,10 +1,3 @@
-//
-//  BTVenmoLineItem.swift
-//  BraintreeVenmo
-//
-//  Created by Khushboo Mukesh Chandwani on 3/23/23.
-//
-
 import Foundation
 
 /// Use this option to specify whether a line item is a debit (sale) or credit (refund) to the customer.
@@ -61,17 +54,17 @@ import Foundation
         self.kind = kind
     }
     
-    // MARK: - Public Methods
+    // MARK: - Internal Methods
 
     /// Returns the line item in a dictionary.
     /// - Returns: A dictionary with the line item information formatted for a request.
-    public func requestParameters() -> [String: Any] {
-        var requestParameters = [
+    func requestParameters() -> [String: Any] {
+        var requestParameters: [String: Any] = [
             "quantity": quantity,
             "unit_amount": unitAmount,
             "name": name,
             "kind": kind == .debit ? "debit" : "credit"
-        ] as [String : Any]
+        ]
 
         if let unitTaxAmount, unitTaxAmount != "" {
             requestParameters["unit_tax_amount"] = unitTaxAmount

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.swift
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.swift
@@ -61,13 +61,13 @@ import Foundation
     func requestParameters() -> [String: Any] {
         var requestParameters: [String: Any] = [
             "quantity": quantity,
-            "unit_amount": unitAmount,
+            "unitAmount": unitAmount,
             "name": name,
-            "kind": kind == .debit ? "debit" : "credit"
+            "type": kind == .debit ? "DEBIT" : "CREDIT"
         ]
 
         if let unitTaxAmount, unitTaxAmount != "" {
-            requestParameters["unit_tax_amount"] = unitTaxAmount
+            requestParameters["unitTaxAmount"] = unitTaxAmount
         }
 
         if let itemDescription, itemDescription != "" {
@@ -75,7 +75,7 @@ import Foundation
         }
 
         if let productCode, productCode != "" {
-            requestParameters["product_code"] = productCode
+            requestParameters["productCode"] = productCode
         }
 
         if let url, url != URL(string: "") {

--- a/Sources/BraintreeVenmo/BTVenmoRequest.swift
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.swift
@@ -50,28 +50,22 @@ import Foundation
     /// Defaults to `false`
     public var collectCustomerShippingAddress: Bool = false
     
-    /// Optional.
-    /// The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
+    /// Optional. The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
     public var subTotalAmount: String?
     
-    /// Optional.
-    /// The total discount amount applied on the transaction to be displayed on the paysheet.
+    /// Optional. The total discount amount applied on the transaction to be displayed on the paysheet.
     public var discountAmount: String?
     
-    /// Optional.
-    /// The total tax amount for the transaction to be displayed on the paysheet.
+    /// Optional. The total tax amount for the transaction to be displayed on the paysheet.
     public var taxAmount: String?
     
-    /// Optional.
-    /// The shipping amount for the transaction to be displayed on the paysheet.
+    /// Optional. The shipping amount for the transaction to be displayed on the paysheet.
     public var shippingAmount: String?
     
-    /// Optional.
-    /// The grand total amount on the transaction that should be displayed on the paysheet.
+    /// Optional. The grand total amount on the transaction that should be displayed on the paysheet.
     public var totalAmount: String?
     
-    /// Optional.
-    /// The line items for this transaction. It can include up to 249 line items.
+    /// Optional. The line items for this transaction. It can include up to 249 line items.
     public var lineItems: [BTVenmoLineItem]?
 
     // MARK: - Initializer

--- a/Sources/BraintreeVenmo/BTVenmoRequest.swift
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.swift
@@ -41,6 +41,38 @@ import Foundation
 
     /// Optional. The business name that will be displayed in the Venmo app payment approval screen. Only used by merchants onboarded as PayFast channel partners.
     public var displayName: String?
+    
+    /// Whether the customer's billing address should be collected and displayed on the Venmo paysheel.
+    /// Defaults to `false`
+    public var collectCustomerBillingAddress: Bool = false
+    
+    /// Whether the customer's shipping address should be collected and displayed on the Venmo paysheel.
+    /// Defaults to `false`
+    public var collectCustomerShippingAddress: Bool = false
+    
+    /// Optional.
+    /// The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
+    public var subTotalAmount: String?
+    
+    /// Optional.
+    /// The total discount amount applied on the transaction to be displayed on the paysheet.
+    public var discountAmount: String?
+    
+    /// Optional.
+    /// The total tax amount for the transaction to be displayed on the paysheet.
+    public var taxAmount: String?
+    
+    /// Optional.
+    /// The shipping amount for the transaction to be displayed on the paysheet.
+    public var shippingAmount: String?
+    
+    /// Optional.
+    /// The grand total amount on the transaction that should be displayed on the paysheet.
+    public var totalAmount: String?
+    
+    /// Optional.
+    /// The line items for this transaction. It can include up to 249 line items.
+    public var lineItems: [BTVenmoLineItem]?
 
     // MARK: - Initializer
 

--- a/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
@@ -41,22 +41,20 @@ class BTConfiguration_Venmo_Tests: XCTestCase {
     
     func testVenmoEnrichedCustomerDataEnabled_returnsEcd() {
         var configurationJSON = BTJSON(value: [
-            "payWithVenmo": ["enrichedCustomerDataEnabled" : true ]
+            "payWithVenmo": ["enrichedCustomerDataEnabled": true]
         ])
         var configuration = BTConfiguration(json: configurationJSON)
 
         XCTAssertTrue(configuration.isVenmoEnrichedCustomerDataEnabled)
         
         configurationJSON = BTJSON(value: [
-            "payWithVenmo": ["enrichedCustomerDataEnabled" : false ]
+            "payWithVenmo": ["enrichedCustomerDataEnabled": false]
         ])
         configuration = BTConfiguration(json: configurationJSON)
 
         XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
 
-        configurationJSON = BTJSON(value: [
-            "payWithVenmo": [:]
-        ])
+        configurationJSON = BTJSON(value: ["payWithVenmo": [:]])
         configuration = BTConfiguration(json: configurationJSON)
 
         XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)

--- a/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
@@ -38,4 +38,27 @@ class BTConfiguration_Venmo_Tests: XCTestCase {
 
         XCTAssertEqual(configuration.venmoEnvironment, "rockbox")
     }
+    
+    func testVenmoEnrichedCustomerDataEnabled_returnsEcd() {
+        var configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled" : true ]
+        ])
+        var configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertTrue(configuration.isVenmoEnrichedCustomerDataEnabled)
+        
+        configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled" : false ]
+        ])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
+
+        configurationJSON = BTJSON(value: [
+            "payWithVenmo": [:]
+        ])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
+    }
 }

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
@@ -31,7 +31,25 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
                         "externalId": "venmo-external-id",
                         "firstName": "venmo-first-name",
                         "lastName": "venmo-last-name",
-                        "phoneNumber": "venmo-phone-number"
+                        "phoneNumber": "venmo-phone-number",
+                        "billingAddress": [
+                            "fullName": "Bar Foo",
+                            "addressLine1": "1 Foo Ct",
+                            "addressLine2": "Apt Foo",
+                            "adminArea2": "Barfoo",
+                            "adminArea1": "BF",
+                            "postalCode": "20",
+                            "countryCode": "AU"
+                        ],
+                        "shippingAddress": [
+                            "fullName": "Some Dude",
+                            "addressLine1": "2 Foo Ct",
+                            "addressLine2": "Apt 5",
+                            "adminArea2": "Dudeville",
+                            "adminArea1": "CA",
+                            "postalCode": "30",
+                            "countryCode": "US"
+                        ]
                     ]
                 ] as [String: Any]
             ]
@@ -46,6 +64,26 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
         XCTAssertEqual(venmoAccountNonce.firstName, "venmo-first-name")
         XCTAssertEqual(venmoAccountNonce.lastName, "venmo-last-name")
         XCTAssertEqual(venmoAccountNonce.phoneNumber, "venmo-phone-number")
+        
+        let billingAddress = venmoAccountNonce.billingAddress
+        XCTAssertNotNil(billingAddress)
+        XCTAssertEqual(billingAddress?.recipientName, "Bar Foo")
+        XCTAssertEqual(billingAddress?.streetAddress, "1 Foo Ct")
+        XCTAssertEqual(billingAddress?.extendedAddress, "Apt Foo")
+        XCTAssertEqual(billingAddress?.locality, "Barfoo")
+        XCTAssertEqual(billingAddress?.region, "BF")
+        XCTAssertEqual(billingAddress?.postalCode, "20")
+        XCTAssertEqual(billingAddress?.countryCodeAlpha2, "AU")
+        
+        let shippingAddress = venmoAccountNonce.shippingAddress
+        XCTAssertNotNil(shippingAddress)
+        XCTAssertEqual(shippingAddress?.recipientName, "Some Dude")
+        XCTAssertEqual(shippingAddress?.streetAddress, "2 Foo Ct")
+        XCTAssertEqual(shippingAddress?.extendedAddress, "Apt 5")
+        XCTAssertEqual(shippingAddress?.locality, "Dudeville")
+        XCTAssertEqual(shippingAddress?.region, "CA")
+        XCTAssertEqual(shippingAddress?.postalCode, "30")
+        XCTAssertEqual(shippingAddress?.countryCodeAlpha2, "US")
     }
 
     func testBTVenmoAccountNonceWithJSON_createsBTVenmoAccountNonceWithExpectedValues() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -100,18 +100,15 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.tokenize(venmoRequest) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
-        XCTAssertEqual(mockAPIClient.lastPOSTParameters as NSObject?, [
-            "query": "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
-            "variables": [
-                "input" : [
-                    "customerClient": "MOBILE_APP",
-                    "intent": "CONTINUE",
-                    "merchantProfileId": "venmo_merchant_id",
-                    "paymentMethodUsage": "MULTI_USE",
-                    "displayName": "app-display-name"
-                ]
-            ]
-        ] as [String: Any] as NSObject)
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+            XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+            XCTAssertEqual("MULTI_USE", input["paymentMethodUsage"] as? String)
+            XCTAssertEqual("CONTINUE",input["intent"] as? String)
+            XCTAssertEqual("app-display-name",input["displayName"] as? String)
+        }
     }
 
     func testTokenizeVenmoAccount_whenDisplayNameNotSet_createsPaymentContextWithoutDisplayName() {
@@ -124,17 +121,85 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.tokenize(venmoRequest) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
-        XCTAssertEqual(mockAPIClient.lastPOSTParameters as NSObject?, [
-            "query": "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
-            "variables": [
-                "input" : [
-                    "customerClient": "MOBILE_APP",
-                    "intent": "CONTINUE",
-                    "merchantProfileId": "venmo_merchant_id",
-                    "paymentMethodUsage": "MULTI_USE"
-                ]
-            ]
-        ] as [String: Any] as NSObject)
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+            XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+            XCTAssertEqual("MULTI_USE", input["paymentMethodUsage"] as? String)
+            XCTAssertEqual("CONTINUE",input["intent"] as? String)
+        }
+    }
+    
+    func testTokenizeVenmoAccount_whenCollectAddressFlagsSet_createsPaymentContextWithTheRightFlags() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        venmoRequest.collectCustomerBillingAddress = true
+        venmoRequest.collectCustomerShippingAddress = true
+        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        let fakeApplication = FakeApplication()
+        venmoClient.application = fakeApplication
+        venmoClient.bundle = FakeBundle()
+
+        venmoClient.tokenize(venmoRequest) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+        
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            if let paysheetDetails = input["paysheetDetails"] as? String {
+                if let jsonData = paysheetDetails.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                    XCTAssertEqual("true",json["collectCustomerShippingAddress"] as? String)
+                    XCTAssertEqual("true",json["collectCustomerBillingAddress"] as? String)
+                }
+            }
+        }
+    }
+    
+    func testTokenizeVenmoAccount_withAmountsAndLineItemsSet_createsPaymentContext() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        venmoRequest.subTotalAmount = "9"
+        venmoRequest.totalAmount = "9"
+        venmoRequest.lineItems = [BTVenmoLineItem(quantity: 1, unitAmount: "9", name: "name", kind: .debit)]
+        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        let fakeApplication = FakeApplication()
+        venmoClient.application = fakeApplication
+        venmoClient.bundle = FakeBundle()
+
+        venmoClient.tokenize(venmoRequest) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+        
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+        let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+            XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+            
+            if let paysheetDetails = input["paysheetDetails"] as? String {
+                if let jsonData = paysheetDetails.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                    XCTAssertEqual("false",json["collectCustomerShippingAddress"] as? String)
+                    XCTAssertEqual("false",json["collectCustomerBillingAddress"] as? String)
+                    
+                    if let transactionDetailsString = json["transactionDetails"] as? String {
+                        if let jsonData = transactionDetailsString.data(using: .utf8),
+                           let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                            XCTAssertEqual(json["totalAmount"] as? String, "9")
+                            XCTAssertEqual(json["subTotalAmount"] as? String, "9")
+                            if let lineItems = json["lineItems"] as? String {
+                                XCTAssertTrue(lineItems.contains("\"quantity\":1"))
+                                XCTAssertTrue(lineItems.contains("\"name\":\"name"))
+                                XCTAssertTrue(lineItems.contains("\"unit_amount\":\"9\""))
+                                XCTAssertTrue(lineItems.contains("\"kind\":\"debit\""))
+                                XCTAssertTrue(lineItems.contains("\"unit_tax_amount\":\"0\""))
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     func testTokenizeVenmoAccount_opensVenmoURLWithPaymentContextID() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -123,7 +123,7 @@ class BTVenmoClient_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
         let params = mockAPIClient.lastPOSTParameters as? NSDictionary
         if let inputDict = params?["variables"] as? NSDictionary,
-           let input = inputDict["input"] as? [String:Any] {
+           let input = inputDict["input"] as? [String: Any] {
             XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
             XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
             XCTAssertEqual("MULTI_USE", input["paymentMethodUsage"] as? String)
@@ -131,7 +131,7 @@ class BTVenmoClient_Tests: XCTestCase {
         }
     }
     
-    func testTokenizeVenmoAccount_whenEcdDisabled_doesNotAllowCollectingAddresses() {
+    func testTokenizeVenmoAccount_whenEnrichedCustomerDataDisabled_doesNotAllowCollectingAddresses() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "payWithVenmo" : [
                 "environment": "sandbox",
@@ -152,7 +152,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
             guard let error = error as NSError? else {return}
-            XCTAssertEqual(error.code, BTVenmoError.ecdDisabled.errorCode)
+            XCTAssertEqual(error.code, BTVenmoError.enrichedCustomerDataDisabled.errorCode)
             expectation.fulfill()
         }
 
@@ -182,7 +182,7 @@ class BTVenmoClient_Tests: XCTestCase {
         
         let params = mockAPIClient.lastPOSTParameters as? NSDictionary
         if let inputDict = params?["variables"] as? NSDictionary,
-           let input = inputDict["input"] as? [String:Any] {
+           let input = inputDict["input"] as? [String: Any] {
             if let paysheetDetails = input["paysheetDetails"] as? String {
                 if let jsonData = paysheetDetails.data(using: .utf8),
                    let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
@@ -209,7 +209,7 @@ class BTVenmoClient_Tests: XCTestCase {
         
         let params = mockAPIClient.lastPOSTParameters as? NSDictionary
         if let inputDict = params?["variables"] as? NSDictionary,
-        let input = inputDict["input"] as? [String:Any] {
+        let input = inputDict["input"] as? [String: Any] {
             XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
             XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
             

--- a/UnitTests/BraintreeVenmoTests/BTVenmoLineItem_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoLineItem_Tests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+@testable import BraintreeVenmo
+
+class BTVenmoLineItem_Tests: XCTestCase {
+    
+    func testRequestParameters() {
+        let lineItem = BTVenmoLineItem(quantity: 1, unitAmount: "10", name: "item-name", kind: BTVenmoLineItemKind.debit);
+        lineItem.unitTaxAmount = "10";
+        let requestParams = lineItem.requestParameters();
+        XCTAssertEqual(requestParams["name"] as! String, "item-name");
+        XCTAssertEqual(requestParams["type"] as! String, "DEBIT");
+        XCTAssertEqual(requestParams["unitAmount"] as! String, "10");
+        XCTAssertEqual(requestParams["quantity"] as! Int, 1);
+        XCTAssertEqual(requestParams["unitTaxAmount"] as! String, "10");
+    }
+}

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -12,4 +12,10 @@ class BTVenmoRequest_Tests: XCTestCase {
         let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
         XCTAssertEqual(request.paymentMethodUsage.stringValue, "SINGLE_USE")
     }
+    
+    func testCollectAddressFlags_setsDefaultValues() {
+        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
+        XCTAssertEqual(request.collectCustomerShippingAddress, false)
+        XCTAssertEqual(request.collectCustomerBillingAddress, false)
+    }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

Adds the following fields to BTVenmoRequest to be used in createPaymentContext:

2 new address collection fields -

collectCustomerBillingAddress
collectCustomerShippingAddress

and 6 new fields for transaction amount and line items -

lineItems
subTotalAmount
discountAmount
taxAmount
shippingAmount
totalAmount

Note: Should not be merged until [this GraphQL PR](https://github.braintreeps.com/braintree/cosmos-apps/pull/8614) is merged.

### JIRA
https://paypal.atlassian.net/browse/DTBTVENMO-940

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- khushboo18
