### PR TITLE
Paypal analytics audit

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		03E7E3D8212469AD000C5094 /* BTPaymentFlowClient+LocalPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E7E3D4212469AD000C5094 /* BTPaymentFlowClient+LocalPayment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03E7E3D9212469AD000C5094 /* BTLocalPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E7E3D5212469AD000C5094 /* BTLocalPaymentRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
+		3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */; };
+		3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */; };
 		3DAB5933286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */; };
 		3DAB5937286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */; };
 		3DAB5939286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */; };
@@ -653,6 +655,8 @@
 		162174E1192D9220008DC35D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		16CD2E9E1B4077FC00E68495 /* BTJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON_Tests.swift; sourceTree = "<group>"; };
 		2D941D381B59C76A0016EFB4 /* BraintreePayPal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreePayPal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics.swift; sourceTree = "<group>"; };
+		3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeHermesResponse_Tests.swift; sourceTree = "<group>"; };
 		3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeTokenizationClient_Tests.swift; sourceTree = "<group>"; };
@@ -1211,6 +1215,7 @@
 				57D9436D2968A8080079EAB1 /* BTPayPalLocaleCode.swift */,
 				BE349112294B798300D2CF68 /* BTPayPalRequest.swift */,
 				BE349110294B77E100D2CF68 /* BTPayPalVaultRequest.swift */,
+				3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */,
 			);
 			path = BraintreePayPal;
 			sourceTree = "<group>";
@@ -1770,6 +1775,7 @@
 				A9E5C1F724FD672A00EE691F /* BraintreePayPalTests-Bridging-Header.h */,
 				A95229C624FD949D006F7D25 /* BTConfiguration+PayPal_Tests.swift */,
 				A977A04024FEC36F006049AB /* BTPaymentMethodNonceParser_PayPal_Tests.swift */,
+				3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */,
 				42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */,
 				427F32DF25D1D62D00435294 /* BTPayPalClient_Tests.swift */,
 				42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */,
@@ -2891,6 +2897,7 @@
 				BEF5D2E6294A18B300FFD56D /* BTPayPalLineItem.swift in Sources */,
 				BE349113294B798300D2CF68 /* BTPayPalRequest.swift in Sources */,
 				57544F5C295254A500DEB7B0 /* BTJSON+PayPal.swift in Sources */,
+				3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */,
 				BE8E5CEF294B6937001BF017 /* BTPayPalCheckoutRequest.swift in Sources */,
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
@@ -3174,6 +3181,7 @@
 				42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */,
 				A977A04124FEC36F006049AB /* BTPaymentMethodNonceParser_PayPal_Tests.swift in Sources */,
 				427F329025D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift in Sources */,
+				3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */,
 				A95229C724FD949D006F7D25 /* BTConfiguration+PayPal_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -662,16 +662,13 @@
 		162174E1192D9220008DC35D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		16CD2E9E1B4077FC00E68495 /* BTJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON_Tests.swift; sourceTree = "<group>"; };
 		2D941D381B59C76A0016EFB4 /* BraintreePayPal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreePayPal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-<<<<<<< HEAD
 		3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics.swift; sourceTree = "<group>"; };
 		3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics_Tests.swift; sourceTree = "<group>"; };
-=======
 		3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3BC72A5129B296E500326652 /* BTCardAnalytics_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTCardAnalytics_Internal.h; sourceTree = "<group>"; };
 		3BC72A5229B296E500326652 /* BTCardAnalytics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTCardAnalytics.m; sourceTree = "<group>"; };
 		3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics.swift; sourceTree = "<group>"; };
 		3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics_Tests.swift; sourceTree = "<group>"; };
->>>>>>> fpti-feature
 		3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeHermesResponse_Tests.swift; sourceTree = "<group>"; };
 		3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeTokenizationClient_Tests.swift; sourceTree = "<group>"; };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Remove `iosBaseSDK`, `iosDeploymentTarget`, `iosIdentifierForVendor`, `deviceAppGeneratedPersistentUuid`, and `deviceScreenOrientation` from `BTAnalyticsMetadata`
+* Fixes error `@objcMembers attribute used without importing module 'Foundation'` in Xcode 14.3+
 * Breaking Changes
   * BraintreePaymentFlow
     * Replaced `SFSafariViewController` with `ASWebAuthenticationSession`

--- a/Sources/BraintreeCore/BTMutableClientMetadata.swift
+++ b/Sources/BraintreeCore/BTMutableClientMetadata.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // NEXT_MAJOR_VERSION (v7): Explore removing this once BraintreeVenmo is in Swift
 /// Required for Objective-C compatibility. Necessary behavior is provided by the swift version.
 @objcMembers public class BTMutableClientMetadata: BTClientMetadata { }

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+class BTPayPalAnalytics {
+    static let vaultRequestStarted = "paypal:vault-tokenize:started"
+    static let checkoutRequestStarted = "paypal:checkout-tokenize:started"
+    
+    // counted in conversion rates
+    static let tokenizeFailed = "paypal:tokenize:failed"
+    static let tokenizeSucceeded = "paypal:tokenize:succeeded"
+    static let browserLoginCanceled = "paypal:tokenize:browser-login:canceled"
+   
+    // additional detail analytic messages
+    static let tokenizeNetworkConnectionFailed = "paypal:tokenize:network-connection:failed"
+    static let tokenizeBrowserSwitchNetworkConnectionLost = "paypal:tokenize:browser-switch-network-connection:failed"
+
+    static let browserPresentationStarted = "paypal:tokenize:browser-presentation:started"
+    static let browserPresentationSucceeded = "paypal:tokenize:browser-presentation:succeeded"
+    static let browserPresentationFailed = "paypal:tokenize:browser-presentation:failed"
+    static let authsessionBrowserCancel = "paypal:tokenize:authsession-browser:canceled"
+    static let authsessionAlertCancel = "paypal:tokenize:authsession-alert:canceled"
+}

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -27,6 +27,9 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
     /// Unable to create BTPayPalAccountNonce
     case failedToCreateNonce
     
+    /// asWebAuthentication error
+    case webSessionError
+    
     static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
     }
@@ -49,6 +52,8 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
             return 6
         case .failedToCreateNonce:
             return 7
+        case .webSessionError:
+            return 8
         }
     }
 
@@ -70,6 +75,8 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
             return "The URL action did not contain a valid URL."
         case .failedToCreateNonce:
             return "Unable to create BTPayPalAccountNonce. Either body did not contain paypalAccounts array or contents could not be parsed."
+        case .webSessionError:
+            return "ASWebAuthenticationSession failed"
         }
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if canImport(BraintreeCore)
 import BraintreeCore
 #endif

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if canImport(BraintreeCore)
 import BraintreeCore
 #endif

--- a/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import BraintreePayPal
+
+final class BTPayPalAnalytics_Tests: XCTestCase {
+    func test_tokenizeAnalyticsEvents_sendsExpectedEventNames() {
+        XCTAssertEqual(BTPayPalAnalytics.vaultRequestStarted, "paypal:vault-tokenize:started")
+        XCTAssertEqual(BTPayPalAnalytics.checkoutRequestStarted, "paypal:checkout-tokenize:started")
+        XCTAssertEqual(BTPayPalAnalytics.tokenizeFailed, "paypal:tokenize:failed")
+        XCTAssertEqual(BTPayPalAnalytics.tokenizeSucceeded, "paypal:tokenize:succeeded")
+        XCTAssertEqual(BTPayPalAnalytics.browserLoginCanceled, "paypal:tokenize:browser-login:canceled")
+        XCTAssertEqual(BTPayPalAnalytics.tokenizeNetworkConnectionFailed, "paypal:tokenize:network-connection:failed")
+        XCTAssertEqual(BTPayPalAnalytics.tokenizeBrowserSwitchNetworkConnectionLost, "paypal:tokenize:browser-switch-network-connection:failed")
+        XCTAssertEqual(BTPayPalAnalytics.browserPresentationStarted, "paypal:tokenize:browser-presentation:started")
+        XCTAssertEqual(BTPayPalAnalytics.browserPresentationSucceeded, "paypal:tokenize:browser-presentation:succeeded")
+        XCTAssertEqual(BTPayPalAnalytics.browserPresentationFailed, "paypal:tokenize:browser-presentation:failed")
+        XCTAssertEqual(BTPayPalAnalytics.authsessionBrowserCancel, "paypal:tokenize:authsession-browser:canceled")
+        XCTAssertEqual(BTPayPalAnalytics.authsessionAlertCancel, "paypal:tokenize:authsession-alert:canceled")        
+    }
+}

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -406,44 +406,6 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertFalse(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal-single-payment.credit.accepted"))
     }
 
-    func testHandleBrowserSwitchReturn_whenCreditFinancingReturned_shouldSendCreditAcceptedAnalyticsEvent() {
-        mockAPIClient.cannedResponseBody = BTJSON(value: [ "paypalAccounts":
-            [
-                [
-                    "description": "jane.doe@example.com",
-                    "details": [
-                        "email": "jane.doe@example.com",
-                        "creditFinancingOffered": [
-                            "cardAmountImmutable": true,
-                            "monthlyPayment": [
-                                "currency": "USD",
-                                "value": "13.88",
-                            ],
-                            "payerAcceptance": true,
-                            "term": 18,
-                            "totalCost": [
-                                "currency": "USD",
-                                "value": "250.00",
-                            ],
-                            "totalInterest": [
-                                "currency": "USD",
-                                "value": "0.00",
-                            ],
-                        ],
-                    ],
-                    "nonce": "a-nonce",
-                    "type": "PayPalAccount",
-                ]
-            ]
-        ])
-        payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
-
-        let returnURL = URL(string: "bar://onetouch/v1/success?token=hermes_token")!
-        payPalClient.handleBrowserSwitchReturn(returnURL, paymentType: .checkout) { _, _ in }
-
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal-single-payment.credit.accepted"))
-    }
-
     func testHandleBrowserSwitchReturn_whenNonceIsNotCreated_returnsError() {
         mockAPIClient.cannedResponseBody = BTJSON(value: ["not-a-paypalAccount"])
         payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
@@ -684,44 +646,6 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertFalse(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal-ba.credit.accepted"))
     }
 
-    func testHandleBrowserSwitchReturn_vault_whenCreditFinancingReturned_shouldSendCreditAcceptedAnalyticsEvent() {
-        mockAPIClient.cannedResponseBody = BTJSON(
-            value: [ "paypalAccounts": [
-                [
-                    "description": "jane.doe@example.com",
-                    "details": [
-                        "email": "jane.doe@example.com",
-                        "creditFinancingOffered": [
-                            "cardAmountImmutable": true,
-                            "monthlyPayment": [
-                                "currency": "USD",
-                                "value": "13.88",
-                            ],
-                            "payerAcceptance": true,
-                            "term": 18,
-                            "totalCost": [
-                                "currency": "USD",
-                                "value": "250.00",
-                            ],
-                            "totalInterest": [
-                                "currency": "USD",
-                                "value": "0.00",
-                            ],
-                        ],
-                    ],
-                    "nonce": "a-nonce",
-                    "type": "PayPalAccount",
-                ]
-            ]
-            ])
-
-        payPalClient.payPalRequest = BTPayPalVaultRequest()
-
-        let returnURL = URL(string: "bar://onetouch/v1/success?token=hermes_token")!
-        payPalClient.handleBrowserSwitchReturn(returnURL, paymentType: .vault) { _, _ in }
-
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal-ba.credit.accepted"))
-    }
     
     func testTokenizePayPalAccountWithPayPalRequest_whenNetworkConnectionLost_sendsAnalytics() {
         mockAPIClient.cannedResponseError = NSError(domain: NSURLErrorDomain, code: -1005, userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
@@ -737,7 +661,7 @@ class BTPayPalClient_Tests: XCTestCase {
         
         waitForExpectations(timeout: 2)
         
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal.tokenize.network-connection.failure"))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:network-connection:failed"))
     }
     
     func testHandleBrowserSwitchReturnURL_whenNetworkConnectionLost_sendsAnalytics() {
@@ -754,6 +678,6 @@ class BTPayPalClient_Tests: XCTestCase {
         
         waitForExpectations(timeout: 2)
         
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.paypal.handle-browser-switch.network-connection.failure"))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:browser-switch-network-connection:failed"))
     }
 }


### PR DESCRIPTION
### Summary of changes
These changes are going into the fpti-feature branch. Which will get merged in once we audit all modules and make the switch to the FPTI endpoints

-Update PayPal analytics events to prepare for switch to FPTI
-Update tests
-Bucketed all analytic events sent before callbacks into 3 categories counted in conversion rates:
    tokenizeFailed, tokenizeSucceeded and browserLoginCanceled
-Deleted "credit.accepted" event fired if tokenizedAccount.creditFinancing is not nil
-Created new BTPayPalError type "webSessionError". Considered sending associated Error type 
   but needed to cover error from ASWebAuthenticationSession.start() failure.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
@KunJeongPark @jaxdesmarais @scannillo 

