### PR TITLE
Update Migration Guide

### DIFF
--- a/V6_MIGRATION.md
+++ b/V6_MIGRATION.md
@@ -54,7 +54,7 @@ The possible values for `BTVenmoPaymentMethodUsage` include:
 * `.multiUse` - the Venmo payment will be authorized for future payments and can be vaulted.
 * `.singleUse` - the Venmo payment will be authorized for a one-time payment and cannot be vaulted.
 
-`BTVenmoClient.tokenizeVenmoAccount(with: BTVenmoRequest, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void)` has been renamed to `BTVenmoClient.tokenize(_ request: BTVenmoRequest, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void)`
+`BTVenmoClient.tokenizeVenmoAccount(with:completion:)` has been renamed to `BTVenmoClient.tokenize(_:completion:)`
 
 `BTVenmoClient.isiOSAppAvailableForAppSwitch()` has been renamed to `BTVenmoClient.isVenmoAppInstalled()`
 
@@ -76,9 +76,9 @@ venmoClient.tokenize(venmoRequest) { venmoAccountNonce, error in
 
 The property `BTPayPalRequest.activeWindow` has been removed
 
-Removed `BTPayPalDriver.requestOneTimePayment` and `BTPayPalDriver.requestBillingAgreement` in favor of `BTPayPalClient.tokenizePayPalAccount`:
+Removed `BTPayPalDriver.requestOneTimePayment` and `BTPayPalDriver.requestBillingAgreement` in favor of `BTPayPalClient.tokenize`:
 ```
-let payPalClient = BTPayPalClient(apiClient: <MY_BTAPICLIENT>)
+let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
 let request = BTPayPalCheckoutRequest(amount: "1")
 
 payPalClient.tokenize(request) { payPalAccountNonce, error in
@@ -89,16 +89,18 @@ payPalClient.tokenize(request) { payPalAccountNonce, error in
 }
 ```
 
-`BTPayPalClient.tokenizePayPalAccount(with: BTPayPalRequest, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void)` has been replaced with two methods: `tokenize(_ request: BTPayPalVaultRequest, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void)` and `tokenize(_ request: BTPayPalCheckoutRequest, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void)`:
+`BTPayPalClient.tokenizePayPalAccount(with:completion:)` has been replaced with two methods called: `BTPayPalClient.tokenize(_:completion:)` taking in either a `BTPayPalCheckoutRequest` or `BTPayPalVaultRequest`
 
 ```
 // BTPayPalCheckoutRequest
+let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
 let request = BTPayPalCheckoutRequest(amount: "1")
 payPalClient.tokenize(request) { payPalAccountNonce, error in 
     // handle response
 }
 
 // BTPayPalVaultRequest
+let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
 let request = BTPayPalVaultRequest()
 payPalClient.tokenize(request) { payPalAccountNonce, error in 
     // handle response
@@ -106,18 +108,18 @@ payPalClient.tokenize(request) { payPalAccountNonce, error in
 ```
 
 ## PayPal Native Checkout
-`BTPayPalNativeCheckoutClient.tokenizePayPalAccount(with: BTPayPalNativeRequest, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void)` has been replaced with two methods: `tokenize(_ request: BTPayPalNativeCheckoutRequest, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void)` and `tokenize(_ request: BTPayPalNativeVaultRequest, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void)`:
+`BTPayPalNativeCheckoutClient.tokenizePayPalAccount(with:completion:` has been replaced with two methods called: `tokenize(_:completion:)` taking in either a `BTPayPalNativeCheckoutRequest` or `BTPayPalNativeVaultRequest`
 
 ```
 // BTPayPalNativeCheckoutRequest
-let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPICLIENT>)
+let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPIClient>)
 let request = BTPayPalNativeCheckoutRequest(amount: "1")
 payPalNativeCheckoutClient.tokenize(request) { payPalNativeCheckoutAccountNonce, error in 
     // handle response
 }
 
 // BTPayPalNativeVaultRequest
-let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPICLIENT>)
+let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPIClient>)
 let request = BTPayPalNativeVaultRequest()
 payPalNativeCheckoutClient.tokenize(request) { payPalNativeCheckoutAccountNonce, error in 
     // handle response
@@ -133,13 +135,10 @@ For merchants collecting device data for PayPal and Local Payment methods will n
 
 The new integration for collecting device data will look like the following:
 ```
-let dataCollector = BTDataCollector(apiClient: <MY_BTAPICLIENT>)
+let dataCollector = BTDataCollector(apiClient: <MY_BTAPIClient>)
 
-dataCollector.collectDeviceData { deviceData, _ in
-    guard let deviceData = deviceData else {
-        // handle error
-    }
-    // Send deviceData to your server
+dataCollector.collectDeviceData { deviceData, error in
+    // handle response
 }
 ```
 
@@ -149,15 +148,14 @@ The `BraintreeUnionPay` module, and all containing classes, was removed in v6. U
 Now, you can tokenize just with the card details:
 
 ```
-let braintreeClient = BTAPIClient(authorization: "<CLIENT_AUTHORIZATION>")!
-let cardClient = BTCardClient(apiClient: braintreeClient)
+let cardClient = BTCardClient(apiClient: <MY_BTAPIClient>)
 
 let card = BTCard()
 card.number = "4111111111111111"
 card.expirationMonth = "12"
 card.expirationYear = "2025"
 
-cardClient.tokenizeCard(card) { (tokenizedCard, error) in
+cardClient.tokenize(card) { tokenizedCard, error in
     // Communicate the tokenizedCard.nonce to your server, or handle error
 }
 ```
@@ -165,7 +163,7 @@ cardClient.tokenizeCard(card) { (tokenizedCard, error) in
 ## SEPA Direct Debit
 We have removed the `context` parameter from the `BTSEPADirectDebit.tokenize()` method. Additionally, conformance to the `ASWebAuthenticationPresentationContextProviding` protocol is no longer needed.
 
-`BTSEPADirectDebitClient.tokenize(request: BTSEPADirectDebitRequest, context: ASWebAuthenticationPresentationContextProviding, completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void)` has been renamed to `BTSEPADirectDebitClient.tokenize(_: BTSEPADirectDebitRequest, completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void)`
+`BTSEPADirectDebitClient.tokenize(request:context:completion:)` has been renamed to `BTSEPADirectDebitClient.tokenize(_:completion:)`
 
 The updated `tokenize` method is as follows:
 ```
@@ -184,9 +182,9 @@ Your view no longer needs to conform to the `BTViewControllerPresentingDelegate`
 Additionally, you do not need to assign the `BTPaymentFlowClient.viewControllerPresentingDelegate` property in your view.
 
 ## American Express
-`BTAmericanExpressClient.getRewardsBalance(forNonce: String, currencyIsoCode: String, completion: @escaping (BTAmericanExpressRewardsBalance?, Error?) -> Void)` has been renamed to `BTAmericanExpressClient.getRewardsBalance(forNonce: String, currencyISOCode: String, completion: @escaping (BTAmericanExpressRewardsBalance?, Error?) -> Void)`
+`BTAmericanExpressClient.getRewardsBalance(forNonce:currencyIsoCode:completion:)` has been renamed to `BTAmericanExpressClient.getRewardsBalance(forNonce:currencyISOCode:completion:)`
 
 ## Apple Pay
-`BTApplePayClient.tokenizeApplePay(_ payment: PKPayment, completion: @escaping (BTApplePayCardNonce?, Error?) -> Void)` has been renamed to `BTApplePayClient.tokenize(_ payment: PKPayment, completion: @escaping (BTApplePayCardNonce?, Error?) -> Void)`
+`BTApplePayClient.tokenizeApplePay(_:completion:)` has been renamed to `BTApplePayClient.tokenize(_:completion:)`
 
 `BTApplePayClient.paymentRequest()` has been renamed to `BTApplePayClient.makePaymentRequest()`

--- a/V6_MIGRATION.md
+++ b/V6_MIGRATION.md
@@ -59,6 +59,8 @@ The possible values for `BTVenmoPaymentMethodUsage` include:
 `BTVenmoClient.isiOSAppAvailableForAppSwitch()` has been renamed to `BTVenmoClient.isVenmoAppInstalled()`
 
 ```
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let venmoClient = BTVenmoClient(apiClient: apiClient)
 let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
 venmoRequest.profileID = "my-profile-id"
 venmoRequest.vault = true
@@ -78,7 +80,8 @@ The property `BTPayPalRequest.activeWindow` has been removed
 
 Removed `BTPayPalDriver.requestOneTimePayment` and `BTPayPalDriver.requestBillingAgreement` in favor of `BTPayPalClient.tokenize`:
 ```
-let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let payPalClient = BTPayPalClient(apiClient: apiClient)
 let request = BTPayPalCheckoutRequest(amount: "1")
 
 payPalClient.tokenize(request) { payPalAccountNonce, error in
@@ -93,14 +96,16 @@ payPalClient.tokenize(request) { payPalAccountNonce, error in
 
 ```
 // BTPayPalCheckoutRequest
-let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let payPalClient = BTPayPalClient(apiClient: apiClient)
 let request = BTPayPalCheckoutRequest(amount: "1")
 payPalClient.tokenize(request) { payPalAccountNonce, error in 
     // handle response
 }
 
 // BTPayPalVaultRequest
-let payPalClient = BTPayPalClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let payPalClient = BTPayPalClient(apiClient: apiClient)
 let request = BTPayPalVaultRequest()
 payPalClient.tokenize(request) { payPalAccountNonce, error in 
     // handle response
@@ -112,14 +117,16 @@ payPalClient.tokenize(request) { payPalAccountNonce, error in
 
 ```
 // BTPayPalNativeCheckoutRequest
-let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
 let request = BTPayPalNativeCheckoutRequest(amount: "1")
 payPalNativeCheckoutClient.tokenize(request) { payPalNativeCheckoutAccountNonce, error in 
     // handle response
 }
 
 // BTPayPalNativeVaultRequest
-let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
 let request = BTPayPalNativeVaultRequest()
 payPalNativeCheckoutClient.tokenize(request) { payPalNativeCheckoutAccountNonce, error in 
     // handle response
@@ -135,7 +142,8 @@ For merchants collecting device data for PayPal and Local Payment methods will n
 
 The new integration for collecting device data will look like the following:
 ```
-let dataCollector = BTDataCollector(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let dataCollector = BTDataCollector(apiClient: apiClient)
 
 dataCollector.collectDeviceData { deviceData, error in
     // handle response
@@ -148,7 +156,8 @@ The `BraintreeUnionPay` module, and all containing classes, was removed in v6. U
 Now, you can tokenize just with the card details:
 
 ```
-let cardClient = BTCardClient(apiClient: <MY_BTAPIClient>)
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let cardClient = BTCardClient(apiClient: apiClient)
 
 let card = BTCard()
 card.number = "4111111111111111"
@@ -156,7 +165,7 @@ card.expirationMonth = "12"
 card.expirationYear = "2025"
 
 cardClient.tokenize(card) { tokenizedCard, error in
-    // Communicate the tokenizedCard.nonce to your server, or handle error
+    // handle response
 }
 ```
 
@@ -167,6 +176,9 @@ We have removed the `context` parameter from the `BTSEPADirectDebit.tokenize()` 
 
 The updated `tokenize` method is as follows:
 ```
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let sepaDirectDebitClient = BTSEPADirectDebitClient(apiClient: apiClient)
+
 sepaDirectDebitClient.tokenize(sepaDirectDebitRequest) { sepaDirectDebitNonce, error in
     // handle response
 }


### PR DESCRIPTION
### Summary of changes

- Update method signature style of the `V6_MIGRATION` guide to match the Apple method signature syntax (example [here](https://developer.apple.com/documentation/passkit/pkpaymentauthorizationcontroller/1649455-canmakepayments))
- Other general cleanup

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 