### PR TITLE
PaypalNativeCheckout analytics audit

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
 		3B14BFDF29B647AF0047426A /* BTCardAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */; };
+		3BF7FFC829D123F9005CA469 /* BTPayPalNativeCheckoutAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7FFC729D123F9005CA469 /* BTPayPalNativeCheckoutAnalytics.swift */; };
+		3BF7FFCC29D1D4D0005CA469 /* BTPayPalNativeCheckoutAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7FFC929D1D480005CA469 /* BTPayPalNativeCheckoutAnalytics_Tests.swift */; };
 		3DAB5933286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */; };
 		3DAB5937286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */; };
 		3DAB5939286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */; };
@@ -642,6 +644,8 @@
 		3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics.swift; sourceTree = "<group>"; };
 		3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardAnalytics_Tests.swift; sourceTree = "<group>"; };
+		3BF7FFC729D123F9005CA469 /* BTPayPalNativeCheckoutAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutAnalytics.swift; sourceTree = "<group>"; };
+		3BF7FFC929D1D480005CA469 /* BTPayPalNativeCheckoutAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeHermesResponse_Tests.swift; sourceTree = "<group>"; };
 		3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeTokenizationClient_Tests.swift; sourceTree = "<group>"; };
@@ -1352,15 +1356,16 @@
 		9CE51786282D527E0013C740 /* BraintreePayPalNativeCheckout */ = {
 			isa = PBXGroup;
 			children = (
+				57108A1B28342BC1004EB870 /* BTPayPalNativeCheckoutAccountNonce.swift */,
+				3BF7FFC729D123F9005CA469 /* BTPayPalNativeCheckoutAnalytics.swift */,
 				3DF38AF328524A0800225F2A /* BTPayPalNativeCheckoutClient.swift */,
-				3DF38AE728523F7500225F2A /* BTPayPalNativeVaultRequest.swift */,
-				3DF38AEF2852493700225F2A /* BTPayPalNativeHermesResponse.swift */,
 				3DF38AFC28590B5600225F2A /* BTPayPalNativeCheckoutRequest.swift */,
 				3DF38AF1285249AE00225F2A /* BTPayPalNativeError.swift */,
-				3DF38AEB2852421B00225F2A /* BTPayPalNativeTokenizationClient.swift */,
+				3DF38AEF2852493700225F2A /* BTPayPalNativeHermesResponse.swift */,
 				3DF38AED2852488E00225F2A /* BTPayPalNativeOrderCreationClient.swift */,
+				3DF38AEB2852421B00225F2A /* BTPayPalNativeTokenizationClient.swift */,
 				3DF38AE928523FC300225F2A /* BTPayPalNativeTokenizationRequest.swift */,
-				57108A1B28342BC1004EB870 /* BTPayPalNativeCheckoutAccountNonce.swift */,
+				3DF38AE728523F7500225F2A /* BTPayPalNativeVaultRequest.swift */,
 			);
 			path = BraintreePayPalNativeCheckout;
 			sourceTree = "<group>";
@@ -1369,6 +1374,7 @@
 			isa = PBXGroup;
 			children = (
 				BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */,
+				3BF7FFC929D1D480005CA469 /* BTPayPalNativeCheckoutAnalytics_Tests.swift */,
 				3DAB593E286CB967003A7BC5 /* BTPayPalNativeCheckoutClient_Tests.swift */,
 				3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */,
 				3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */,
@@ -2864,6 +2870,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BF7FFC829D123F9005CA469 /* BTPayPalNativeCheckoutAnalytics.swift in Sources */,
 				3DF38AF428524A0800225F2A /* BTPayPalNativeCheckoutClient.swift in Sources */,
 				3DF38AFD28590B5600225F2A /* BTPayPalNativeCheckoutRequest.swift in Sources */,
 				3DF38AEE2852488E00225F2A /* BTPayPalNativeOrderCreationClient.swift in Sources */,
@@ -2887,6 +2894,7 @@
 				3DAB5937286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift in Sources */,
 				BEDB820629B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift in Sources */,
 				3DF4B4CA285A74200072DC60 /* BTPayPalNativeVaultRequest_Tests.swift in Sources */,
+				3BF7FFCC29D1D4D0005CA469 /* BTPayPalNativeCheckoutAnalytics_Tests.swift in Sources */,
 				3DAB5933286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -4,8 +4,7 @@ class BTPayPalNativeCheckoutAnalytics {
     
     // MARK: - Tokenize Events
     
-    static let vaultRequestStarted = "paypal-native:vault-tokenize:started"
-    static let checkoutRequestStarted = "paypal-native:checkout-tokenize:started"
+    static let tokenizeStarted = "paypal-native:tokenize:started"
     static let tokenizeFailed = "paypal-native:tokenize:failed"
     static let tokenizeSucceeded = "paypal-native:tokenize:succeeded"
     static let tokenizeCanceled = "paypal-native:tokenize:canceled"

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+class BTPayPalNativeCheckoutAnalytics {
+    
+    // MARK: - Tokenize Events
+    
+    // Counted in conversion rates
+    static let vaultRequestStarted = "paypal-native:vault-tokenize:started"
+    static let checkoutRequestStarted = "paypal-native:checkout-tokenize:started"
+    static let tokenizeFailed = "paypal-native:tokenize:failed"
+    static let tokenizeSucceeded = "paypal-native:tokenize:succeeded"
+    static let tokenizeCanceled = "paypal-native:tokenize:canceled"
+    
+    // Specific tokenize failures
+    static let tokenizeUrlRequestFailed = "paypal-native:tokenize:url-request:failed"
+    static let tokenizeParsingResultFailed = "paypal-native:tokenize:parsing-result:failed"
+    
+    // MARK: - Create Order Events
+    
+    static let createOrderStarted = "paypal-native:create-order:started"
+    static let createOrderFailed = "paypal-native:create-order:failed"
+    static let createOrderSucceeded = "paypal-native:create-order:succeeded"
+    
+    // Specific Create Order Fails
+    static let createOrderPayPalNotEnabledFailed = "paypal-native:create-order:paypal-not-enabled:failed"
+    static let createOrderClientIdNotFoundFailed = "paypal-native:create-order:client-id-not-found:failed"
+    static let createOrderInvalidEnvironmentFailed = "paypal-native:create-order:invalid-environment:failed"
+    static let createOrderHermesUrlRequestFailed = "paypal-native:create-order:hermes-url-request:failed"
+    static let createOrderInvalidPaymentType =
+        "paypal-native:create-order:invalid-payment-type:failed"
+}

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -11,5 +11,5 @@ class BTPayPalNativeCheckoutAnalytics {
     
     // MARK: - Order Creation Fail
     
-    static let orderCreateFailed = "paypal-native:order-create:failed"
+    static let orderCreationFailed = "paypal-native:order-creation:failed"
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -2,14 +2,14 @@ import Foundation
 
 class BTPayPalNativeCheckoutAnalytics {
     
-    // MARK: - Tokenize Events
+    // MARK: - Conversion Events
     
     static let tokenizeStarted = "paypal-native:tokenize:started"
     static let tokenizeFailed = "paypal-native:tokenize:failed"
     static let tokenizeSucceeded = "paypal-native:tokenize:succeeded"
     static let tokenizeCanceled = "paypal-native:tokenize:canceled"
     
-    // MARK: - Order Creation Fail
+    // MARK: - Additional Detail Events
     
     static let orderCreationFailed = "paypal-native:tokenize:order-creation:failed"
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -8,4 +8,8 @@ class BTPayPalNativeCheckoutAnalytics {
     static let tokenizeFailed = "paypal-native:tokenize:failed"
     static let tokenizeSucceeded = "paypal-native:tokenize:succeeded"
     static let tokenizeCanceled = "paypal-native:tokenize:canceled"
+    
+    // MARK: - Order Creation Fail
+    
+    static let orderCreateFailed = "paypal-native:order-create:failed"
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -11,5 +11,5 @@ class BTPayPalNativeCheckoutAnalytics {
     
     // MARK: - Order Creation Fail
     
-    static let orderCreationFailed = "paypal-native:order-creation:failed"
+    static let orderCreationFailed = "paypal-native:tokenize:order-creation:failed"
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -4,28 +4,9 @@ class BTPayPalNativeCheckoutAnalytics {
     
     // MARK: - Tokenize Events
     
-    // Counted in conversion rates
     static let vaultRequestStarted = "paypal-native:vault-tokenize:started"
     static let checkoutRequestStarted = "paypal-native:checkout-tokenize:started"
     static let tokenizeFailed = "paypal-native:tokenize:failed"
     static let tokenizeSucceeded = "paypal-native:tokenize:succeeded"
     static let tokenizeCanceled = "paypal-native:tokenize:canceled"
-    
-    // Specific tokenize failures
-    static let tokenizeUrlRequestFailed = "paypal-native:tokenize:url-request:failed"
-    static let tokenizeParsingResultFailed = "paypal-native:tokenize:parsing-result:failed"
-    
-    // MARK: - Create Order Events
-    
-    static let createOrderStarted = "paypal-native:create-order:started"
-    static let createOrderFailed = "paypal-native:create-order:failed"
-    static let createOrderSucceeded = "paypal-native:create-order:succeeded"
-    
-    // Specific Create Order Fails
-    static let createOrderPayPalNotEnabledFailed = "paypal-native:create-order:paypal-not-enabled:failed"
-    static let createOrderClientIdNotFoundFailed = "paypal-native:create-order:client-id-not-found:failed"
-    static let createOrderInvalidEnvironmentFailed = "paypal-native:create-order:invalid-environment:failed"
-    static let createOrderHermesUrlRequestFailed = "paypal-native:create-order:hermes-url-request:failed"
-    static let createOrderInvalidPaymentType =
-        "paypal-native:create-order:invalid-payment-type:failed"
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -146,6 +146,7 @@ import PayPalCheckout
               
                 PayPalCheckout.Checkout.start()
             case .failure(let error):
+                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreateFailed)
                 self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -146,7 +146,6 @@ import PayPalCheckout
               
                 PayPalCheckout.Checkout.start()
             case .failure(let error):
-                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -38,7 +38,6 @@ import PayPalCheckout
         _ request: BTPayPalNativeCheckoutRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.checkoutRequestStarted)
         tokenize(request: request, completion: completion)
     }
 
@@ -77,7 +76,6 @@ import PayPalCheckout
         _ request: BTPayPalNativeVaultRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.vaultRequestStarted)
         tokenize(request: request, completion: completion)
     }
 
@@ -109,6 +107,7 @@ import PayPalCheckout
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
         
+        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeStarted)
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
         orderCreationClient.createOrder(with: request) { [weak self] result in
             switch result {

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -106,7 +106,6 @@ import PayPalCheckout
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
-        
         self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeStarted)
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
         orderCreationClient.createOrder(with: request) { [weak self] result in
@@ -146,6 +145,7 @@ import PayPalCheckout
               
                 PayPalCheckout.Checkout.start()
             case .failure(let error):
+                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }
@@ -161,8 +161,10 @@ import PayPalCheckout
         tokenizationClient.tokenize(request: request, returnURL: approval.data.returnURL!.absoluteString) { result in
             switch result {
             case .success(let nonce):
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded)
                 completion(nonce, nil)
             case .failure(let error):
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -146,7 +146,7 @@ import PayPalCheckout
               
                 PayPalCheckout.Checkout.start()
             case .failure(let error):
-                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreateFailed)
+                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -113,7 +113,6 @@ import PayPalCheckout
         orderCreationClient.createOrder(with: request) { [weak self] result in
             switch result {
             case .success(let order):
-                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderStarted)
                 let payPalNativeConfig = PayPalCheckout.CheckoutConfig(
                     clientID: order.payPalClientID,
                     createOrder: { action in
@@ -123,7 +122,6 @@ import PayPalCheckout
                         case .vault:
                             action.set(billingAgreementToken: order.orderID)
                         @unknown default:
-                            self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderInvalidPaymentType)
                             self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                             completion(nil, BTPayPalNativeError.invalidRequest)
                         }
@@ -150,7 +148,6 @@ import PayPalCheckout
                 PayPalCheckout.Checkout.start()
             case .failure(let error):
                 self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
-                self?.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderFailed)
                 completion(nil, error)
             }
         }
@@ -167,7 +164,6 @@ import PayPalCheckout
             case .success(let nonce):
                 completion(nonce, nil)
             case .failure(let error):
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(nil, error)
             }
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -28,19 +28,16 @@ class BTPayPalNativeOrderCreationClient {
     ) {
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             guard let config = configuration, error == nil else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.fetchConfigurationFailed))
                 return
             }
 
             guard let paypalEnabled = config.json?["paypalEnabled"].isTrue, paypalEnabled else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.payPalNotEnabled))
                 return
             }
 
             guard let payPalClientID = config.json?["paypal"]["clientId"].asString() else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.payPalClientIDNotFound))
                 return
             }
@@ -55,7 +52,6 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let environment = payPalEnvironment else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.invalidEnvironment))
                 return
             }
@@ -66,7 +62,6 @@ class BTPayPalNativeOrderCreationClient {
             ) { json, response, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                    self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                     completion(.failure(.orderCreationFailed(underlyingError)))
                     return
                 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -28,16 +28,19 @@ class BTPayPalNativeOrderCreationClient {
     ) {
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             guard let config = configuration, error == nil else {
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.fetchConfigurationFailed))
                 return
             }
 
             guard let paypalEnabled = config.json?["paypalEnabled"].isTrue, paypalEnabled else {
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.payPalNotEnabled))
                 return
             }
 
             guard let payPalClientID = config.json?["paypal"]["clientId"].asString() else {
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.payPalClientIDNotFound))
                 return
             }
@@ -52,6 +55,7 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let environment = payPalEnvironment else {
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                 completion(.failure(.invalidEnvironment))
                 return
             }
@@ -62,6 +66,7 @@ class BTPayPalNativeOrderCreationClient {
             ) { json, response, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
+                    self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
                     completion(.failure(.orderCreationFailed(underlyingError)))
                     return
                 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -33,13 +33,11 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let paypalEnabled = config.json?["paypalEnabled"].isTrue, paypalEnabled else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed)
                 completion(.failure(.payPalNotEnabled))
                 return
             }
 
             guard let payPalClientID = config.json?["paypal"]["clientId"].asString() else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed)
                 completion(.failure(.payPalClientIDNotFound))
                 return
             }
@@ -54,7 +52,6 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let environment = payPalEnvironment else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed)
                 completion(.failure(.invalidEnvironment))
                 return
             }
@@ -65,7 +62,6 @@ class BTPayPalNativeOrderCreationClient {
             ) { json, response, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                    self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed)
                     completion(.failure(.orderCreationFailed(underlyingError)))
                     return
                 }
@@ -76,7 +72,6 @@ class BTPayPalNativeOrderCreationClient {
                     orderID: hermesResponse.orderID
                 )
 
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderSucceeded)
                 completion(.success(order))
             }
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -33,13 +33,13 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let paypalEnabled = config.json?["paypalEnabled"].isTrue, paypalEnabled else {
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.create-order.paypal-not-enabled.failed")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed)
                 completion(.failure(.payPalNotEnabled))
                 return
             }
 
             guard let payPalClientID = config.json?["paypal"]["clientId"].asString() else {
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.create-order.client-id-not-found.failed")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed)
                 completion(.failure(.payPalClientIDNotFound))
                 return
             }
@@ -54,7 +54,7 @@ class BTPayPalNativeOrderCreationClient {
             }
 
             guard let environment = payPalEnvironment else {
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.create-order.invalid-environment.failed")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed)
                 completion(.failure(.invalidEnvironment))
                 return
             }
@@ -65,7 +65,7 @@ class BTPayPalNativeOrderCreationClient {
             ) { json, response, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                    self.apiClient.sendAnalyticsEvent("ios.paypal-native.create-order.hermes-url-request.failed")
+                    self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed)
                     completion(.failure(.orderCreationFailed(underlyingError)))
                     return
                 }
@@ -76,7 +76,7 @@ class BTPayPalNativeOrderCreationClient {
                     orderID: hermesResponse.orderID
                 )
 
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.create-order.succeeded")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.createOrderSucceeded)
                 completion(.success(order))
             }
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -33,18 +33,15 @@ class BTPayPalNativeTokenizationClient {
         ) { body, _, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(.failure(.tokenizationFailed(underlyingError)))
                 return
             }
 
             guard let accountNonce = BTPayPalNativeCheckoutAccountNonce(json: json) else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(.failure(.parsingTokenizationResultFailed))
                 return
             }
             
-            self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded)
             completion(.success(accountNonce))
         }
     }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -33,14 +33,13 @@ class BTPayPalNativeTokenizationClient {
         ) { body, _, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeUrlRequestFailed)
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(.failure(.tokenizationFailed(underlyingError)))
                 return
             }
 
             guard let accountNonce = BTPayPalNativeCheckoutAccountNonce(json: json) else {
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed)
-
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
                 completion(.failure(.parsingTokenizationResultFailed))
                 return
             }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -33,18 +33,19 @@ class BTPayPalNativeTokenizationClient {
         ) { body, _, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeError.invalidJSONResponse
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.tokenize.tokenize-url-request.failed")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeUrlRequestFailed)
                 completion(.failure(.tokenizationFailed(underlyingError)))
                 return
             }
 
             guard let accountNonce = BTPayPalNativeCheckoutAccountNonce(json: json) else {
-                self.apiClient.sendAnalyticsEvent("ios.paypal-native.tokenize.parsing-result.failed")
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed)
+
                 completion(.failure(.parsingTokenizationResultFailed))
                 return
             }
-
-            self.apiClient.sendAnalyticsEvent("ios.paypal-native.tokenize.succeeded")
+            
+            self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded)
             completion(.success(accountNonce))
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -7,6 +7,6 @@ final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.orderCreateFailed, "paypal-native:order-create:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.orderCreationFailed, "paypal-native:order-creation:failed")
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -7,5 +7,6 @@ final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.orderCreateFailed, "paypal-native:order-create:failed")
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -3,8 +3,7 @@ import XCTest
 
 final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
     func test_tokenizeAnalyticEvents_sendExpectedEventNames() {
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.vaultRequestStarted, "paypal-native:vault-tokenize:started")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.checkoutRequestStarted, "paypal-native:checkout-tokenize:started")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeStarted, "paypal-native:tokenize:started")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import BraintreePayPalNativeCheckout
+
+final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
+    func test_tokenizeAnalyticEvents_sendExpectedEventNames() {
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.vaultRequestStarted, "paypal-native:vault-tokenize:started")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.checkoutRequestStarted, "paypal-native:checkout-tokenize:started")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeUrlRequestFailed, "paypal-native:tokenize:url-request:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed, "paypal-native:tokenize:parsing-result:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderStarted, "paypal-native:create-order:started")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderFailed, "paypal-native:create-order:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderSucceeded, "paypal-native:create-order:succeeded")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed, "paypal-native:create-order:paypal-not-enabled:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed, "paypal-native:create-order:client-id-not-found:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed, "paypal-native:create-order:invalid-environment:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed, "paypal-native:create-order:hermes-url-request:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderInvalidPaymentType, "paypal-native:create-order:invalid-payment-type:failed")
+    }
+}

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -8,15 +8,5 @@ final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeUrlRequestFailed, "paypal-native:tokenize:url-request:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed, "paypal-native:tokenize:parsing-result:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderStarted, "paypal-native:create-order:started")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderFailed, "paypal-native:create-order:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderSucceeded, "paypal-native:create-order:succeeded")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed, "paypal-native:create-order:paypal-not-enabled:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed, "paypal-native:create-order:client-id-not-found:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed, "paypal-native:create-order:invalid-environment:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed, "paypal-native:create-order:hermes-url-request:failed")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.createOrderInvalidPaymentType, "paypal-native:create-order:invalid-payment-type:failed")
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import BraintreePayPalNativeCheckout
 
-final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
+final class BTPayPalNativeCheckoutAnalytics_Tests: XCTestCase {
     func test_tokenizeAnalyticEvents_sendExpectedEventNames() {
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeStarted, "paypal-native:tokenize:started")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAnalytics_Tests.swift
@@ -7,6 +7,6 @@ final class BTPayPalNativeCheckoutAnalytics_tests: XCTestCase {
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeFailed, "paypal-native:tokenize:failed")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, "paypal-native:tokenize:succeeded")
         XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, "paypal-native:tokenize:canceled")
-        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.orderCreationFailed, "paypal-native:order-creation:failed")
+        XCTAssertEqual(BTPayPalNativeCheckoutAnalytics.orderCreationFailed, "paypal-native:tokenize:order-creation:failed")
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -25,7 +25,7 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         checkoutClient.tokenize(nativeCheckoutRequest) { nonce, error in
             XCTAssertNil(nonce)
             XCTAssertEqual(error as? BTPayPalNativeError, .payPalClientIDNotFound)
-            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:failed")
+            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
         }
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -25,7 +25,6 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         checkoutClient.tokenize(nativeCheckoutRequest) { nonce, error in
             XCTAssertNil(nonce)
             XCTAssertEqual(error as? BTPayPalNativeError, .payPalClientIDNotFound)
-            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderFailed)
         }
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -25,6 +25,7 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         checkoutClient.tokenize(nativeCheckoutRequest) { nonce, error in
             XCTAssertNil(nonce)
             XCTAssertEqual(error as? BTPayPalNativeError, .payPalClientIDNotFound)
+            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:failed")
         }
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -25,7 +25,7 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         checkoutClient.tokenize(nativeCheckoutRequest) { nonce, error in
             XCTAssertNil(nonce)
             XCTAssertEqual(error as? BTPayPalNativeError, .payPalClientIDNotFound)
-            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.failed")
+            XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderFailed)
         }
     }
 }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
@@ -59,7 +59,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .fetchConfigurationFailed)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:order-creation:failed")
             }
         }
     }
@@ -74,7 +73,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalNotEnabled)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:order-creation:failed")
             }
         }
     }
@@ -92,7 +90,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalClientIDNotFound)
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }
@@ -111,7 +108,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .invalidEnvironment)
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }
@@ -131,7 +127,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .orderCreationFailed(BTPayPalNativeError.invalidJSONResponse))
-                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
@@ -59,6 +59,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .fetchConfigurationFailed)
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:order-creation:failed")
             }
         }
     }
@@ -73,6 +74,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalNotEnabled)
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "paypal-native:tokenize:order-creation:failed")
             }
         }
     }
@@ -90,6 +92,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalClientIDNotFound)
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }
@@ -108,6 +111,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .invalidEnvironment)
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }
@@ -127,6 +131,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .orderCreationFailed(BTPayPalNativeError.invalidJSONResponse))
+                self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.orderCreationFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
@@ -40,7 +40,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
                 XCTAssertEqual(order.payPalClientID, clientId)
                 XCTAssertEqual(order.environment.name, environment)
                 XCTAssertEqual(order.orderID, orderId)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderSucceeded)
 
             case .failure:
                 XCTFail("No error should be thrown")
@@ -74,7 +73,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalNotEnabled)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed)
             }
         }
     }
@@ -92,7 +90,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalClientIDNotFound)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed)
             }
         }
     }
@@ -111,7 +108,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .invalidEnvironment)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed)
             }
         }
     }
@@ -131,7 +127,6 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .orderCreationFailed(BTPayPalNativeError.invalidJSONResponse))
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
@@ -40,7 +40,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
                 XCTAssertEqual(order.payPalClientID, clientId)
                 XCTAssertEqual(order.environment.name, environment)
                 XCTAssertEqual(order.orderID, orderId)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.succeeded")
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderSucceeded)
 
             case .failure:
                 XCTFail("No error should be thrown")
@@ -74,7 +74,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalNotEnabled)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.paypal-not-enabled.failed")
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderPayPalNotEnabledFailed)
             }
         }
     }
@@ -92,7 +92,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .payPalClientIDNotFound)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.client-id-not-found.failed")
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderClientIdNotFoundFailed)
             }
         }
     }
@@ -111,7 +111,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .invalidEnvironment)
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.invalid-environment.failed")
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderInvalidEnvironmentFailed)
             }
         }
     }
@@ -131,7 +131,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
 
             case .failure(let error):
                 XCTAssertEqual(error, .orderCreationFailed(BTPayPalNativeError.invalidJSONResponse))
-                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, "ios.paypal-native.create-order.hermes-url-request.failed")
+                XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.createOrderHermesUrlRequestFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
@@ -73,7 +73,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
                 XCTFail("A response without a nonce string should be a failure")
             case .failure(let error):
                 XCTAssertEqual(error, .parsingTokenizationResultFailed)
-                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed)
+                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
@@ -39,7 +39,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
                 XCTAssertEqual(account.nonce, mockNonce)
                 XCTAssertEqual(account.type, "PayPal")
                 XCTAssertEqual(account.clientMetadataID, mockCorrelationId)
-                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, "ios.paypal-native.tokenize.succeeded")
+                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded)
 
             case .failure:
                 XCTFail("Successful mock did not vend a PayPal account nonce")
@@ -73,7 +73,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
                 XCTFail("A response without a nonce string should be a failure")
             case .failure(let error):
                 XCTAssertEqual(error, .parsingTokenizationResultFailed)
-                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, "ios.paypal-native.tokenize.parsing-result.failed")
+                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeParsingResultFailed)
             }
         }
     }

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
@@ -38,9 +38,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
             case .success(let account):
                 XCTAssertEqual(account.nonce, mockNonce)
                 XCTAssertEqual(account.type, "PayPal")
-                XCTAssertEqual(account.clientMetadataID, mockCorrelationId)
-                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded)
-
+                XCTAssertEqual(account.clientMetadataID, mockCorrelationId)              
             case .failure:
                 XCTFail("Successful mock did not vend a PayPal account nonce")
             }
@@ -73,7 +71,6 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
                 XCTFail("A response without a nonce string should be a failure")
             case .failure(let error):
                 XCTAssertEqual(error, .parsingTokenizationResultFailed)
-                XCTAssertEqual(mockClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
             }
         }
     }


### PR DESCRIPTION
### Summary of changes
These changes are going into the fpti-feature branch which will get merged once we audit all modules and make the switch to the FPTI endpoints
- Update PayPalNativeCheckout analytic events to prepare switch to FPT
- Update tests
- Bucketed all analytic events sent before callbacks into 3 categories of final events: tokenizeFailed, tokenizeSucceeded, tokenizeCanceled.

### Checklist

~- [ ] Added a changelog entry~

### Authors
@KunJeongPark 