### PR TITLE
Add capture lists to `fetchOrReturnRemoteConfiguration()` calls

### DIFF
--- a/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPal - Checkout/BraintreeDemoPayPalCheckoutViewController.swift
@@ -3,6 +3,8 @@ import BraintreePayPal
 
 class BraintreeDemoPayPalCheckoutViewController: BraintreeDemoPaymentButtonBaseViewController {
     
+    private lazy var paypalClient = BTPayPalClient(apiClient: apiClient)
+    
     override func createPaymentButton() -> UIView! {
         lazy var payPalCheckoutButton: UIButton = {
             let payPalCheckoutButton = UIButton(type: .system)
@@ -22,10 +24,9 @@ class BraintreeDemoPayPalCheckoutViewController: BraintreeDemoPaymentButtonBaseV
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
         
-        let client = BTPayPalClient(apiClient: apiClient)
         let request = BTPayPalCheckoutRequest(amount: "4.30")
         
-        client.tokenize(request) { nonce, error in
+        paypalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
             
             guard let nonce = nonce else {

--- a/Demo/Application/Features/PayPal - Pay Later/BraintreeDemoPayPalPayLaterViewController.swift
+++ b/Demo/Application/Features/PayPal - Pay Later/BraintreeDemoPayPalPayLaterViewController.swift
@@ -3,6 +3,8 @@ import BraintreePayPal
 
 class BraintreeDemoPayPalPayLaterViewController: BraintreeDemoPaymentButtonBaseViewController {
     
+    private lazy var paypalClient = BTPayPalClient(apiClient: apiClient)
+    
     override func createPaymentButton() -> UIView! {
         lazy var payPalPayLaterButton: UIButton = {
             let payPalPayLaterButton = UIButton(type: .system)
@@ -22,11 +24,10 @@ class BraintreeDemoPayPalPayLaterViewController: BraintreeDemoPaymentButtonBaseV
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
         
-        let client = BTPayPalClient(apiClient: apiClient)
         let request = BTPayPalCheckoutRequest(amount: "4.30")
         request.offerPayLater = true
         
-        client.tokenize(request) { nonce, error in
+        paypalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
             
             guard let nonce = nonce else {

--- a/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.swift
+++ b/Demo/Application/Features/PayPal - Vault/BraintreeDemoPayPalVaultViewController.swift
@@ -3,6 +3,8 @@ import BraintreePayPal
 
 class BraintreeDemoPayPalVaultViewController: BraintreeDemoPaymentButtonBaseViewController {
     
+    private lazy var paypalClient = BTPayPalClient(apiClient: apiClient)
+    
     override func createPaymentButton() -> UIView! {
         lazy var payPalVaultButton: UIButton = {
             let payPalVaultButton = UIButton(type: .system)
@@ -22,10 +24,9 @@ class BraintreeDemoPayPalVaultViewController: BraintreeDemoPaymentButtonBaseView
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
         
-        let client = BTPayPalClient(apiClient: apiClient)
         let request = BTPayPalVaultRequest()
         
-        client.tokenize(request) { nonce, error in
+        paypalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
             
             guard let nonce = nonce else {

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -30,7 +30,7 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent("ios.amex.rewards-balance.start")
 
         apiClient.get("v1/payment_methods/amex_rewards_balance", parameters: parameters) { [weak self] body, response, error in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if let error = error {
                 self.apiClient.sendAnalyticsEvent("ios.amex.rewards-balance.error")

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -29,7 +29,9 @@ import BraintreeCore
     /// - Parameter completion: A completion block that returns the payment request or an error.
     @objc(makePaymentRequest:)
     public func makePaymentRequest(completion: @escaping (PKPaymentRequest?, Error?) -> Void) {
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+            
             if let error {
                 self.apiClient.sendAnalyticsEvent("ios.apple-pay.error.configuration")
                 self.completionHandler(onMainThreadWithPaymentRequest: nil, error: error, completion: completion)
@@ -77,7 +79,9 @@ import BraintreeCore
     public func tokenize(_ payment: PKPayment, completion: @escaping (BTApplePayCardNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent("ios.apple-pay.start")
 
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+            
             if let error {
                 self.apiClient.sendAnalyticsEvent("ios.apple-pay.error.configuration")
                 completion(nil, error)

--- a/Sources/BraintreeCore/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/BTAnalyticsService.swift
@@ -81,7 +81,9 @@ class BTAnalyticsService: Equatable {
     }
 
     func flush(_ completion: @escaping (Error?) -> Void = { _ in }) {
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+
             guard let configuration, error == nil else {
                 if let error {
                     completion(error)

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -167,7 +167,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
                     self.handleRequestCompletion(data: cachedResponse.data, request: nil, shouldCache: false, response: cachedResponse.response, error: nil, completion: completion)
                 } else {
                     self.session.dataTask(with: request) { [weak self] data, response, error in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         self.handleRequestCompletion(data: data, request: request, shouldCache: true, response: response, error: error, completion: completion)
                     }.resume()
                 }
@@ -188,7 +188,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
             }
 
             self.session.dataTask(with: request) { [weak self] data, response, error in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.handleRequestCompletion(data: data, request: request, shouldCache: false, response: response, error: error, completion: completion)
             }.resume()
         }
@@ -334,7 +334,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
 
         if httpResponse.statusCode >= 400 {
             handleHTTPResponseError(response: httpResponse, data: data) { [weak self] json, error in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.callCompletionAsync(with: completion, body: json, response: httpResponse, error: error)
             }
             return
@@ -344,7 +344,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         let json: BTJSON = data.isEmpty ? BTJSON() : BTJSON(data: data)
         if json.isError {
             handleJSONResponseError(json: json, response: response) { [weak self] error in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.callCompletionAsync(with: completion, body: nil, response: nil, error: error)
             }
             return

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -255,9 +255,7 @@ import BraintreeDataCollector
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
-            guard let self else { return }
-
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
                 completion(nil, error)
                 return

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -255,7 +255,9 @@ import BraintreeDataCollector
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+
             if let error {
                 completion(nil, error)
                 return

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -255,7 +255,9 @@ import BraintreeDataCollector
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+            
             if let error {
                 completion(nil, error)
                 return

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -26,7 +26,9 @@ class BTPayPalNativeOrderCreationClient {
         with request: BTPayPalRequest,
         completion: @escaping (Result<BTPayPalNativeOrder, BTPayPalNativeError>) -> Void
     ) {
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+
             guard let config = configuration, error == nil else {
                 completion(.failure(.fetchConfigurationFailed))
                 return

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -67,7 +67,9 @@ import BraintreeCore
             NSLog("%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)", BTLogLevelDescription.string(for: .critical) ?? "[BraintreeSDK] CRITICAL", bundleIdentifier, returnURLScheme)
         }
 
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
+            guard let self else { return }
+
             if let error {
                 completion(nil, error)
                 return


### PR DESCRIPTION
### Summary of changes

- Add missing [weak capture lists ](https://www.hackingwithswift.com/articles/179/capture-lists-in-swift-whats-the-difference-between-weak-strong-and-unowned-references)when holding references in `BTAPIClient.fetchOrReturnRemoteConfiguration()`'s non-escaping closure to avoid retain cycle.
- Use new Swift 5.8 `guard let self` shorthand.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 