### PR TITLE
Venmo analytics audit

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -25,9 +25,11 @@
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		3B0EF89429B28C0800456973 /* BTAmericanExpressAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */; };
 		3B0EF89629B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */; };
+		3B14BFDF29B647AF0047426A /* BTCardAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */; };
+		3B1C529429D5EB4E00B68A58 /* BTVenmoAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1C529329D5EB4E00B68A58 /* BTVenmoAnalytics.swift */; };
+		3B1C529729D638D400B68A58 /* BTVenmoAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1C529529D637F400B68A58 /* BTVenmoAnalytics_Tests.swift */; };
 		3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */; };
 		3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */; };
-		3B14BFDF29B647AF0047426A /* BTCardAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */; };
 		3DAB5933286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */; };
 		3DAB5937286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */; };
 		3DAB5939286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */; };
@@ -643,9 +645,11 @@
 		2D941D381B59C76A0016EFB4 /* BraintreePayPal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreePayPal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B0EF89329B28C0800456973 /* BTAmericanExpressAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics.swift; sourceTree = "<group>"; };
 		3B0EF89529B28F3800456973 /* BTAmericanExpressAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAmericanExpressAnalytics_Tests.swift; sourceTree = "<group>"; };
+		3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardAnalytics_Tests.swift; sourceTree = "<group>"; };
+		3B1C529329D5EB4E00B68A58 /* BTVenmoAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoAnalytics.swift; sourceTree = "<group>"; };
+		3B1C529529D637F400B68A58 /* BTVenmoAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics.swift; sourceTree = "<group>"; };
 		3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics_Tests.swift; sourceTree = "<group>"; };
-		3B14BFDE29B647AF0047426A /* BTCardAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardAnalytics_Tests.swift; sourceTree = "<group>"; };
 		3DAB5932286B40E2003A7BC5 /* BTPayPalNativeCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		3DAB5936286B9C6E003A7BC5 /* BTPayPalNativeHermesResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeHermesResponse_Tests.swift; sourceTree = "<group>"; };
 		3DAB5938286BA3D0003A7BC5 /* BTPayPalNativeTokenizationClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeTokenizationClient_Tests.swift; sourceTree = "<group>"; };
@@ -1531,6 +1535,7 @@
 			isa = PBXGroup;
 			children = (
 				BEDB820729B675DC00075AF3 /* BTVenmoAccountNonce.swift */,
+				3B1C529329D5EB4E00B68A58 /* BTVenmoAnalytics.swift */,
 				BE0AF6BC29AFDCD100245C2C /* BTVenmoAppSwitchRedirectURL.swift */,
 				BE0AF6B829AFD50500245C2C /* BTVenmoAppSwitchReturnURL.swift */,
 				BEDB820929B7A9E600075AF3 /* BTVenmoClient.swift */,
@@ -1667,6 +1672,7 @@
 			children = (
 				A9589DD924FEA45C00AF4FF7 /* BTConfiguration+Venmo_Tests.swift */,
 				4228D80C2624D8C9001D2564 /* BTVenmoAccountNonce_Tests.swift */,
+				3B1C529529D637F400B68A58 /* BTVenmoAnalytics_Tests.swift */,
 				428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRedirectURL_Tests.swift */,
 				4245D668256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift */,
 				A71F7DE61B6180A3005DA1B0 /* BTVenmoClient_Tests.swift */,
@@ -2912,6 +2918,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BEDB820829B675DC00075AF3 /* BTVenmoAccountNonce.swift in Sources */,
+				3B1C529429D5EB4E00B68A58 /* BTVenmoAnalytics.swift in Sources */,
 				BE0AF6BF29AFF13200245C2C /* BTVenmoRequest.swift in Sources */,
 				BEDB820A29B7A9E600075AF3 /* BTVenmoClient.swift in Sources */,
 				BEDB820829B675DC00075AF3 /* BTVenmoAccountNonce.swift in Sources */,
@@ -3066,6 +3073,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9589DDA24FEA45C00AF4FF7 /* BTConfiguration+Venmo_Tests.swift in Sources */,
+				3B1C529729D638D400B68A58 /* BTVenmoAnalytics_Tests.swift in Sources */,
 				4228D8692624E5C3001D2564 /* BTVenmoRequest_Tests.swift in Sources */,
 				428F48E42624C9B700EC8DB4 /* BTVenmoAppSwitchRedirectURL_Tests.swift in Sources */,
 				4245D669256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift in Sources */,

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -6,12 +6,12 @@ class BTVenmoAnalytics {
     
     static let tokenizeStarted = "venmo:tokenize:started"
     static let tokenizeFailed = "venmo:tokenize:failed"
-    static let tokenizeSucceeded = "venmo:tokenize:succeeded"
+    static let tokenizeSucceeded = "venmo:tokenize:succeeded"    
+    static let appSwitchCanceled = "venmo:tokenize:app-switch:canceled"
     
     // MARK: - Additional Detail Events
     
     static let tokenizeNetworkConnectionLost = "venmo:tokenize:network-connection:failed"
     static let appSwitchSucceeded = "venmo:tokenize:app-switch:succeeded"
     static let appSwitchFailed = "venmo:tokenize:app-switch:failed"
-    static let appSwitchCanceled = "venmo:tokenize:app-switch:canceled"
 }

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -2,14 +2,14 @@ import Foundation
 
 class BTVenmoAnalytics {
     
-    // MARK: - Tokenize Request events
+    // MARK: - Conversion Events
     
     static let tokenizeStarted = "venmo:tokenize:started"
     static let tokenizeFailed = "venmo:tokenize:failed"
     static let tokenizeNetworkConnectionLost = "venmo:tokenize:network-connection:failed"
     static let tokenizeSucceeded = "venmo:tokenize:succeeded"
     
-    // MARK: - App Switch Events
+    // MARK: - Additional Detail Events
     
     static let appSwitchSucceeded = "venmo:tokenize:app-switch:succeeded"
     static let appSwitchFailed = "venmo:tokenize:app-switch:failed"

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+class BTVenmoAnalytics {
+    
+    // MARK: - Tokenize Request events
+    
+    static let tokenizeStarted = "venmo:tokenize:started"
+    static let tokenizeFailed = "venmo:tokenize:failed"
+    static let tokenizeNetworkConnectionLost = "venmo:tokenize:network-connection:failed"
+    static let tokenizeSucceeded = "venmo:tokenize:succeeded"
+    
+    // MARK: - App Switch Events
+    
+    static let appSwitchSucceeded = "venmo:tokenize:app-switch:succeeded"
+    static let appSwitchFailed = "venmo:tokenize:app-switch:failed"
+    static let appSwitchCanceled = "venmo:tokenize:app-switch:canceled"
+}

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -6,11 +6,11 @@ class BTVenmoAnalytics {
     
     static let tokenizeStarted = "venmo:tokenize:started"
     static let tokenizeFailed = "venmo:tokenize:failed"
-    static let tokenizeNetworkConnectionLost = "venmo:tokenize:network-connection:failed"
     static let tokenizeSucceeded = "venmo:tokenize:succeeded"
     
     // MARK: - Additional Detail Events
     
+    static let tokenizeNetworkConnectionLost = "venmo:tokenize:network-connection:failed"
     static let appSwitchSucceeded = "venmo:tokenize:app-switch:succeeded"
     static let appSwitchFailed = "venmo:tokenize:app-switch:failed"
     static let appSwitchCanceled = "venmo:tokenize:app-switch:canceled"

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -197,8 +197,7 @@ import BraintreeCore
     // MARK: - App Switch Methods
 
     func handleOpen(_ url: URL) {
-        guard let returnURL = BTVenmoAppSwitchReturnURL(url: url) else {
-          
+        guard let returnURL = BTVenmoAppSwitchReturnURL(url: url) else {          
             apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeFailed)
             appSwitchCompletion(nil, BTVenmoError.invalidReturnURL(""))
             return

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAnalytics_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAnalytics_Tests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import BraintreeVenmo
+
+final class BTVenmoAnalytics_Tests: XCTestCase {
+    func test_tokenizeAnalyticsEvents_sendsExpectedEventNames() {
+        XCTAssertEqual(BTVenmoAnalytics.tokenizeStarted, "venmo:tokenize:started")
+        XCTAssertEqual(BTVenmoAnalytics.tokenizeFailed, "venmo:tokenize:failed")
+        XCTAssertEqual(BTVenmoAnalytics.tokenizeNetworkConnectionLost, "venmo:tokenize:network-connection:failed")
+        XCTAssertEqual(BTVenmoAnalytics.tokenizeSucceeded, "venmo:tokenize:succeeded")
+        XCTAssertEqual(BTVenmoAnalytics.appSwitchSucceeded, "venmo:tokenize:app-switch:succeeded")
+        XCTAssertEqual(BTVenmoAnalytics.appSwitchFailed, "venmo:tokenize:app-switch:failed")
+        XCTAssertEqual(BTVenmoAnalytics.appSwitchCanceled, "venmo:tokenize:app-switch:canceled")
+    }
+}

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -464,7 +464,7 @@ class BTVenmoClient_Tests: XCTestCase {
         BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
         waitForExpectations(timeout: 2)
 
-        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.vault.success")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)
     }
 
     func testTokenizeVenmoAccount_vaultTrue_sendsFailureAnalyticsEvent() {
@@ -489,7 +489,7 @@ class BTVenmoClient_Tests: XCTestCase {
         BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
         waitForExpectations(timeout: 2)
 
-        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.vault.failure")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeFailed)
     }
 
     func testTokenizeVenmoAccount_whenAppSwitchCanceled_callsBackWithNoError() {
@@ -566,7 +566,7 @@ class BTVenmoClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: 2)
         
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("ios.pay-with-venmo.network-connection.failure"))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTVenmoAnalytics.tokenizeNetworkConnectionLost))
     }
 
     func testTokenize_whenConfigurationIsInvalid_returnsError() async {
@@ -656,7 +656,7 @@ class BTVenmoClient_Tests: XCTestCase {
         BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=lmnop-venmo-nonce&username=venmotim")!)
         waitForExpectations(timeout: 2)
 
-        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.appswitch.handle.success")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)
     }
 
     // Note: testing of handleReturnURL is done implicitly while testing authorizeAccountWithCompletion


### PR DESCRIPTION
Summary of changes
These changes are going into the fpti-feature branch. Which will get merged in once we audit all modules and make the switch to the FPTI endpoints

-Update Venmo analytics events to prepare for switch to FPTI
-Update tests
-Bucketed all analytic events sent before callbacks into 3 categories counted in conversion rates:
tokenizeFailed, tokenizeSucceeded and appSwitchCanceled

Checklist
~[ ] Added a changelog entry~
Authors
@KunJeongPark @sshropshire 
