### PR TITLE
Removing weak self on native order creation client

### DIFF
--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -26,8 +26,7 @@ class BTPayPalNativeOrderCreationClient {
         with request: BTPayPalRequest,
         completion: @escaping (Result<BTPayPalNativeOrder, BTPayPalNativeError>) -> Void
     ) {
-        apiClient.fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
-            guard let self else { return }
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
 
             guard let config = configuration, error == nil else {
                 completion(.failure(.fetchConfigurationFailed))


### PR DESCRIPTION
### Summary of changes

- The native checkout order creation client was being weakly retained by the `fetchOrReturnRemoteConfiguration` request. This causes the order creation client to be deallocated, as it was created locally up the chain. The solution here is to strongly capture `self` in the completion of `fetchOrReturnRemoteConfiguration` - this does not risk a retain cycle as the closure is not being retained by the client

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jonathajones 
