### PR TITLE
Updating PayPalCheckout to 0.112.0

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '0.110.0'
+    s.dependency "PayPalCheckout", '0.112.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7492,7 +7492,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 0.112.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## Unreleased
+* BraintreePayPalNativeCheckout
+  * Update NativeCheckout version from 0.110.0 to 0.112.0
+
 ## 5.21.0 (2023-03-14)
 * Add missed deprecation warnings to `BTCardRequest` Union Pay properties
 * Update Cardinal SDK to version 2.2.5-6

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-6
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.0-no-bitcode-fixed
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.110.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.112.0

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -1248,7 +1248,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 0.112.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.swift
+++ b/Package.swift
@@ -106,8 +106,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PayPalCheckout",
-            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.110.0/PayPalCheckout.xcframework.zip",
-            checksum: "e9895c202b090a7bde5c47685e96aef68b6f334e3f3798a79dd49b32c81fe130"
+            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.112.0/PayPalCheckout.xcframework.zip",
+            checksum: "8d53d2d42f80e2980ff570f0fa6a2986f56ab2ed13d7834ab1c362db21ca8c88"
         ),
         .target(
             name: "BraintreeSEPADirectDebit",


### PR DESCRIPTION
### Summary of changes

- This PR bumps the version of PayPalCheckout from 0.110.0 to 0.112.0. This version would be the version we use for the GA within Braintree.
- Updates include:
  - The AddCard flow includes address inputs
  - Support for adding a card natively if the user has no available FI
  - Increments minimum xcode version to 14.1
  - Increments Swift version to 5.7.1
  - Increments minimum supported iOS version to 13
  - Layout fixes
  - Misc. bugfixes

I will add more detailed notes to the changelog if we need - the only merchant / user facing change included here would be the add card changes.

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jonathajones 
