### PR TITLE
Drop Xcode 13 & require Xcode 14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 14.0)
+    name: CocoaPods (Xcode 14)
     runs-on: macOS-latest
     steps:
       - name: Check out repository
@@ -13,14 +13,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 14.0
+      - name: Use Xcode 14
         run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
-    name: Carthage (Xcode 14.0)
+    name: Carthage (Xcode 14)
     runs-on: macOS-latest
     steps:
       - name: Check out repository
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 14.0
+      - name: Use Xcode 14
         run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Remove SPMTest
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   cocoapods:
     name: CocoaPods (Xcode 14.0)
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -14,14 +14,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
     name: Carthage (Xcode 14.0)
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -48,7 +48,7 @@ jobs:
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
     name: SPM (Xcode 14)
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -56,70 +56,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
-  cocoapods_xcode_13:
-    name: CocoaPods (Xcode 13)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-           ref: ${{ github.event.pull_request.head.ref }}
-           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
-      - name: Install CocoaPod dependencies
-        run: pod install
-      - name: Run pod lib lint 
-        run: pod lib lint
-  carthage_xcode_13:
-    name: Carthage (Xcode 13)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
-      - name: Remove SPMTest
-        run: |
-          git checkout $GITHUB_HEAD_REF
-          rm -rf SampleApps/SPMTest
-          rm -rf /Users/runner/Library/Developer/Xcode/DerivedData
-          git add SampleApps/SPMTest
-          git commit -m 'Remove SPMTest app to avoid Carthage timeout'
-      - name: Use current branch
-        run: echo 'git "file://'$PWD'" "'$GITHUB_HEAD_REF'"' > SampleApps/CarthageTest/Cartfile
-      - name: Run carthage build
-        run: carthage build --no-skip-current --use-xcframeworks
-      - name: Run carthage update
-        run: cd SampleApps/CarthageTest && carthage update --use-xcframeworks
-      - name: Build CarthageTest
-        run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
-      - name: Run carthage build without --use-xcframeworks
-        run: |
-          ./carthage.sh build --no-skip-current
-          ./carthage.sh archive "BraintreeAmericanExpress" "BraintreeApplePay" "BraintreeCard" "BraintreeCore" "BraintreeDataCollector" "BraintreePaymentFlow" "BraintreePayPal" "BraintreeSEPADirectDebit" "BraintreeThreeDSecure" "BraintreeUnionPay" "BraintreeVenmo" "PayPalDataCollector" "BraintreePayPalNativeCheckout" --output Braintree.framework.zip
-  spm_xcode_13:
-    name: SPM (Xcode 13)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-11
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)
@@ -114,13 +114,13 @@ jobs:
 
   docs:
     name: Publish Reference Docs
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
 
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: Publish reference docs
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
@@ -23,7 +23,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -31,14 +31,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 11,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Require Xcode 14.1 (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
+
 ## 5.21.0 (2023-03-14)
 * Add missed deprecation warnings to `BTCardRequest` Union Pay properties
 * Update Cardinal SDK to version 2.2.5-6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to Braintree's iOS SDK. This library will help you accept card and alter
 
 v5 is the latest major version of Braintree iOS. To update from v4, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/master/V5_MIGRATION.md).
 
-**The Braintree iOS SDK permits a deployment target of iOS 12.0 or higher**. It requires Xcode 12+ and Swift 5.1+.
+**The Braintree iOS SDK permits a deployment target of iOS 12.0 or higher**. It requires Xcode 14.1+ and Swift 5.7.1+.
 
 ## Supported Payment Methods
 


### PR DESCRIPTION
### Summary of changes

- On April 25, 2023 Apple is mandating that apps submitted to the App Store must be built with Xcode 14.1 or higher (Swift 5.7.1+)
- [See news article](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store)

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 