### PR TITLE
Remove unused `BTClientMetadataIntegration` types

### DIFF
--- a/Sources/BraintreeCore/BTClientMetadataIntegration.swift
+++ b/Sources/BraintreeCore/BTClientMetadataIntegration.swift
@@ -6,23 +6,13 @@
     /// Drop-in
     case dropIn
     
-    /// Drop-in 2
-    case dropIn2
-    
-    /// Unknown Integration
-    case unknown
-    
     /// String value representing the integration.
     var stringValue: String {
         switch self {
-        case .unknown:
-            return "unknown"
-        case .dropIn:
-            return "dropin"
-        case .dropIn2:
-            return "dropin2"
         case .custom:
             return "custom"
+        case .dropIn:
+            return "dropin"
         }
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTClientMetadata_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTClientMetadata_Tests.swift
@@ -21,9 +21,7 @@ final class BTClientMetadata_Tests: XCTestCase {
 
     func testIntegration_returnsExpectedString_forAllIntegrations() {
         XCTAssertEqual(BTClientMetadataIntegration.dropIn.stringValue, "dropin")
-        XCTAssertEqual(BTClientMetadataIntegration.dropIn2.stringValue, "dropin2")
         XCTAssertEqual(BTClientMetadataIntegration.custom.stringValue, "custom")
-        XCTAssertEqual(BTClientMetadataIntegration.unknown.stringValue, "unknown")
     }
 
     func testSessionID_returns32CharacterUUIDString() {


### PR DESCRIPTION
### Summary of changes

- Remove `BTClientMetadataIntegration.dropin2`
   - For V6, we will just use `dropin` (it's less confusing)
- Remove `BTClientMetadataIntegration.unknown`
    - This is never sent. Verified in SPLUNK.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
