### PR TITLE
Update Docs Portion of GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 14
+      - name: Use Xcode 14.1
         run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: Check for unreleased section in changelog
@@ -111,17 +111,6 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push Braintree.podspec
-
-  docs:
-    name: Publish Reference Docs
-    runs-on: macOS-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-
-      - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
-
       - name: Publish reference docs
         run: |
           gem install jazzy


### PR DESCRIPTION
### Summary of changes

The docs job has been failing for a while and we've needed to manually complete this step each time we do a release. It seems like it was always attempting to pull the release tag before it was generated vs running the job after the other job completed. Now that we require Xcode 14.1 in our `release.yml` we can remove this as a separate job as it was only done because SourceKitten required a higher Xcode + Swift version.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
