### PR TITLE
Update Test Apps to Add Basic Client Creation

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		BE9BD7C52888467700022983 /* BraintreeDataCollector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A76D7C001BB1CAB00000FA6A /* BraintreeDataCollector.framework */; };
 		BE9BD7EB28884EA100022983 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BE9BD7EF2888517300022983 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
+		BE9D76BC2A03F92F00DF9023 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BE9D76BB2A03F92F00DF9023 /* PayPalCheckout */; };
 		BE9EC0982899CF040022EC63 /* BTAPIPinnedCertificates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9EC0972899CF040022EC63 /* BTAPIPinnedCertificates.swift */; };
 		BE9FB82B2898324C00D6FE2F /* BTPaymentMethodNonce.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FB82A2898324C00D6FE2F /* BTPaymentMethodNonce.swift */; };
 		BE9FB82D28984ADE00D6FE2F /* BTPaymentMethodNonceParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FB82C28984ADE00D6FE2F /* BTPaymentMethodNonceParser.swift */; };
@@ -900,6 +901,7 @@
 			files = (
 				BEBC6E4B29258FD4004E25A0 /* BraintreeCore.framework in Frameworks */,
 				3DF4B4CD285B77A80072DC60 /* BraintreePayPal.framework in Frameworks */,
+				BE9D76BC2A03F92F00DF9023 /* PayPalCheckout in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1817,6 +1819,7 @@
 			);
 			name = BraintreePayPalNativeCheckout;
 			packageProductDependencies = (
+				BE9D76BB2A03F92F00DF9023 /* PayPalCheckout */,
 			);
 			productName = BraintreeCard;
 			productReference = 9CE51784282D51DD0013C740 /* BraintreePayPalNativeCheckout.framework */;
@@ -6061,6 +6064,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		BE9D76BB2A03F92F00DF9023 /* PayPalCheckout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BEE2E4B52900436600C03FDD /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;
+			productName = PayPalCheckout;
+		};
 		BEE2E4B8290043A200C03FDD /* PayPalCheckout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BEE2E4B52900436600C03FDD /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -247,7 +247,6 @@
 		BEDB820829B675DC00075AF3 /* BTVenmoAccountNonce.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB820729B675DC00075AF3 /* BTVenmoAccountNonce.swift */; };
 		BEDB820A29B7A9E600075AF3 /* BTVenmoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB820929B7A9E600075AF3 /* BTVenmoClient.swift */; };
 		BEE2E4A728FDB64400C03FDD /* BTAnalyticsService_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE2E4A628FDB64400C03FDD /* BTAnalyticsService_Tests.swift */; };
-		BEE2E4B72900436600C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B62900436600C03FDD /* PayPalCheckout */; };
 		BEE2E4B9290043A200C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B8290043A200C03FDD /* PayPalCheckout */; };
 		BEE2E4E6290080BD00C03FDD /* BTAnalyticsServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE2E4E5290080BD00C03FDD /* BTAnalyticsServiceError.swift */; };
 		BEEBC3C029D5DD16009C7F77 /* BTThreeDSecureV2UICustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECA56C929C3F0A80098EC3C /* BTThreeDSecureV2UICustomization.swift */; };
@@ -901,7 +900,6 @@
 			files = (
 				BEBC6E4B29258FD4004E25A0 /* BraintreeCore.framework in Frameworks */,
 				3DF4B4CD285B77A80072DC60 /* BraintreePayPal.framework in Frameworks */,
-				BEE2E4B72900436600C03FDD /* PayPalCheckout in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1819,7 +1817,6 @@
 			);
 			name = BraintreePayPalNativeCheckout;
 			packageProductDependencies = (
-				BEE2E4B62900436600C03FDD /* PayPalCheckout */,
 			);
 			productName = BraintreeCard;
 			productReference = 9CE51784282D51DD0013C740 /* BraintreePayPalNativeCheckout.framework */;
@@ -6064,11 +6061,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		BEE2E4B62900436600C03FDD /* PayPalCheckout */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BEE2E4B52900436600C03FDD /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;
-			productName = PayPalCheckout;
-		};
 		BEE2E4B8290043A200C03FDD /* PayPalCheckout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BEE2E4B52900436600C03FDD /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */; };
 		BE777ABD27D9122D00487D23 /* BraintreeSEPADirectDebit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */; };
 		BE9D76AA2A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */; };
-		BE9D76AE2A02FE7700DF9023 /* PayPalCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,7 +49,6 @@
 		BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../../Frameworks/XCFrameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = ../../Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
 		BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = ../../Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
-		BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = ../../Carthage/Build/PayPalCheckout.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +68,6 @@
 				429925BB266189020085F77D /* BraintreeCard.xcframework in Frameworks */,
 				429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */,
 				429925AD266189010085F77D /* BraintreeDataCollector.xcframework in Frameworks */,
-				BE9D76AE2A02FE7700DF9023 /* PayPalCheckout.xcframework in Frameworks */,
 				429925AB266189010085F77D /* BraintreeAmericanExpress.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		A74D4AFF1BFBB3FB00BF36CD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74D4AFD1BFBB3FB00BF36CD /* LaunchScreen.storyboard */; };
 		BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */; };
 		BE777ABD27D9122D00487D23 /* BraintreeSEPADirectDebit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */; };
+		BE9D76AA2A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */; };
+		BE9D76AE2A02FE7700DF9023 /* PayPalCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +49,8 @@
 		A74D4B001BFBB3FB00BF36CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../../Frameworks/XCFrameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = ../../Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
+		BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = ../../Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
+		BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = ../../../../../Downloads/PayPalCheckout.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +60,7 @@
 			files = (
 				429925B3266189020085F77D /* BraintreePaymentFlow.xcframework in Frameworks */,
 				BE777ABD27D9122D00487D23 /* BraintreeSEPADirectDebit.xcframework in Frameworks */,
+				BE9D76AA2A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */,
 				BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */,
 				429925B5266189020085F77D /* BraintreeCore.xcframework in Frameworks */,
 				429925B1266189020085F77D /* PPRiskMagnes.xcframework in Frameworks */,
@@ -65,6 +70,7 @@
 				429925BB266189020085F77D /* BraintreeCard.xcframework in Frameworks */,
 				429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */,
 				429925AD266189010085F77D /* BraintreeDataCollector.xcframework in Frameworks */,
+				BE9D76AE2A02FE7700DF9023 /* PayPalCheckout.xcframework in Frameworks */,
 				429925AB266189010085F77D /* BraintreeAmericanExpress.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -75,6 +81,8 @@
 		03BFA5C81FB2F0BB0003ABCE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */,
+				BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */,
 				BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */,
 				BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */,
 				4299259D266189010085F77D /* BraintreeAmericanExpress.xcframework */,

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../../Frameworks/XCFrameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = ../../Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
 		BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = ../../Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
-		BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = ../../../../../Downloads/PayPalCheckout.xcframework; sourceTree = "<group>"; };
+		BE9D76AD2A02FE7700DF9023 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = ../../Carthage/Build/PayPalCheckout.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -8,6 +8,8 @@ import BraintreePaymentFlow
 import BraintreePayPal
 import BraintreeThreeDSecure
 import BraintreeVenmo
+import PayPalCheckout
+import BraintreePayPalNativeCheckout
 import BraintreeSEPADirectDebit
 
 class ViewController: UIViewController {

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -8,7 +8,6 @@ import BraintreePaymentFlow
 import BraintreePayPal
 import BraintreeThreeDSecure
 import BraintreeVenmo
-import PayPalCheckout
 import BraintreePayPalNativeCheckout
 import BraintreeSEPADirectDebit
 

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -13,14 +13,18 @@ import BraintreeSEPADirectDebit
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
-        super.viewDidLoad()
+        let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
+
+        let amexClient = BTAmericanExpressClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let cardClient = BTCardClient(apiClient: apiClient)
+        let dataCollector = BTDataCollector(apiClient: apiClient)
+        let paymentFlowClient = BTPaymentFlowClient(apiClient: apiClient)
+        let payPalClient = BTPayPalClient(apiClient: apiClient)
+        let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
+        let venmoClient = BTVenmoClient(apiClient: apiClient)
+        let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
+        let sepaDirectDebitClient = BTSEPADirectDebitClient(apiClient: apiClient)
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
-
 }
 

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -13,4 +13,18 @@ import BraintreeSEPADirectDebit
 
 class ViewController: UIViewController {
 
+    override func viewDidLoad() {
+        let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
+
+        let amexClient = BTAmericanExpressClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let cardClient = BTCardClient(apiClient: apiClient)
+        let dataCollector = BTDataCollector(apiClient: apiClient)
+        let paymentFlowClient = BTPaymentFlowClient(apiClient: apiClient)
+        let payPalClient = BTPayPalClient(apiClient: apiClient)
+        let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
+        let venmoClient = BTVenmoClient(apiClient: apiClient)
+        let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
+        let sepaDirectDebitClient = BTSEPADirectDebitClient(apiClient: apiClient)
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Based on the [SPM bug](https://paypal.sharepoint.com/:w:/r/sites/BTSDK/_layouts/15/Doc.aspx?sourcedoc=%7B006D11FE-7148-456F-B191-B9E77CC67A71%7D&file=iOS%20v6%20Beta%20SPM%20Bug.docx&action=default&mobileredirect=true) we found earlier in the conversion process, we realized that we have no way to "smoke test" these integrations as our Sample Apps don't do much
    - This adds the basic structure of creating all of our clients (which would have caught the bug)
    - This also acts as a bit more robust sample app vs what we had previously with no implementation
    - In the future we can decide if it makes sense to add more to these sample apps

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 