### PR TITLE
Resolve Xcode 14.3 Test Warnings

### DIFF
--- a/Sources/BraintreeCard/BTCard.swift
+++ b/Sources/BraintreeCard/BTCard.swift
@@ -244,7 +244,7 @@ import Foundation
         var variables: [String: Any] = ["input": inputDictionary]
 
         if authenticationInsightRequested {
-            variables["authenticationInsightInput"] = merchantAccountID != nil ? ["merchantAccountId": merchantAccountID] : [:] as [String?: Any]
+            variables["authenticationInsightInput"] = merchantAccountID != nil ? ["merchantAccountId": merchantAccountID] : [:] as [String?: Any]?
         }
 
         return [

--- a/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
@@ -5,16 +5,18 @@ import XCTest
 class BTApplePayCardNonce_Tests: XCTestCase {
 
     func testInitWithJSON_populatesAllProperties() {
-        let applePayCard = BTJSON(value: [
-            "consumed": false,
-            "binData": [
-                "commercial": "yes"
-            ],
-            "details": [
-                "cardType": "fake-card-type"
-            ],
-            "nonce": "a-nonce"
-        ])
+        let applePayCard = BTJSON(
+            value: [
+                "consumed": false,
+                "binData": [
+                    "commercial": "yes"
+                ],
+                "details": [
+                    "cardType": "fake-card-type"
+                ],
+                "nonce": "a-nonce"
+            ] as [String: Any]
+        )
 
         let applePayNonce = BTApplePayCardNonce(json: applePayCard)
         XCTAssertEqual(applePayNonce?.nonce, "a-nonce")
@@ -23,13 +25,15 @@ class BTApplePayCardNonce_Tests: XCTestCase {
     }
 
     func testInitWithJSON_setsDefaultProperties() {
-        let applePayCard = BTJSON(value: [
-            "consumed": false,
-            "binData": [
-                "commercial": "yes"
-            ],
-            "nonce": "a-nonce"
-        ])
+        let applePayCard = BTJSON(
+            value: [
+                "consumed": false,
+                "binData": [
+                    "commercial": "yes"
+                ],
+                "nonce": "a-nonce"
+            ] as [String: Any]
+        )
 
         let applePayNonce = BTApplePayCardNonce(json: applePayCard)
         XCTAssertEqual(applePayNonce?.type, "ApplePayCard")
@@ -45,9 +49,9 @@ class BTApplePayCardNonce_Tests: XCTestCase {
                     ],
                     "isLocked": false,
                     "nonce": "a-nonce",
-                    "securityQuestions": [],
+                    "securityQuestions": [] as [Any],
                     "type": "ApplePayCard",
-                ]
+                ] as [String: Any]
             )
         )
 

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -34,7 +34,7 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testPaymentRequest_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
-        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
+        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any?])
         let applePayClient = BTApplePayClient(apiClient: mockClient)
 
         let expectation = self.expectation(description: "Callback invoked")

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -34,7 +34,7 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testPaymentRequest_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
-        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
         let applePayClient = BTApplePayClient(apiClient: mockClient)
 
         let expectation = self.expectation(description: "Callback invoked")
@@ -57,7 +57,7 @@ class BTApplePay_Tests: XCTestCase {
                 "currencyCode": "BTB",
                 "merchantIdentifier": "merchant.com.braintree-unit-tests",
                 "supportedNetworks": ["visa", "mastercard", "amex"]
-            ]
+            ] as [String: Any]
         ])
         let applePayClient = BTApplePayClient(apiClient: mockClient)
 
@@ -129,7 +129,7 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
-        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
         let expectation = self.expectation(description: "Unsuccessful tokenization")
 
         let client = BTApplePayClient(apiClient: mockClient)
@@ -208,25 +208,27 @@ class BTApplePay_Tests: XCTestCase {
                 "status" : "production"
             ]
         ])
-        mockClient.cannedResponseBody = BTJSON(value: [
-            "applePayCards": [
-                [
-                    "nonce" : "an-apple-pay-nonce",
-                    "default": true,
-                    "binData": [
-                        "prepaid": "Yes",
-                        "healthcare": "Yes",
-                        "debit": "No",
-                        "durbinRegulated": "No",
-                        "commercial": "Yes",
-                        "payroll": "No",
-                        "issuingBank": "US",
-                        "countryOfIssuance": "Something",
-                        "productId": "123"
+        mockClient.cannedResponseBody = BTJSON(
+            value: [
+                "applePayCards": [
+                    [
+                        "nonce" : "an-apple-pay-nonce",
+                        "default": true,
+                        "binData": [
+                            "prepaid": "Yes",
+                            "healthcare": "Yes",
+                            "debit": "No",
+                            "durbinRegulated": "No",
+                            "commercial": "Yes",
+                            "payroll": "No",
+                            "issuingBank": "US",
+                            "countryOfIssuance": "Something",
+                            "productId": "123"
+                        ]
                     ]
-                ]
+                ] as [[String: Any]]
             ]
-        ])
+        )
         let expectation = self.expectation(description: "successful tokenization")
 
         let client = BTApplePayClient(apiClient: mockClient)

--- a/UnitTests/BraintreeCardTests/BTAuthenticationInsight_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTAuthenticationInsight_Tests.swift
@@ -13,9 +13,13 @@ class BTAuthenticationInsight_Tests: XCTestCase {
     }
     
     func testInitWithJSON_whenRegulationEnvironmentIsNil_setsRegulationEnvironmentToNil() {
-        let authInsight = BTAuthenticationInsight(json: BTJSON(value: [
-            "regulationEnvironment": nil
-            ]))
+        let authInsight = BTAuthenticationInsight(
+            json: BTJSON(
+                value: [
+                    "regulationEnvironment": nil
+                ] as [String: Any?]
+            )
+        )
         
         XCTAssertNil(authInsight.regulationEnvironment)
     }
@@ -45,15 +49,19 @@ class BTAuthenticationInsight_Tests: XCTestCase {
     }
     
     func testInitWithJSON_whenCustomerAuthenticationRegulationEnvironmentIsNil_setsRegulationEnvironmentToNil() {
-        let authInsight = BTAuthenticationInsight(json: BTJSON(value: [
-            "customerAuthenticationRegulationEnvironment": nil
-            ]))
+        let authInsight = BTAuthenticationInsight(
+            json: BTJSON(
+                value: [
+                    "customerAuthenticationRegulationEnvironment": nil
+                ] as [String: Any?]
+            )
+        )
         
         XCTAssertNil(authInsight.regulationEnvironment)
     }
     
     func testInitWithJSON_whenRegulationEnvironmentKeyIsNotPresent_setsRegulationEnvironmentToNil() {
-        let authInsight = BTAuthenticationInsight(json: BTJSON(value: [:]))
+        let authInsight = BTAuthenticationInsight(json: BTJSON(value: [:] as [String?: Any]))
         
         XCTAssertNil(authInsight.regulationEnvironment)
     }

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -11,7 +11,7 @@ class BTCardClient_Tests: XCTestCase {
         let expectation = self.expectation(description: "Tokenize Card")
 
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
 
         let cardClient = BTCardClient(apiClient: mockAPIClient)
 
@@ -54,7 +54,7 @@ class BTCardClient_Tests: XCTestCase {
         let expectation = self.expectation(description: "Tokenize Card")
 
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         
         let cardClient = BTCardClient(apiClient: mockAPIClient)
 
@@ -93,12 +93,12 @@ class BTCardClient_Tests: XCTestCase {
                     "details": [
                         "lastTwo" : "11",
                         "cardType": "visa"]
-                ]
+                ] as [String: Any]
             ]
         ]
 
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         mockAPIClient.cannedResponseBody = BTJSON(value: mockTokenizeResponse)
 
         let cardClient = BTCardClient(apiClient: mockAPIClient)
@@ -129,7 +129,7 @@ class BTCardClient_Tests: XCTestCase {
         let mockError = NSError(domain: "TestErrorDomain", code: 1, userInfo: nil)
 
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         mockAPIClient.cannedResponseError = mockError
 
         let cardClient = BTCardClient(apiClient: mockAPIClient)
@@ -150,24 +150,26 @@ class BTCardClient_Tests: XCTestCase {
 
     func testTokenization_whenTokenizationEndpointReturns422_callCompletionWithValidationError() {
         let stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
-        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
-        let stubJSONResponse = BTJSON(value: [
-            "error" : [
-                "message" : "Credit card is invalid"
-            ],
-            "fieldErrors" : [
-                [
-                    "field" : "creditCard",
-                    "fieldErrors" : [
-                        [
-                            "field" : "number",
-                            "message" : "Credit card number must be 12-19 digits",
-                            "code" : "81716"
+        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
+        let stubJSONResponse = BTJSON(
+            value: [
+                "error" : [
+                    "message" : "Credit card is invalid"
+                ],
+                "fieldErrors" : [
+                    [
+                        "field" : "creditCard",
+                        "fieldErrors" : [
+                            [
+                                "field" : "number",
+                                "message" : "Credit card number must be 12-19 digits",
+                                "code" : "81716"
+                            ]
                         ]
-                    ]
+                    ] as [String: Any]
                 ]
-            ]
-        ])
+            ] as [String: Any]
+        )
         let stubError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: [
             BTCoreConstants.urlResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
             BTCoreConstants.jsonResponseBodyKey: stubJSONResponse
@@ -204,24 +206,26 @@ class BTCardClient_Tests: XCTestCase {
     
     func testTokenization_whenTokenizationEndpointReturns422AndCode81724_callCompletionWithValidationError() {
         let stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
-        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
-        let stubJSONResponse = BTJSON(value: [
-            "error" : [
-                "message" : "Credit card is invalid"
-            ],
-            "fieldErrors" : [
-                [
-                    "field" : "creditCard",
-                    "fieldErrors" : [
-                        [
-                            "field" : "number",
-                            "message" : "Duplicate card exists in the vault.",
-                            "code" : "81724"
+        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
+        let stubJSONResponse = BTJSON(
+            value: [
+                "error" : [
+                    "message" : "Credit card is invalid"
+                ],
+                "fieldErrors" : [
+                    [
+                        "field" : "creditCard",
+                        "fieldErrors" : [
+                            [
+                                "field" : "number",
+                                "message" : "Duplicate card exists in the vault.",
+                                "code" : "81724"
+                            ]
                         ]
-                    ]
+                    ] as [String: Any]
                 ]
-            ]
-        ])
+            ] as [String: Any]
+        )
         let stubError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: [
             BTCoreConstants.urlResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
             BTCoreConstants.jsonResponseBodyKey: stubJSONResponse
@@ -263,40 +267,42 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
-        let stubJSONResponse = BTJSON(value: [
-            "errors": [
-                [
-                    "message": "Duplicate card exists in the vault",
-                    "locations": [
-                        [
-                            "line": 2,
-                            "column": 3
-                        ]
-                    ],
-                    "path": [
-                        "tokenizeCreditCard"
-                    ],
-                    "extensions": [
-                        "errorClass": "VALIDATION",
-                        "errorType": "user_error",
-                        "inputPath": [
-                            "input",
-                            "creditCard",
-                            "number"
+        let stubJSONResponse = BTJSON(
+            value: [
+                "errors": [
+                    [
+                        "message": "Duplicate card exists in the vault",
+                        "locations": [
+                            [
+                                "line": 2,
+                                "column": 3
+                            ]
                         ],
-                        "legacyCode": "81724"
-                    ]
+                        "path": [
+                            "tokenizeCreditCard"
+                        ],
+                        "extensions": [
+                            "errorClass": "VALIDATION",
+                            "errorType": "user_error",
+                            "inputPath": [
+                                "input",
+                                "creditCard",
+                                "number"
+                            ],
+                            "legacyCode": "81724"
+                        ] as [String: Any]
+                    ] as [String: Any]
+                ],
+                "data": [
+                    "tokenizeCreditCard": "null"
+                ],
+                "extensions": [
+                    "requestId": "3521c97e-a420-47f4-a8ef-a8cefb0fa635"
                 ]
-            ],
-            "data": [
-                "tokenizeCreditCard": "null"
-            ],
-            "extensions": [
-                "requestId": "3521c97e-a420-47f4-a8ef-a8cefb0fa635"
-            ]
-        ])
+            ] as [String: Any]
+        )
         let stubError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: [
             BTCoreConstants.urlResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
             BTCoreConstants.jsonResponseBodyKey: stubJSONResponse
@@ -332,7 +338,7 @@ class BTCardClient_Tests: XCTestCase {
     func testTokenization_whenTokenizationEndpointReturnsAnyNon422Error_callCompletionWithError() {
         let stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
         stubAPIClient.cannedResponseError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: nil)
-        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [])
+        stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         let cardClient = BTCardClient(apiClient: stubAPIClient)
 
         let card = BTCard()
@@ -361,7 +367,7 @@ class BTCardClient_Tests: XCTestCase {
         card.expirationMonth = "12"
         card.expirationYear = "2038"
 
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
         
         let expectation = self.expectation(description: "Tokenized card")
         cardClient.tokenize(card) { _,_  -> Void in
@@ -383,7 +389,7 @@ class BTCardClient_Tests: XCTestCase {
 
     func testAnalyticsEvent_whenTokenizationSucceeds_isSent() {
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
 
         let cardClient = BTCardClient(apiClient: mockAPIClient)
         let card = BTCard()
@@ -403,29 +409,31 @@ class BTCardClient_Tests: XCTestCase {
 
     func testAnalyticsEvent_whenTokenizationFails_isSent() {
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        let stubJSONResponse = BTJSON(value: [
-            "error" : [
-                "message" : "Credit card is invalid"
-            ],
-            "fieldErrors" : [
-                [
-                    "field" : "creditCard",
-                    "fieldErrors" : [
-                        [
-                            "field" : "number",
-                            "message" : "Credit card number must be 12-19 digits",
-                            "code" : "81716"
+        let stubJSONResponse = BTJSON(
+            value: [
+                "error" : [
+                    "message" : "Credit card is invalid"
+                ],
+                "fieldErrors" : [
+                    [
+                        "field" : "creditCard",
+                        "fieldErrors" : [
+                            [
+                                "field" : "number",
+                                "message" : "Credit card number must be 12-19 digits",
+                                "code" : "81716"
+                            ]
                         ]
-                    ]
+                    ] as [String: Any]
                 ]
-            ]
-        ])
+            ] as [String: Any]
+        )
         let stubError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: [
             BTCoreConstants.urlResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
             BTCoreConstants.jsonResponseBodyKey: stubJSONResponse
         ])
         mockAPIClient.cannedResponseError = stubError
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
         let cardClient = BTCardClient(apiClient: mockAPIClient)
 
         let card = BTCard()
@@ -446,7 +454,7 @@ class BTCardClient_Tests: XCTestCase {
     func testTokenize_whenNetworkConnectionLost_sendsAnalytics() {
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
         mockAPIClient.cannedResponseError = NSError(domain: NSURLErrorDomain, code: -1005, userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
 
         let card = BTCard()
         card.number = "4111111111111111"
@@ -474,7 +482,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
         
         let cardClient = BTCardClient(apiClient: mockApiClient)
@@ -505,7 +513,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
 
         let cardClient = BTCardClient(apiClient: mockApiClient)
@@ -535,8 +543,7 @@ class BTCardClient_Tests: XCTestCase {
 
     func testTokenization_whenGraphQLIsDisabled_postsCardDataToGatewayAPI() {
         let mockApiClient = MockAPIClient(authorization: "development_tokenization_key")!
-        mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
-        ])
+        mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         
         let cardClient = BTCardClient(apiClient: mockApiClient)
         let card = BTCard()
@@ -562,7 +569,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["do_not_tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
         
         let cardClient = BTCardClient(apiClient: mockApiClient)
@@ -590,32 +597,33 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
-        mockApiClient.cannedResponseBody = BTJSON(value: [
-            "data": [
-                "tokenizeCreditCard" : [
-                    "token" : "a-nonce",
-                    "creditCard" : [
-                        "brand" : "Visa",
-                        "last4" : "1111",
-                        "binData": [
-                            "prepaid": "Yes",
-                            "healthcare": "Yes",
-                            "debit": "No",
-                            "durbinRegulated": "No",
-                            "commercial": "Yes",
-                            "payroll": "No",
-                            "issuingBank": "US",
-                            "countryOfIssuance": "Something",
-                            "productId": "123"
-                        ]
-                    ]
-                ]
-            ],
-            "extensions": [
-            ]
-        ])
+        mockApiClient.cannedResponseBody = BTJSON(
+            value: [
+                "data": [
+                    "tokenizeCreditCard" : [
+                        "token" : "a-nonce",
+                        "creditCard" : [
+                            "brand" : "Visa",
+                            "last4" : "1111",
+                            "binData": [
+                                "prepaid": "Yes",
+                                "healthcare": "Yes",
+                                "debit": "No",
+                                "durbinRegulated": "No",
+                                "commercial": "Yes",
+                                "payroll": "No",
+                                "issuingBank": "US",
+                                "countryOfIssuance": "Something",
+                                "productId": "123"
+                            ]
+                        ] as [String: Any]
+                    ] as [String: Any]
+                ],
+                "extensions": [] as [Any?]
+            ] as [String: Any]
+        )
 
         let cardClient = BTCardClient(apiClient: mockApiClient)
 
@@ -659,7 +667,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
         mockApiClient.cannedResponseBody = BTJSON(value: [
             "data": [
@@ -679,11 +687,11 @@ class BTCardClient_Tests: XCTestCase {
                             "countryOfIssuance": "Something",
                             "productId": "123"
                         ]
-                    ]
-                ]
+                    ] as [String: Any]
+                ] as [String: Any]
             ],
-            "extensions": []
-        ])
+            "extensions": [] as [Any?]
+        ] as [String: Any])
 
         let cardClient = BTCardClient(apiClient: mockApiClient)
 
@@ -710,7 +718,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
         let stubJSONResponse = BTJSON(value: [
             "error" : [
@@ -726,9 +734,9 @@ class BTCardClient_Tests: XCTestCase {
                             "code" : "81716"
                         ]
                     ]
-                ]
+                ] as [String: Any]
             ]
-        ])
+        ] as [String: Any])
         let stubError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: [
             BTCoreConstants.urlResponseKey: HTTPURLResponse(url: URL(string: "http://fake")!, statusCode: 422, httpVersion: nil, headerFields: nil)!,
             BTCoreConstants.jsonResponseBodyKey: stubJSONResponse
@@ -759,7 +767,7 @@ class BTCardClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ])
 
         let card = BTCard()

--- a/UnitTests/BraintreeCardTests/BTCardNonce_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardNonce_Tests.swift
@@ -32,7 +32,7 @@ class BTCardNonce_Tests: XCTestCase {
             "authenticationInsight": [
                 "regulationEnvironment": "UNREGULATED"
             ]
-        ]))
+        ] as [String: Any]))
 
         XCTAssertNotNil(cardNonce.threeDSecureInfo)
         XCTAssertTrue(cardNonce.threeDSecureInfo.liabilityShiftPossible)
@@ -84,7 +84,7 @@ class BTCardNonce_Tests: XCTestCase {
                 "productId": "123"
             ],
             "nonce": "fake-nonce",
-        ]))
+        ] as [String: Any]))
 
         XCTAssertNotNil(cardNonce.threeDSecureInfo)
         XCTAssertFalse(cardNonce.threeDSecureInfo.liabilityShiftPossible)
@@ -114,7 +114,7 @@ class BTCardNonce_Tests: XCTestCase {
                 "lastFour": "1111"
             ],
             "nonce": "fake-nonce",
-        ]))
+        ] as [String: Any]))
 
         XCTAssertEqual(cardNonce.cardNetwork, BTCardNetwork.visa)
         XCTAssertEqual(cardNonce.lastTwo, "11")
@@ -211,11 +211,11 @@ class BTCardNonce_Tests: XCTestCase {
                     "countryOfIssuance": "USA",
                     "productId": "123"
                 ]
-            ],
+            ] as [String: Any],
             "authenticationInsight": [
                 "customerAuthenticationRegulationEnvironment": "UNREGULATED"
             ]
-        ]))
+        ] as [String: Any]))
 
         XCTAssertEqual(cardNonce.cardNetwork, BTCardNetwork.visa)
         XCTAssertEqual(cardNonce.expirationMonth, "01")
@@ -246,14 +246,18 @@ class BTCardNonce_Tests: XCTestCase {
     }
 
     func testCardNonceWithGraphQLJSON_ignoresCaseWhenParsingCardType() {
-        let cardNonce = BTCardNonce(graphQLJSON: BTJSON(value: [
-            "token": "fake-nonce",
-            "creditCard": [
-                "token": "fake-nonce",
-                "brand": "vIsA",
-                "last4": "1111"
-            ]
-        ]))
+        let cardNonce = BTCardNonce(
+            graphQLJSON: BTJSON(
+                value: [
+                    "token": "fake-nonce",
+                    "creditCard": [
+                        "token": "fake-nonce",
+                        "brand": "vIsA",
+                        "last4": "1111"
+                    ]
+                ] as [String: Any]
+            )
+        )
 
         XCTAssertEqual(cardNonce.cardNetwork, BTCardNetwork.visa)
         XCTAssertEqual(cardNonce.lastTwo, "11")
@@ -330,14 +334,18 @@ class BTCardNonce_Tests: XCTestCase {
     }
 
     func testCardNonceWithGraphQLJSON_withCVVOnlyTokenization_createsNonceWithExpectedValues() {
-        let cardNonce = BTCardNonce(graphQLJSON: BTJSON(value: [
-            "token": "fake-nonce",
-            "creditCard": [
-                "brand": nil,
-                "last4": nil,
-                "binData": nil
-            ]
-        ]))
+        let cardNonce = BTCardNonce(
+            graphQLJSON: BTJSON(
+                value: [
+                    "token": "fake-nonce",
+                    "creditCard": [
+                        "brand": nil,
+                        "last4": nil,
+                        "binData": nil
+                    ] as [String: Any?]
+                ] as [String: Any]
+            )
+        )
 
         XCTAssertEqual(cardNonce.cardNetwork, BTCardNetwork.unknown)
         XCTAssertEqual(cardNonce.lastTwo, "")
@@ -372,7 +380,7 @@ class BTCardNonce_Tests: XCTestCase {
                     "threeDSecureInfo": NSNull(),
                     "type": "CreditCard",
                     "default": true
-                ]
+                ] as [String: Any]
             )
         )
 

--- a/UnitTests/BraintreeCardTests/BTCard_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCard_Tests.swift
@@ -175,11 +175,11 @@ class BTCard_Tests: XCTestCase {
                             "countryCodeNumeric": "123",
                             "postalCode": "94107"
                         ],
-                    ],
+                    ] as [String: Any],
                     "options": ["validate": false]
                 ]
             ]
-        ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
 
     func testGraphQLParameters_whenDoingCVVOnly_returnsExpectedValue() {
@@ -191,13 +191,11 @@ class BTCard_Tests: XCTestCase {
             "query": graphQLQuery,
             "variables": [
                 "input": [
-                    "creditCard": [
-                        "cvv": "123"
-                    ],
+                    "creditCard": ["cvv": "123"] as [String: String],
                     "options": ["validate": false]
-                ]
+                ] as [String: Any]
             ]
-        ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
     
     func testGraphQLParameters_whenMerchantAccountIDIsPresent_andAuthInsightRequestedIsTrue_requestsAuthInsight() {
@@ -215,12 +213,12 @@ class BTCard_Tests: XCTestCase {
                         "number": "4111111111111111",
                     ],
                     "options": [ "validate": false ],
-                ],
+                ] as [String: Any],
                 "authenticationInsightInput": [
                     "merchantAccountId": "some id"
                 ]
             ]
-        ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
     
     func testGraphQLParameters_whenMerchantAccountIDIsPresent_andAuthInsightRequestedIsFalse_doesNotRequestAuthInsight() {
@@ -234,13 +232,11 @@ class BTCard_Tests: XCTestCase {
             "query": graphQLQuery,
             "variables": [
                 "input": [
-                    "creditCard": [
-                        "number": "4111111111111111",
-                    ],
-                    "options": [ "validate": false ],
-                ]
+                    "creditCard": ["number": "4111111111111111"] as [String: String],
+                    "options": ["validate": false],
+                ] as [String: Any]
             ]
-            ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
     
     func testGraphQLParameters_whenMerchantAccountIDIsNil_andAuthInsightRequestedIsTrue_requestsAuthInsight() {
@@ -261,7 +257,7 @@ class BTCard_Tests: XCTestCase {
                 ],
                 "authenticationInsightInput": NSDictionary()
             ]
-            ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
     
     func testGraphQLParameters_whenMerchantAccountIDIsNil_andAuthInsightRequestedIsFalse_doesNotRequestAuthInsight() {
@@ -275,12 +271,10 @@ class BTCard_Tests: XCTestCase {
             "query": graphQLQuery,
             "variables": [
                 "input": [
-                    "creditCard": [
-                        "number": "4111111111111111",
-                    ],
+                    "creditCard": ["number": "4111111111111111"] as [String: String],
                     "options": [ "validate": false ],
-                ]
+                ] as [String: Any]
             ]
-            ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
 }

--- a/UnitTests/BraintreeCardTests/BTThreeDSecureInfo_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTThreeDSecureInfo_Tests.swift
@@ -4,30 +4,30 @@ import BraintreeCore
 
 class BTThreeDSecureInfo_Tests: XCTestCase {
     func testParsesJson() {
-        let json = BTJSON(value:
-                            [
-                                "acsTransactionId": "fake-acs-transaction-id",
-                                "cavv": "fake-cavv",
-                                "dsTransactionId": "fake-txn-id",
-                                "eciFlag": "07",
-                                "enrolled": "Y",
-                                "liabilityShiftPossible": true,
-                                "liabilityShifted": false,
-                                "paresStatus": "U",
-                                "status": "lookup_enrolled",
-                                "threeDSecureAuthenticationId" : "3fg8syh4nsmq3nzrmv",
-                                "threeDSecureServerTransactionId": "fake-threedsecure-server-transaction-id",
-                                "threeDSecureVersion": "2.2.0",
-                                "xid": "fake-xid",
-                                "authentication": [
-                                    "transStatus": "Y",
-                                    "transStatusReason": "02"
-                                ],
-                                "lookup": [
-                                    "transStatus": "N",
-                                    "transStatusReason": "01"
-                                ]
-                            ]
+        let json = BTJSON(
+            value: [
+                "acsTransactionId": "fake-acs-transaction-id",
+                "cavv": "fake-cavv",
+                "dsTransactionId": "fake-txn-id",
+                "eciFlag": "07",
+                "enrolled": "Y",
+                "liabilityShiftPossible": true,
+                "liabilityShifted": false,
+                "paresStatus": "U",
+                "status": "lookup_enrolled",
+                "threeDSecureAuthenticationId" : "3fg8syh4nsmq3nzrmv",
+                "threeDSecureServerTransactionId": "fake-threedsecure-server-transaction-id",
+                "threeDSecureVersion": "2.2.0",
+                "xid": "fake-xid",
+                "authentication": [
+                    "transStatus": "Y",
+                    "transStatusReason": "02"
+                ],
+                "lookup": [
+                    "transStatus": "N",
+                    "transStatusReason": "01"
+                ]
+            ] as [String: Any]
         )
         let info = BTThreeDSecureInfo(json: json)
         

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -231,7 +231,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
         if analyticsURL != nil {
             stubAPIClient?.cannedConfigurationResponseBody = BTJSON(value: ["analytics": ["url": analyticsURL]])
         } else {
-            stubAPIClient?.cannedConfigurationResponseBody = BTJSON(value: [:])
+            stubAPIClient?.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
         }
 
         return stubAPIClient!

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -7,7 +7,7 @@ class BTAPIClient_Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockConfigurationHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [], statusCode: 200)
+        mockConfigurationHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
     }
 
     // MARK: - Initialization
@@ -64,7 +64,7 @@ class BTAPIClient_Tests: XCTestCase {
     func testFetchOrReturnRemoteConfiguration_performsGETWithCorrectPayload() {
         let apiClient = BTAPIClient(authorization: "development_testing_integration_merchant_id")
         let mockHTTP = FakeHTTP.fakeHTTP()
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/v1/configuration", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.configurationHTTP = mockHTTP
 
         let expectation = expectation(description: "Callback invoked")
@@ -158,7 +158,7 @@ class BTAPIClient_Tests: XCTestCase {
         let mockHTTP = FakeHTTP.fakeHTTP()
 
         apiClient?.configurationHTTP = mockConfigurationHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
 
         let expectation = expectation(description: "Callback invoked")
@@ -177,7 +177,7 @@ class BTAPIClient_Tests: XCTestCase {
         let mockHTTP = FakeHTTP.fakeHTTP()
 
         apiClient?.configurationHTTP = mockConfigurationHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
 
         let expectation = expectation(description: "Callback invoked")
@@ -195,7 +195,7 @@ class BTAPIClient_Tests: XCTestCase {
         let mockHTTP = FakeHTTP.fakeHTTP()
 
         apiClient?.configurationHTTP = mockConfigurationHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
 
         let expectation = expectation(description: "Callback invoked")
@@ -221,11 +221,11 @@ class BTAPIClient_Tests: XCTestCase {
                     ],
                     "nonce": "fake-nonce1",
                     "type": "CreditCard"
-                ],
+                ] as [String: Any?],
                 [
                     "default" : false,
                     "description": "jane.doe@example.com",
-                    "details": [],
+                    "details": [] as [Any?],
                     "nonce": "fake-nonce2",
                     "type": "PayPalAccount"
                 ]
@@ -283,7 +283,7 @@ class BTAPIClient_Tests: XCTestCase {
         let apiClient = BTAPIClient(authorization: clientToken)
         let mockHTTP = FakeHTTP.fakeHTTP()
 
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
         apiClient?.configurationHTTP = mockConfigurationHTTP
 
@@ -305,7 +305,7 @@ class BTAPIClient_Tests: XCTestCase {
         let apiClient = BTAPIClient(authorization: clientToken)
         let mockHTTP = FakeHTTP.fakeHTTP()
 
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
         apiClient?.configurationHTTP = mockConfigurationHTTP
 
@@ -324,7 +324,7 @@ class BTAPIClient_Tests: XCTestCase {
         let apiClient = BTAPIClient(authorization: clientToken)
         let mockHTTP = FakeHTTP.fakeHTTP()
 
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/payment_methods", respondWith: [] as [Any?], statusCode: 200)
         apiClient?.http = mockHTTP
         apiClient?.configurationHTTP = mockConfigurationHTTP
 
@@ -347,7 +347,7 @@ class BTAPIClient_Tests: XCTestCase {
         // Override apiClient.http so that requests don't fail
         apiClient?.configurationHTTP = mockHTTP
         apiClient?.http = mockHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
 
         let expectation1 = expectation(description: "Fetch configuration")
         apiClient?.fetchOrReturnRemoteConfiguration() { _, _ in
@@ -418,7 +418,7 @@ class BTAPIClient_Tests: XCTestCase {
 
         apiClient?.http = mockHTTP
         apiClient?.configurationHTTP = mockHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
 
         let expectation = expectation(description: "POST callback")
         apiClient?.post("/", parameters: [:], httpType: .gateway) { _, _, _ in
@@ -438,7 +438,7 @@ class BTAPIClient_Tests: XCTestCase {
 
         apiClient?.apiHTTP = mockAPIHTTP
         apiClient?.configurationHTTP = mockHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [], statusCode: 200)
+        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
 
         let expectation = expectation(description: "POST callback")
         apiClient?.post("/", parameters: [:], httpType: .braintreeAPI) { _, _, _ in
@@ -458,7 +458,7 @@ class BTAPIClient_Tests: XCTestCase {
             "graphQL": [
                 "url": "graphql://graphql",
                 "features": ["tokenize_credit_cards"]
-            ]
+            ] as [String: Any]
         ]
 
         apiClient?.graphQLHTTP = mockGraphQLHTTP

--- a/UnitTests/BraintreeCoreTests/BTBinData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTBinData_Tests.swift
@@ -21,7 +21,7 @@ class BTBinData_Tests: XCTestCase {
                 "productId": "123"
             ],
             "nonce": "fake-nonce",
-            ])
+        ] as [String: Any])
         let binData = BTBinData(json: json["binData"])
 
         XCTAssertEqual(binData.prepaid, "Yes")

--- a/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
@@ -8,7 +8,7 @@ class BTConfiguration_Tests: XCTestCase {
         let json = BTJSON(value: [
             "some": "things",
             "number": 1,
-            "array": [1, 2, 3]])
+            "array": [1, 2, 3]] as [String: Any])
         let configuration = BTConfiguration(json: json)
 
         XCTAssertEqual(configuration.json, json)
@@ -28,8 +28,8 @@ class BTConfiguration_Tests: XCTestCase {
         let configurationJSON = BTJSON(value: [
             "graphQL": [
                 "url": nil
-            ]
-        ])
+            ] as [String: Any?]
+        ] as [String: Any])
         let configuration = BTConfiguration(json: configurationJSON)
         XCTAssertFalse(configuration.isGraphQLEnabled)
     }

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
@@ -194,8 +194,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
 
     func testErrorResponse_whenErrorTypeIsUserError_containsExpectedError() {
         let expectation = expectation(description: "POST callback")
-        let stubGraphQLErrorResponse: [String: Any] = [
-            "data": ["tokenizeCreditCard": nil],
+        let stubGraphQLErrorResponse: [String: Any?] = [
+            "data": ["tokenizeCreditCard": nil] as [String: Any?],
             "errors": [
                 [
                     "message": "Expiration month is invalid",
@@ -207,8 +207,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "errorType": "user_error",
                         "legacyCode": "81712",
                         "inputPath": ["input", "creditCard", "expirationMonth"]
-                    ]
-                ],
+                    ] as [String: Any]
+                ] as [String: Any],
                 [
                     "message": "Expiration year is invalid",
                     "path": ["tokenizeCreditCard"],
@@ -219,7 +219,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "errorType": "user_error",
                         "legacyCode": "81713",
                         "inputPath": ["input", "creditCard", "expirationYear"]
-                    ]
+                    ] as [String: Any]
                 ],
                 [
                     "message": "CVV verification failed",
@@ -231,7 +231,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "errorType": "user_error",
                         "legacyCode": "81736",
                         "inputPath": ["input", "creditCard", "cvv"]
-                    ]
+                    ] as [String: Any]
                 ],
                 [
                     "message": "Street address verification failed",
@@ -243,7 +243,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "errorType": "user_error",
                         "legacyCode": "12345",
                         "inputPath": ["input", "creditCard", "billingAddress", "streetAddress"]
-                    ]
+                    ] as [String: Any]
                 ]
             ],
             "extensions": ["requestId": "de1f7c67-4861-455f-89bb-1d208915f270"]
@@ -269,7 +269,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                             "field": "cvv",
                             "code": "81736",
                             "message": "CVV verification failed"
-                        ],
+                        ] as [String: Any],
                         [
                             "field": "billingAddress",
                             "fieldErrors": [
@@ -281,7 +281,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                             ]
                         ]
                     ]
-                ]
+                ] as [String: Any]
             ]
         ]
 
@@ -309,8 +309,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
 
     func testErrorResponse_whenErrorTypeIsNotUserError_containsExpectedError() {
         let expectation = expectation(description: "POST callback")
-        let stubGraphQLErrorResponse: [String: Any] = [
-            "data": ["tokenizeCard": nil],
+        let stubGraphQLErrorResponse: [String: Any?] = [
+            "data": ["tokenizeCard": nil] as [String: Any?],
             "errors": [
                 [
                     "message": "Validation is not supported for requests authorized with a tokenization key.",
@@ -322,8 +322,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "errorType": "developer_error",
                         "legacyCode": "50000",
                         "inputPath": ["input", "options", "validate"]
-                    ]
-                ]
+                    ] as [String: Any]
+                ] as [String: Any]
             ]
         ]
 
@@ -456,8 +456,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
 
     func testErrorResponse_whenErrorIsMissingLegacyCode_doesNotSetCodeNumber() {
         let expectation = expectation(description: "POST callback")
-        let stubGraphQLErrorResponse: [String: Any] = [
-            "data": ["tokenizeCreditCard": nil],
+        let stubGraphQLErrorResponse: [String: Any?] = [
+            "data": ["tokenizeCreditCard": nil] as [String: Any?],
             "errors": [
                 [
                     "message": "Expiration month is invalid",
@@ -465,12 +465,12 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                     "extensions": [
                         "errorType": "user_error",
                         "inputPath": ["input", "creditCard", "expirationMonth"]
-                    ]
-                ]
+                    ] as [String: Any]
+                ] as [String: Any]
             ],
         ]
 
-        let expectedErrorBody: [String: Any] = [
+        let expectedErrorBody: [String: Any?] = [
             "error": ["message": "Input is invalid"],
             "fieldErrors": [
                 [
@@ -481,7 +481,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                             "message": "Expiration month is invalid"
                         ]
                     ]
-                ]
+                ] as [String: Any]
             ]
         ]
 

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -760,7 +760,7 @@ final class BTHTTP_Tests: XCTestCase {
             return true
         } withStubResponse: { request in
             return HTTPStubsResponse(
-                data: try! JSONSerialization.data(withJSONObject: [], options: .prettyPrinted),
+                data: try! JSONSerialization.data(withJSONObject: [] as [Any?], options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
@@ -817,7 +817,7 @@ final class BTHTTP_Tests: XCTestCase {
             return true
         } withStubResponse: { request in
             return HTTPStubsResponse(
-                data: try! JSONSerialization.data(withJSONObject: [:], options: .prettyPrinted),
+                data: try! JSONSerialization.data(withJSONObject: [:] as [String: Any?], options: .prettyPrinted),
                 statusCode: 429,
                 headers: ["Content-Type": "application/json"]
                 )

--- a/UnitTests/BraintreeCoreTests/BTPaymentMethodNonceParser_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTPaymentMethodNonceParser_Tests.swift
@@ -44,7 +44,7 @@ class BTPaymentMethodNonceParser_Tests: XCTestCase {
     }
     
     func testParseJSON_whenTypeIsNotRegisteredAndJSONDoesNotContainNonce_returnsNil() {
-        let paymentMethodNonce = parser.parseJSON(BTJSON(value: ["details": []]), withParsingBlockForType: "MyType")
+        let paymentMethodNonce = parser.parseJSON(BTJSON(value: ["details": [] as [Any?]]), withParsingBlockForType: "MyType")
         
        XCTAssertNil(paymentMethodNonce)
     }
@@ -54,12 +54,12 @@ class BTPaymentMethodNonceParser_Tests: XCTestCase {
         let JSON = BTJSON(value: [
             "consumed": false,
             "description": "Some thing",
-            "details": [],
+            "details": [] as [Any?],
             "isLocked": false,
             "nonce": "a-nonce",
             "type": "asdfasdfasdf",
             "default": true
-            ])
+            ] as [String: Any])
 
         let unknownNonce = sharedParser.parseJSON(JSON, withParsingBlockForType: "asdfasdfasdf")!
 

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutAccountNonce_Tests.swift
@@ -27,7 +27,7 @@ final class BTPayPalNativeCheckoutAccountNonce_Tests: XCTestCase {
                                     "state": "FU",
                                     "postalCode": "42",
                                     "country": "USA"
-                                ],
+                                ] as [String: Any],
                                 "billingAddress": [
                                     "recipientName": "Bar Foo",
                                     "line1": "2 Foo Ct",
@@ -46,9 +46,9 @@ final class BTPayPalNativeCheckoutAccountNonce_Tests: XCTestCase {
                                     "postalCode": "24",
                                     "countryCode": "US"
                                 ]
-                            ]
-                        ]
-                    ]
+                            ] as [String: Any]
+                        ] as [String: Any]
+                    ] as [String: Any]
                 ]
             ]
         )

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -17,8 +17,8 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
         apiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": true,
             "environment": environment,
-            "paypal": ["clientId": nil]
-        ])
+            "paypal": ["clientId": nil] as [String: Any?]
+        ] as [String: Any])
 
         let nativeCheckoutRequest = BTPayPalNativeCheckoutRequest(amount: "4.30")
         let checkoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutRequest_Tests.swift
@@ -14,7 +14,7 @@ class BTPayPalNativeCheckoutRequest_Tests: XCTestCase {
             "paypal": [
                 "environment": "offline"
             ]
-        ])
+        ] as [String: Any])
         configuration = BTConfiguration(json: json)
     }
 

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeOrderCreationClient_Tests.swift
@@ -23,7 +23,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
             "paypalEnabled": true,
             "environment": environment,
             "paypal": ["clientId": clientId]
-        ])
+        ] as [String: Any])
 
         apiClient.cannedResponseBody = BTJSON(value: [
             "paymentResource": [
@@ -82,8 +82,8 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
     func testCreateOrder_NoClientID_ThrowsClientIDError() {
         apiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": ["clientId": nil]
-        ])
+            "paypal": ["clientId": nil] as [String: Any?]
+        ] as [String: Any])
 
         orderCreationClient.createOrder(with: request) { result in
             switch result {
@@ -102,7 +102,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
             "paypalEnabled": true,
             "environment": "staging",
             "paypal": ["clientId": "12345"]
-        ])
+        ] as [String: Any])
 
         orderCreationClient.createOrder(with: request) { result in
             switch result {
@@ -121,7 +121,7 @@ class BTPayPalNativeOrderCreationClient_Tests: XCTestCase {
             "paypalEnabled": true,
             "environment": "sandbox",
             "paypal": ["clientId": "12345"]
-        ])
+        ] as [String: Any])
         apiClient.cannedResponseBody = nil
 
         orderCreationClient.createOrder(with: request) { result in

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeVaultRequest_Tests.swift
@@ -13,7 +13,7 @@ class BTPayPalNativeVaultRequest_Tests: XCTestCase {
             "paypal": [
                 "environment": "offline"
             ]
-        ])
+        ] as [String: Any])
         configuration = BTConfiguration(json: json)
     }
     

--- a/UnitTests/BraintreePayPalTests/BTConfiguration+PayPal_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTConfiguration+PayPal_Tests.swift
@@ -22,7 +22,7 @@ class BTConfiguration_PayPal_Tests : XCTestCase {
     }
 
     func testIsPayPalEnabled_whenPayPalEnabledStatusNotPresentInConfigurationJSON_returnsFalse() {
-        let configuration = BTConfiguration(json: BTJSON(value: []))
+        let configuration = BTConfiguration(json: BTJSON(value: [] as [Any?]))
         XCTAssertFalse(configuration.isPayPalEnabled)
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -13,7 +13,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
             "paypal": [
                 "environment": "offline"
             ]
-        ])
+        ] as [String: Any])
 
         configuration = BTConfiguration(json: json)
     }
@@ -133,10 +133,8 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
     func testParametersWithConfiguration_whenCurrencyCodeNotSet_usesConfigCurrencyCode() {
         let json = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": [
-                "currencyIsoCode": "currency-code"
-            ]
-        ])
+            "paypal": ["currencyIsoCode": "currency-code"]
+        ] as [String: Any])
 
         configuration = BTConfiguration(json: json)
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -13,14 +13,10 @@ class BTPayPalClient_Tests: XCTestCase {
         mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": [
-                "environment": "offline"
-            ]
-        ])
+            "paypal": ["environment": "offline"]
+        ] as [String: Any])
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
-                "redirectUrl": "http://fakeURL.com"
-            ]
+            "paymentResource": ["redirectUrl": "http://fakeURL.com"]
         ])
 
         payPalClient = BTPayPalClient(apiClient: mockAPIClient)
@@ -395,7 +391,7 @@ class BTPayPalClient_Tests: XCTestCase {
                     ],
                     "nonce": "a-nonce",
                     "type": "PayPalAccount",
-                    ]
+                    ] as [String: Any]
                 ]
         ])
         payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
@@ -429,11 +425,11 @@ class BTPayPalClient_Tests: XCTestCase {
                                 "currency": "USD",
                                 "value": "0.00",
                             ],
-                        ],
-                    ],
+                        ] as [String: Any],
+                    ] as [String: Any],
                     "nonce": "a-nonce",
                     "type": "PayPalAccount",
-                ]
+                ] as [String: Any]
             ]
         ])
         payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
@@ -528,9 +524,9 @@ class BTPayPalClient_Tests: XCTestCase {
                                 "postalCode": "24",
                                 "countryCode": "US"
                             ]
-                        ]
-                    ]
-                ]
+                        ] as [String: Any]
+                    ] as [String: Any]
+                ] as [String: Any]
             ]
         ]
 
@@ -596,9 +592,9 @@ class BTPayPalClient_Tests: XCTestCase {
                                 "postalCode": "24",
                                 "countryCode": "ASU"
                             ]
-                        ]
-                    ]
-                ]
+                        ] as [String: Any]
+                    ] as [String: Any]
+                ] as [String: Any]
             ]
         ]
 
@@ -625,11 +621,9 @@ class BTPayPalClient_Tests: XCTestCase {
                     "nonce": "fake-nonce",
                     "details": [
                         "email": "not-hello@world.com",
-                        "payerInfo": [
-                            "email": "hello@world.com",
-                        ]
-                    ],
-                ]
+                        "payerInfo": ["email": "hello@world.com"]
+                    ] as [String: Any],
+                ] as [String: Any]
             ]
         ]
         mockAPIClient.cannedResponseBody = BTJSON(value: checkoutResponse as [String : AnyObject])
@@ -664,18 +658,19 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testHandleBrowserSwitchReturn_vault_whenCreditFinancingNotReturned_shouldNotSendCreditAcceptedAnalyticsEvent() {
-        mockAPIClient.cannedResponseBody = BTJSON(value: [ "paypalAccounts":
-            [
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paypalAccounts":
                 [
-                    "description": "jane.doe@example.com",
-                    "details": [
-                        "email": "jane.doe@example.com",
-                    ],
-                    "nonce": "a-nonce",
-                    "type": "PayPalAccount",
-                    ]
-            ]
-            ])
+                    [
+                        "description": "jane.doe@example.com",
+                        "details": [
+                            "email": "jane.doe@example.com",
+                        ],
+                        "nonce": "a-nonce",
+                        "type": "PayPalAccount",
+                    ] as [String: Any]
+                ]
+        ])
         payPalClient.payPalRequest = BTPayPalVaultRequest()
 
         let returnURL = URL(string: "bar://hello/world")!
@@ -707,11 +702,11 @@ class BTPayPalClient_Tests: XCTestCase {
                                 "currency": "USD",
                                 "value": "0.00",
                             ],
-                        ],
-                    ],
+                        ] as [String: Any],
+                    ] as [String: Any],
                     "nonce": "a-nonce",
                     "type": "PayPalAccount",
-                ]
+                ] as [String: Any]
             ]
             ])
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -9,10 +9,8 @@ class BTPayPalRequest_Tests: XCTestCase {
         super.setUp()
         let json = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": [
-                "environment": "offline"
-            ]
-        ])
+            "paypal": ["environment": "offline"]
+        ] as [String: Any])
 
         configuration = BTConfiguration(json: json)
     }

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -9,10 +9,8 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         super.setUp()
         let json = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": [
-                "environment": "offline"
-            ]
-        ])
+            "paypal": ["environment": "offline"]
+        ] as [String: Any])
 
         configuration = BTConfiguration(json: json)
     }

--- a/UnitTests/BraintreePayPalTests/BTPaymentMethodNonceParser_PayPal_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPaymentMethodNonceParser_PayPal_Tests.swift
@@ -13,10 +13,10 @@ class BTPaymentMethodNonceParser_PayPal_Tests: XCTestCase {
                     ],
                     "isLocked": false,
                     "nonce": "a-nonce",
-                    "securityQuestions": [],
+                    "securityQuestions": [] as [Any?],
                     "type": "PayPalAccount",
                     "default": true
-                ]
+                ] as [String: Any]
             )
         )
 
@@ -58,7 +58,7 @@ class BTPaymentMethodNonceParser_PayPal_Tests: XCTestCase {
                 "currency": "XYZ",
                 "value": "456.78",
             ],
-        ])
+        ] as [String: Any])
 
         guard let creditFinancing = payPalCreditFinancing.asPayPalCreditFinancing() else {
             XCTFail("Expected credit financing")
@@ -106,7 +106,7 @@ class BTPaymentMethodNonceParser_PayPal_Tests: XCTestCase {
                             "monthlyPayment": [
                                 "currency": "USD",
                                 "value": "13.88",
-                            ],
+                            ] as [String: Any],
                             "payerAcceptance": true,
                             "term": 18,
                             "totalCost": [
@@ -117,14 +117,14 @@ class BTPaymentMethodNonceParser_PayPal_Tests: XCTestCase {
                                 "currency": "USD",
                                 "value": "0.00",
                             ],
-                        ],
-                    ],
+                        ] as [String: Any],
+                    ] as [String: Any],
                     "isLocked": false,
                     "nonce": "a-nonce",
-                    "securityQuestions": [],
+                    "securityQuestions": [] as [Any?],
                     "type": "PayPalAccount",
                     "default": true,
-                ]
+                ] as [String: Any]
             )
         )
 

--- a/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
@@ -325,7 +325,7 @@ class BTSEPADirectDebitClient_Tests: XCTestCase {
                     "merchantOrPartnerCustomerId": "a-customer-id",
                     "mandateType": "RECURRENT"
                 ]
-            ]
+            ] as [String: Any]
         )
         
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://example/sepa/success?success=true")
@@ -378,7 +378,7 @@ class BTSEPADirectDebitClient_Tests: XCTestCase {
                     "merchantOrPartnerCustomerId": "a-customer-id",
                     "mandateType": "RECURRENT"
                 ]
-            ]
+            ] as [String: Any]
         )
         
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://example/sepa/success?success=true")

--- a/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitNonce_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitNonce_Tests.swift
@@ -17,7 +17,7 @@ class BTSEPADirectDebitNonce_Tests: XCTestCase {
                         "merchantOrPartnerCustomerId": "a-customer-id",
                         "mandateType": "ONE_OFF"
                     ]
-                ]
+                ] as [String: Any]
             )
         )
 

--- a/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
@@ -147,7 +147,7 @@ class SEPADirectDebitAPI_Tests: XCTestCase {
                     "merchantOrPartnerCustomerId": "a-customer-id",
                     "mandateType": "RECURRENT"
                 ]
-            ]
+            ] as [String: Any]
         )
         
         mockAPIClient.cannedResponseBody = json

--- a/UnitTests/BraintreeTestShared/TestClientTokenFactory.swift
+++ b/UnitTests/BraintreeTestShared/TestClientTokenFactory.swift
@@ -67,7 +67,7 @@ public class TestClientTokenFactory: NSObject {
                 "environment": "offline",
                 "merchantAccountId": "a_merchant_account_id",
                 "currencyIsoCode": "USD"
-                ],
+                ] as [String: Any?],
                 "merchantId": "a_merchant_id",
                 "venmo": "offline",
                 "applePay": [
@@ -75,10 +75,8 @@ public class TestClientTokenFactory: NSObject {
                     "countryCode": "US",
                     "currencyCode": "USD",
                     "merchantIdentifier": "apple-pay-merchant-id",
-                    "supportedNetworks": ["visa",
-                                          "mastercard",
-                                          "amex"]
-                ],
+                    "supportedNetworks": ["visa", "mastercard","amex"]
+                ] as [String: Any],
                 "merchantAccountId": "some-merchant-account-id",
             ]
         } else {
@@ -116,7 +114,7 @@ public class TestClientTokenFactory: NSObject {
                 "environment": "offline",
                 "merchantAccountId": "a_merchant_account_id",
                 "currencyIsoCode": "USD"
-            ],
+            ] as [String: Any?],
             "merchantId": "a_merchant_id",
             "venmo": "offline",
             "applePay": [
@@ -124,11 +122,9 @@ public class TestClientTokenFactory: NSObject {
                 "countryCode": "US",
                 "currencyCode": "USD",
                 "merchantIdentifier": "apple-pay-merchant-id",
-                "supportedNetworks": [ "visa",
-                                       "mastercard",
-                                       "amex" ]
+                "supportedNetworks": ["visa", "mastercard", "amex"]
 
-            ],
+            ] as [String: Any],
             "merchantAccountId": "some-merchant-account-id",
         ]
     }

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
@@ -32,9 +32,9 @@ class BTThreeDSecureAuthenticateJWT_Tests: XCTestCase {
                     "liabilityShiftPossible": true,
                     "liabilityShifted": true,
                     "status": "authenticate_successful",
-                ],
+                ] as [String: Any],
                 "type": "CreditCard",
-            ],
+            ] as [String: Any],
             "threeDSecureInfo":     [
                 "liabilityShiftPossible": true,
                 "liabilityShifted": true,

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -233,7 +233,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         
         let request =  BTThreeDSecureRequest()
         request.amount = NSDecimalNumber.notANumber
@@ -259,7 +259,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
 
         client.startPaymentFlow(threeDSecureRequest) { result, error in
@@ -280,9 +280,9 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         let expectation = self.expectation(description: "willCallCompletion")
 
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
-            "threeDSecure": [],
+            "threeDSecure": [] as [Any?],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
 
         client.startPaymentFlow(threeDSecureRequest) { result, error in
@@ -306,7 +306,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
         let responseBody = [
             "paymentMethod": [
@@ -322,9 +322,9 @@ class BTThreeDSecureClient_Tests: XCTestCase {
                     "liabilityShiftPossible": false,
                     "liabilityShifted": false,
                     "status": "authenticate_successful_issuer_not_participating",
-                ],
+                ] as [String: Any],
                 "type": "CreditCard",
-            ],
+            ] as [String: Any],
             "success": true,
             "threeDSecureInfo":     [
                 "liabilityShiftPossible": false,
@@ -334,7 +334,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseBody = BTJSON(value: responseBody)
 
         client.startPaymentFlow(threeDSecureRequest) { result, error in
-            guard let result = result as? BTThreeDSecureResult else { XCTFail(); return }
+            guard let result = result else { XCTFail(); return }
             guard let tokenizedCard = result.tokenizedCard else { XCTFail(); return }
 
             XCTAssertTrue(tokenizedCard.nonce.isANonce())
@@ -358,7 +358,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
 
         client.startPaymentFlow(threeDSecureRequest) { result, error in
@@ -374,7 +374,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
 
         client.startPaymentFlow(threeDSecureRequest) { result, error in
@@ -405,9 +405,9 @@ class BTThreeDSecureClient_Tests: XCTestCase {
                     "liabilityShiftPossible": true,
                     "liabilityShifted": true,
                     "status": "authenticate_successful",
-                ],
+                ] as [String: Any],
                 "type": "CreditCard",
-            ],
+            ] as [String: Any],
             "success": true,
             "threeDSecureInfo":     [
                 "liabilityShiftPossible": true,
@@ -430,7 +430,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
 
         let responseBody = [
             "paymentMethod": [
@@ -446,9 +446,9 @@ class BTThreeDSecureClient_Tests: XCTestCase {
                     "liabilityShiftPossible": true,
                     "liabilityShifted": true,
                     "status": "authenticate_successful",
-                ],
+                ] as [String: Any],
                 "type": "CreditCard",
-            ],
+            ] as [String: Any],
             "success": true,
             "threeDSecureInfo":     [
                 "liabilityShiftPossible": true,
@@ -481,7 +481,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         mockAPIClient.cannedResponseError = NSError(domain:"BTError", code: 500, userInfo: nil)
         threeDSecureRequest.threeDSecureRequestDelegate = mockThreeDSecureRequestDelegate
 
@@ -504,7 +504,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)
         let expectation = expectation(description: "willCallCompletion")
 
@@ -534,7 +534,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "threeDSecure": ["cardinalAuthenticationJWT": "FAKE_JWT"],
             "assetsUrl": "http://assets.example.com"
-        ])
+        ] as [String: Any])
         
         let mockAPIClient = MockAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
         let client = BTThreeDSecureClient(apiClient: mockAPIClient)

--- a/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
@@ -14,7 +14,7 @@ class BTConfiguration_Venmo_Tests: XCTestCase {
 
     func testIsVenmoEnabled_whenAccessTokenNotPresent_returnsFalse() {
         let configurationJSON = BTJSON(value: [
-            "payWithVenmo": [:]
+            "payWithVenmo": [:] as [String: Any?]
         ])
         let configuration = BTConfiguration(json: configurationJSON)
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
@@ -33,7 +33,7 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
                         "lastName": "venmo-last-name",
                         "phoneNumber": "venmo-phone-number"
                     ]
-                ]
+                ] as [String: Any]
             ]
         ])
 
@@ -57,10 +57,10 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
                     "details": ["username": "jane.doe.username@example.com", "cardType": "Discover"],
                     "isLocked": false,
                     "nonce": "a-nonce",
-                    "securityQuestions": [],
+                    "securityQuestions": [] as [Any?],
                     "type": "VenmoAccount",
                     "default": true
-                ]
+                ] as [String: Any]
             )
         )
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -45,7 +45,7 @@ class BTVenmoClient_Tests: XCTestCase {
     }
 
     func testTokenizeVenmoAccount_whenVenmoConfigurationDisabled_callsBackWithError() {
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
 
@@ -60,7 +60,7 @@ class BTVenmoClient_Tests: XCTestCase {
     }
 
     func testTokenizeVenmoAccount_whenVenmoConfigurationMissing_callsBackWithError() {
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:])
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
 
@@ -111,7 +111,7 @@ class BTVenmoClient_Tests: XCTestCase {
                     "displayName": "app-display-name"
                 ]
             ]
-        ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
 
     func testTokenizeVenmoAccount_whenDisplayNameNotSet_createsPaymentContextWithoutDisplayName() {
@@ -134,7 +134,7 @@ class BTVenmoClient_Tests: XCTestCase {
                     "paymentMethodUsage": "MULTI_USE"
                 ]
             ]
-        ] as NSObject)
+        ] as [String: Any] as NSObject)
     }
 
     func testTokenizeVenmoAccount_opensVenmoURLWithPaymentContextID() {
@@ -417,7 +417,7 @@ class BTVenmoClient_Tests: XCTestCase {
                     "cardType": "Discover",
                     "username": "venmojoe"
                 ]
-            ]]
+            ] as [String: Any]]
         ])
 
         BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
@@ -458,7 +458,7 @@ class BTVenmoClient_Tests: XCTestCase {
                     "cardType": "Discover",
                     "username": "venmojoe"
                 ]
-            ]]
+            ] as [String: Any]]
         ])
 
         BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)


### PR DESCRIPTION
### Summary of changes

- Resolves the following Xcode warnings in our tests:
    - Empty collection literal requires an explicit type
    - Heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 