### PR TITLE
[v5] Add Cardinal UI Type and Render Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Require Xcode 14.1 (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
+* BraintreeThreeDSecure
+  * Add properties `uiType` and `renderType` to `BTThreeDSecureRequest`
 
 ## 5.21.0 (2023-03-14)
 * Add missed deprecation warnings to `BTCardRequest` Union Pay properties

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -195,6 +195,14 @@
         // MARK: - UI and Render Type Customization
 
         request.uiType = BTThreeDSecureUITypeBoth;
+        request.renderType = [[NSArray alloc] initWithObjects:
+                              BTThreeDSecureRenderTypeHTML,
+                              BTThreeDSecureRenderTypeOOB,
+                              BTThreeDSecureRenderTypeOTP,
+                              BTThreeDSecureRenderTypeMultiSelect,
+                              BTThreeDSecureRenderTypeSingleSelect,
+                              nil
+        ];
 
         [self.paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
             self.callbackCount++;

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -192,6 +192,10 @@
 
         request.v2UICustomization = ui;
 
+        // MARK: - UI and Render Type Customization
+
+        request.uiType = BTThreeDSecureUITypeBoth;
+
         [self.paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
             self.callbackCount++;
             [self updateCallbackCount];

--- a/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
+++ b/Demo/Application/Features/3D Secure/BraintreeDemoThreeDSecurePaymentFlowViewController.m
@@ -195,7 +195,7 @@
         // MARK: - UI and Render Type Customization
 
         request.uiType = BTThreeDSecureUITypeBoth;
-        request.renderType = [[NSArray alloc] initWithObjects:
+        request.renderTypes = [[NSArray alloc] initWithObjects:
                               BTThreeDSecureRenderTypeHTML,
                               BTThreeDSecureRenderTypeOOB,
                               BTThreeDSecureRenderTypeOTP,

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.m
@@ -42,6 +42,12 @@
 
 #endif
 
+BTThreeDSecureRenderType BTThreeDSecureRenderTypeOTP = @"CardinalSessionRenderTypeOTP";
+BTThreeDSecureRenderType BTThreeDSecureRenderTypeHTML = @"CardinalSessionRenderTypeHTML";
+BTThreeDSecureRenderType BTThreeDSecureRenderTypeSingleSelect = @"CardinalSessionRenderTypeSingleSelect";
+BTThreeDSecureRenderType BTThreeDSecureRenderTypeMultiSelect = @"CardinalSessionRenderTypeMultiSelect";
+BTThreeDSecureRenderType BTThreeDSecureRenderTypeOOB = @"CardinalSessionRenderTypeOOB";
+
 @interface BTThreeDSecureRequest () <BTThreeDSecureRequestDelegate>
 
 @property (nonatomic, strong) BTThreeDSecureV2Provider *threeDSecureV2Provider;

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
@@ -67,8 +67,7 @@
     }
 
     if (request.renderType) {
-        CardinalSessionRenderTypeArray *renderType = [self renderTypeAsCardinalRenderType:request];
-        cardinalConfiguration.renderType = renderType;
+        cardinalConfiguration.renderType = request.renderType;
     }
 
     [instance.cardinalSession configure:cardinalConfiguration];
@@ -119,26 +118,6 @@
         case BTThreeDSecureUITypeHTML:
             return CardinalSessionUITypeHTML;
     }
-}
-
-+ (CardinalSessionRenderTypeArray *)renderTypeAsCardinalRenderType:(BTThreeDSecureRequest *)request {
-    CardinalSessionRenderTypeArray *renderTypes = [[CardinalSessionRenderTypeArray alloc] init];
-
-    for (NSString *renderType in request.renderType) {
-//        if (renderType == BTThreeDSecureRenderTypeOTP) {
-//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeOTP];
-//        } else if (renderType == BTThreeDSecureRenderTypeHTML) {
-//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeHTML];
-//        } else if (renderType == BTThreeDSecureRenderTypeOOB) {
-//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeOOB];
-//        } else if (renderType == BTThreeDSecureRenderTypeSingleSelect) {
-//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeSingleSelect];
-//        } else if (renderType == BTThreeDSecureRenderTypeMultiSelect) {
-//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeMultiSelect];
-//        }
-    }
-
-    return renderTypes;
 }
 
 #pragma mark - Cardinal Delegate

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
@@ -66,8 +66,8 @@
         cardinalConfiguration.uiType = uiType;
     }
 
-    if (request.renderType) {
-        cardinalConfiguration.renderType = request.renderType;
+    if (request.renderTypes) {
+        cardinalConfiguration.renderType = request.renderTypes;
     }
 
     [instance.cardinalSession configure:cardinalConfiguration];

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.m
@@ -60,6 +60,17 @@
         cardinalEnvironment = CardinalSessionEnvironmentProduction;
     }
     cardinalConfiguration.deploymentEnvironment = cardinalEnvironment;
+
+    if (request.uiType) {
+        CardinalSessionUIType uiType = [self uiTypeAsCardinalUIType:request];
+        cardinalConfiguration.uiType = uiType;
+    }
+
+    if (request.renderType) {
+        CardinalSessionRenderTypeArray *renderType = [self renderTypeAsCardinalRenderType:request];
+        cardinalConfiguration.renderType = renderType;
+    }
+
     [instance.cardinalSession configure:cardinalConfiguration];
 
     [instance.cardinalSession setupWithJWT:configuration.cardinalAuthenticationJWT
@@ -95,6 +106,39 @@
     if (failureHandler != nil) {
         failureHandler(error);
     }
+}
+
++ (CardinalSessionUIType)uiTypeAsCardinalUIType:(BTThreeDSecureRequest *)request {
+    switch (request.uiType) {
+        case BTThreeDSecureUITypeBoth:
+            return CardinalSessionUITypeBoth;
+
+        case BTThreeDSecureUITypeNative:
+            return CardinalSessionUITypeNative;
+
+        case BTThreeDSecureUITypeHTML:
+            return CardinalSessionUITypeHTML;
+    }
+}
+
++ (CardinalSessionRenderTypeArray *)renderTypeAsCardinalRenderType:(BTThreeDSecureRequest *)request {
+    CardinalSessionRenderTypeArray *renderTypes = [[CardinalSessionRenderTypeArray alloc] init];
+
+    for (NSString *renderType in request.renderType) {
+//        if (renderType == BTThreeDSecureRenderTypeOTP) {
+//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeOTP];
+//        } else if (renderType == BTThreeDSecureRenderTypeHTML) {
+//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeHTML];
+//        } else if (renderType == BTThreeDSecureRenderTypeOOB) {
+//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeOOB];
+//        } else if (renderType == BTThreeDSecureRenderTypeSingleSelect) {
+//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeSingleSelect];
+//        } else if (renderType == BTThreeDSecureRenderTypeMultiSelect) {
+//            [renderTypes arrayByAddingObject:CardinalSessionRenderTypeMultiSelect];
+//        }
+    }
+
+    return renderTypes;
 }
 
 #pragma mark - Cardinal Delegate

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -239,11 +239,16 @@ extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeOOB;
 
 /**
  Optional. The interface types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+
+ Defaults to `BTThreeDSecureUITypeBoth`
  */
 @property (nonatomic, assign) BTThreeDSecureUIType uiType;
 
 /**
  Optional.  List of all the render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+
+ Defaults to `BTThreeDSecureRenderTypeOTP`, `BTThreeDSecureRenderTypeHTML`, `BTThreeDSecureRenderTypeOOB`, `BTThreeDSecureRenderTypeSingleSelect`,
+ `BTThreeDSecureRenderTypeMultiSelect`
 
  - Note: When using `BTThreeDSecureUITypeBoth` or `BTThreeDSecureUITypeHTML`, all `renderType` options must be set.
  When using `BTThreeDSecureUITypeNative`, all `renderType` options except `BTThreeDSecureRenderTypeHTML` must be set.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -247,8 +247,8 @@ extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeOOB;
 /**
  Optional.  List of all the render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
 
- Defaults to `BTThreeDSecureRenderTypeOTP`, `BTThreeDSecureRenderTypeHTML`, `BTThreeDSecureRenderTypeOOB`, `BTThreeDSecureRenderTypeSingleSelect`,
- `BTThreeDSecureRenderTypeMultiSelect`
+ Defaults to `BTThreeDSecureRenderTypeOTP`, `BTThreeDSecureRenderTypeHTML`, `BTThreeDSecureRenderTypeOOB`,
+ `BTThreeDSecureRenderTypeSingleSelect`,`BTThreeDSecureRenderTypeMultiSelect`
 
  - Note: When using `BTThreeDSecureUITypeBoth` or `BTThreeDSecureUITypeHTML`, all `renderType` options must be set.
  When using `BTThreeDSecureUITypeNative`, all `renderType` options except `BTThreeDSecureRenderTypeHTML` must be set.

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -118,22 +118,22 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureUIType) {
     BTThreeDSecureUITypeHTML
 };
 
-typedef NSString *BTThreeDSecureRenderType;
+typedef NSString * BTThreeDSecureRenderType;
 
 /// OTP
-extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeOTP;
+extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeOTP;
 
 /// HTML
-extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeHTML;
+extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeHTML;
 
 /// Single select
-extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeSingleSelect;
+extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeSingleSelect;
 
 /// Multi select
-extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeMultiSelect;
+extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeMultiSelect;
 
 /// OOB
-extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeOOB;
+extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeOOB;
 
 /**
  Used to initialize a 3D Secure payment flow

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -105,6 +105,37 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureRequestedExemptionType) {
 };
 
 /**
+ The interface types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+ */
+typedef NS_ENUM(NSInteger, BTThreeDSecureUIType) {
+    /// Both
+    BTThreeDSecureUITypeBoth,
+
+    /// Native
+    BTThreeDSecureUITypeNative,
+
+    /// HTML
+    BTThreeDSecureUITypeHTML
+};
+
+typedef NSString *BTThreeDSecureRenderType;
+
+/// OTP
+extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeOTP;
+
+/// HTML
+extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeHTML;
+
+/// Single select
+extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeSingleSelect;
+
+/// Multi select
+extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeMultiSelect;
+
+/// OOB
+extern BTThreeDSecureRenderType const BTThreeDSecureRenderTypeOOB;
+
+/**
  Used to initialize a 3D Secure payment flow
  */
 @interface BTThreeDSecureRequest : BTPaymentFlowRequest <BTPaymentFlowRequestDelegate>
@@ -205,6 +236,19 @@ typedef NS_ENUM(NSInteger, BTThreeDSecureRequestedExemptionType) {
  A delegate for receiving information about the ThreeDSecure payment flow.
  */
 @property (nonatomic, nullable, weak) id<BTThreeDSecureRequestDelegate> threeDSecureRequestDelegate;
+
+/**
+ Optional. The interface types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+ */
+@property (nonatomic, assign) BTThreeDSecureUIType uiType;
+
+/**
+ Optional.  List of all the render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+
+ - Note: When using `BTThreeDSecureUITypeBoth` or `BTThreeDSecureUITypeHTML`, all `renderType` options must be set.
+ When using `BTThreeDSecureUITypeNative`, all `renderType` options except `BTThreeDSecureRenderTypeHTML` must be set.
+ */
+@property (nonatomic, copy) NSArray<BTThreeDSecureRenderType> *renderType;
 
 @end
 

--- a/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
+++ b/Sources/BraintreeThreeDSecure/Public/BraintreeThreeDSecure/BTThreeDSecureRequest.h
@@ -253,7 +253,7 @@ extern BTThreeDSecureRenderType BTThreeDSecureRenderTypeOOB;
  - Note: When using `BTThreeDSecureUITypeBoth` or `BTThreeDSecureUITypeHTML`, all `renderType` options must be set.
  When using `BTThreeDSecureUITypeNative`, all `renderType` options except `BTThreeDSecureRenderTypeHTML` must be set.
  */
-@property (nonatomic, copy) NSArray<BTThreeDSecureRenderType> *renderType;
+@property (nonatomic, copy) NSArray<BTThreeDSecureRenderType> *renderTypes;
 
 @end
 


### PR DESCRIPTION
Note: there will be a separate PR for iOS v6 in Swift - this change needs to go in both versions of the SDK.

### Summary of changes

- Add `uiType` to `BTThreeDSecureRequest`
- Add `renderType` to `BTThreeDSecureRequest`
- Set default parameters in Demo app
- **Note:** on iOS we are not currently testing anything set on `CardinalSessionConfiguration` - on Android we wrap Cardinal to allow it to be more testable. These params have been added to the Demo app and tested there, but we should punt on testing Cardinal directly for a later time. 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 