### PR TITLE
Remove Specta dependency

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -91,7 +91,7 @@
 		80CF988529DB64D400D51979 /* BTLocalPaymentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CF988429DB64D400D51979 /* BTLocalPaymentError.swift */; };
 		80D1638729E75CF1001D880E /* BTThreeDSecureClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D1638529E75766001D880E /* BTThreeDSecureClient.swift */; };
 		80E2460F29E492DF00945A1D /* BTLocalPaymentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2460E29E492DF00945A1D /* BTLocalPaymentClient.swift */; };
-		80F4F4DA29F8A70D003EACB1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		80F4F4DA29F8A70D003EACB1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		80F86FF029FC2ED6003297FF /* Encodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F86FEF29FC2ED6003297FF /* Encodable+Dictionary.swift */; };
 		80FF7D1A25881C03001C32EF /* BTThreeDSecureV2UICustomization_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FF7D1925881C03001C32EF /* BTThreeDSecureV2UICustomization_Tests.swift */; };
 		80FF7D9825882669001C32EF /* BTThreeDSecureV2ToolbarCustomization_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FF7D9725882669001C32EF /* BTThreeDSecureV2ToolbarCustomization_Tests.swift */; };
@@ -2610,14 +2610,12 @@
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2656,14 +2654,12 @@
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2725,7 +2721,7 @@
 				BE9FB82D28984ADE00D6FE2F /* BTPaymentMethodNonceParser.swift in Sources */,
 				BED00CAE28A5419900D74AEC /* BTBinData.swift in Sources */,
 				BC17F9BE28D25054004B18CC /* BTGraphQLErrorNode.swift in Sources */,
-				80F4F4DA29F8A70D003EACB1 /* (null) in Sources */,
+				80F4F4DA29F8A70D003EACB1 /* BuildFile in Sources */,
 				800E78C429E0DD5300D1B0FC /* FPTIBatchData.swift in Sources */,
 				57CBBCE628B02FE80037F4EE /* BTAPIHTTP.swift in Sources */,
 				BED00CB028A579D700D74AEC /* BTClientToken.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,6 @@ target 'Demo' do
 end
 
 abstract_target 'Tests' do
-  pod 'Specta'
   pod 'Expecta'
   pod 'OCMock'
   pod 'OHHTTPStubs/Swift'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,6 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - Specta (1.0.7)
   - xcbeautify (0.8.1)
 
 DEPENDENCIES:
@@ -23,7 +22,6 @@ DEPENDENCIES:
   - InAppSettingsKit
   - OCMock
   - OHHTTPStubs/Swift
-  - Specta
   - xcbeautify
 
 SPEC REPOS:
@@ -32,7 +30,6 @@ SPEC REPOS:
     - InAppSettingsKit
     - OCMock
     - OHHTTPStubs
-    - Specta
     - xcbeautify
 
 SPEC CHECKSUMS:
@@ -40,9 +37,8 @@ SPEC CHECKSUMS:
   InAppSettingsKit: 01fb9774c74a11fefc521f29cb2338909e1c2b61
   OCMock: 75fbeaa46a9b11f8c182bbb1d1f7e9a35ccc9955
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   xcbeautify: a3b03e4a38eb1a5766a83a7a3c53915a233572e3
 
-PODFILE CHECKSUM: d13bb859974d75763866520e0313eec1e5f76228
+PODFILE CHECKSUM: 7bd765c4960dac904d148f1363e5621aafe82cce
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Specta
 import OHHTTPStubs
 @testable import BraintreeCore
 
@@ -1017,7 +1016,6 @@ final class BTHTTP_Tests: XCTestCase {
     func testNoopsForANilCompletionBlock() {
         http = BTHTTP(url: URL(string: "stub://stub")!, authorizationFingerprint: "test-authorization-fingerprint")
 
-        setAsyncSpecTimeout(2)
         http?.get("200.json") { body, response, error in
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
                 // no-op


### PR DESCRIPTION
### Summary of changes

- Remove `Specta` from Podfile & project
- Why?
    - We don't need it
    - Want to prepare to move all project dependencies to SPM instead of CocoaPods
- Bump CocoaPods version to 1.12.1 in Podfile.lock

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 