### PR TITLE
Add `.spi.yml` for Swift Package Index docs

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: [Braintree]
+      documentation_targets: [BraintreeAmericanExpress, BraintreeApplePay, BraintreeCard, BraintreeCore, BraintreeDataCollector, BraintreeLocalPayment, BraintreePayPal, BraintreePayPalNativeCheckout, BraintreeSEPADirectDebit, BraintreeThreeDSecure, BraintreeVenmo]

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [Braintree]


### PR DESCRIPTION

### Summary

Braintree iOS is currently accessible via the Swift Package Index (https://swiftpackageindex.com/braintree/braintree_ios). This PR enhances our Swift Package Index experience by supporting it's auto-hosting DocC feature.

### Changes
- Add a `.spi.yml` file
    - [See SPI docs](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/) on how this auto-hosted, auto-generated docs works. It's really neat! We could even have this replace our hosted reference docs entirely 👀. 

### Result

Once merged into `master` our SPI landing site will add this button:
![Screenshot 2023-06-16 at 10 45 42 AM](https://github.com/braintree/braintree_ios/assets/35243507/0e730afc-cff2-4ffe-8f34-19c46cf5ca52)

The hosted docs & new button won't be visible until merged.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 