### PR TITLE
Add `locale` to `BTSEPADirectDebitRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreePayPalNativeCheckout (BETA)
   * Fix bug where setting `userAction` does not update button as expected
+* BraintreeSEPADirectDebit
+  * Add `BTSEPADirectDebitRequest.locale`
 
 ## 6.1.0 (2023-06-22)
 * BraintreeVenmo

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
@@ -26,6 +26,8 @@ import BraintreeCore
     public var merchantAccountID: String?
 
     /// Optional. A locale code to use for creating a mandate.
+    /// See https://developer.paypal.com/reference/locale-codes/ for a list of possible values.
+    /// Locale code should be supplied as a BCP-47 formatted locale code.
     public var locale: String?
 
     /// Initialize a new SEPA Direct Debit request.
@@ -37,6 +39,8 @@ import BraintreeCore
     ///   - billingAddress: Required. The user's billing address.
     ///   - merchantAccountID: Optional. A non-default merchant account to use for tokenization.
     ///   - locale: Optional. A locale code to use for creating a mandate.
+    ///   See https://developer.paypal.com/reference/locale-codes/ for a list of possible values.
+    ///   Locale code should be supplied as a BCP-47 formatted locale code.
     public init(
         accountHolderName: String? = nil,
         iban: String? = nil,

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitRequest.swift
@@ -25,6 +25,9 @@ import BraintreeCore
     /// Optional. A non-default merchant account to use for tokenization.
     public var merchantAccountID: String?
 
+    /// Optional. A locale code to use for creating a mandate.
+    public var locale: String?
+
     /// Initialize a new SEPA Direct Debit request.
     /// - Parameters:
     ///   - accountHolderName:Required. The account holder name.
@@ -33,13 +36,15 @@ import BraintreeCore
     ///   - mandateType: Optional. The `BTSEPADebitMandateType`. If not set, defaults to `.oneOff`
     ///   - billingAddress: Required. The user's billing address.
     ///   - merchantAccountID: Optional. A non-default merchant account to use for tokenization.
+    ///   - locale: Optional. A locale code to use for creating a mandate.
     public init(
         accountHolderName: String? = nil,
         iban: String? = nil,
         customerID: String? = nil,
         mandateType: BTSEPADirectDebitMandateType? = .oneOff,
         billingAddress: BTPostalAddress? = nil,
-        merchantAccountID: String? = nil
+        merchantAccountID: String? = nil,
+        locale: String? = nil
     ) {
         self.accountHolderName = accountHolderName
         self.iban = iban
@@ -47,5 +52,6 @@ import BraintreeCore
         self.mandateType = mandateType
         self.billingAddress = billingAddress
         self.merchantAccountID = merchantAccountID
+        self.locale = locale
     }
 }

--- a/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
@@ -40,7 +40,8 @@ class SEPADirectDebitAPI {
             "sepa_debit": sepaDebitDictionary,
             "merchant_account_id": sepaDirectDebitRequest.merchantAccountID ?? "",
             "cancel_url": BTCoreConstants.callbackURLScheme + "://sepa/cancel",
-            "return_url": BTCoreConstants.callbackURLScheme + "://sepa/success"
+            "return_url": BTCoreConstants.callbackURLScheme + "://sepa/success",
+            "locale": sepaDirectDebitRequest.locale ?? ""
         ]
 
         apiClient.post("v1/sepa_debit", parameters: json) { body, response, error in

--- a/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
@@ -66,6 +66,7 @@ class SEPADirectDebitAPI_Tests: XCTestCase {
         sepaDirectDebitRequest.customerID = "fake-customer-id"
         sepaDirectDebitRequest.billingAddress = billingAddress
         sepaDirectDebitRequest.merchantAccountID = "fake-account-id"
+        sepaDirectDebitRequest.locale = "fr-FR"
         
         let api = SEPADirectDebitAPI(apiClient: mockAPIClient)
         api.createMandate(sepaDirectDebitRequest: sepaDirectDebitRequest) { _, _ in }
@@ -74,6 +75,7 @@ class SEPADirectDebitAPI_Tests: XCTestCase {
         XCTAssertEqual(lastPOSTParameters["merchant_account_id"] as! String, "fake-account-id")
         XCTAssertEqual(lastPOSTParameters["cancel_url"] as! String, "sdk.ios.braintree://sepa/cancel")
         XCTAssertEqual(lastPOSTParameters["return_url"] as! String, "sdk.ios.braintree://sepa/success")
+        XCTAssertEqual(lastPOSTParameters["locale"] as! String, "fr-FR")
         
         let sepaDebit = lastPOSTParameters["sepa_debit"] as! [String: Any]
         XCTAssertEqual(sepaDebit["merchant_or_partner_customer_id"] as! String, "fake-customer-id")


### PR DESCRIPTION
### Summary of changes

- Add the ability to set a locale when creating a SEPA direct debit request

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 