### PR TITLE
Fix PayPal Account Nonce Missing Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * BraintreeSEPADirectDebit
   * Add `BTSEPADirectDebitRequest.locale`
 * BraintreePayPal
-  * Fix bug where `BTPayPalAccountNonce` values were not being returned as expected
+  * Fix bug where `BTPayPalAccountNonce` values were not being returned as expected (fixes #1063)
 
 ## 6.1.0 (2023-06-22)
 * BraintreeVenmo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Fix bug where setting `userAction` does not update button as expected
 * BraintreeSEPADirectDebit
   * Add `BTSEPADirectDebitRequest.locale`
+* BraintreePayPal
+  * Fix bug where `BTPayPalAccountNonce` values were not being returned as expected
 
 ## 6.1.0 (2023-06-22)
 * BraintreeVenmo

--- a/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
+++ b/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
@@ -48,7 +48,7 @@ import BraintreeCore
         self.phone = payerInfo["phone"].asString()
         self.billingAddress = payerInfo["billingAddress"].asAddress()
         self.shippingAddress = payerInfo["shippingAddress"].asAddress() ?? payerInfo["accountAddress"].asAddress()
-        self.clientMetadataID = payerInfo["correlationId"].asString()
+        self.clientMetadataID = details["correlationId"].asString()
         self.payerID = payerInfo["payerId"].asString()
         self.creditFinancing = details["creditFinancingOffered"].asPayPalCreditFinancing()
         super.init(nonce: nonce, type: "PayPal", isDefault: json["default"].isTrue)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -155,9 +155,8 @@ import BraintreeDataCollector
             return
         }
         
-        var parameters: [String: Any] = ["paypal_account": response]
-        var account: [String: Any] = [:]
-        
+        var account: [String: Any] = response
+
         if paymentType == .checkout {
             account["options"] = ["validate": false]
             if let request  = payPalRequest as? BTPayPalCheckoutRequest {
@@ -170,12 +169,10 @@ import BraintreeDataCollector
         }
         
         if let payPalRequest, let merchantAccountID = payPalRequest.merchantAccountID {
-            parameters["merchant_account_id"] = merchantAccountID
+            account["merchant_account_id"] = merchantAccountID
         }
-        
-        if !account.isEmpty {
-            parameters["paypal_account"] = account
-        }
+
+        var parameters: [String: Any] = ["paypal_account": account]
         
         let metadata = apiClient.metadata
         metadata.source = .payPalBrowser

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -167,13 +167,13 @@ import BraintreeDataCollector
         if let clientMetadataID {
             account["correlation_id"] = clientMetadataID
         }
-        
-        if let payPalRequest, let merchantAccountID = payPalRequest.merchantAccountID {
-            account["merchant_account_id"] = merchantAccountID
-        }
 
         var parameters: [String: Any] = ["paypal_account": account]
         
+        if let payPalRequest, let merchantAccountID = payPalRequest.merchantAccountID {
+            parameters["merchant_account_id"] = merchantAccountID
+        }
+
         let metadata = apiClient.metadata
         metadata.source = .payPalBrowser
         


### PR DESCRIPTION
### Summary of changes

- Fixes #1063
- We were not constructing the `parameters` dictionary as expected, which resulted in missing account fields in the body we were getting back from the API

Account fields are now populating as expected when returned by the API:
![Screenshot 2023-06-27 at 9 20 41 AM](https://github.com/braintree/braintree_ios/assets/20733831/71bd5537-e262-4b86-971a-5febd5a6413d)

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 