### PR TITLE
Nxo fix fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPalNativeCheckout (BETA)
+  * Fixed a bug where post vaulting FirstName, LastName and email are null but a nonce is generated.
+
 ## 6.0.0 (2023-06-20)
 * The Braintree SDK is now written in Swift
 * Breaking Changes

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
@@ -42,7 +42,7 @@ import PayPalCheckout
 
     // MARK: - Initializer
 
-  init?(json: BTJSON, approvalData: ApprovalData) {
+    init?(json: BTJSON, approvalData: ApprovalData? = nil) {
         let paypalAccounts = json["paypalAccounts"][0]
         guard let nonce = paypalAccounts["nonce"].asString() else {
             return nil
@@ -53,11 +53,11 @@ import PayPalCheckout
         let payerInfo = details["payerInfo"]
 
         clientMetadataID = details["correlationId"].asString()
-        email = payerInfo["email"].asString() ?? details["email"].asString() ?? approvalData.buyer?.email
-        firstName = payerInfo["firstName"].asString() ?? approvalData.buyer?.givenName
-        lastName = payerInfo["lastName"].asString() ?? approvalData.buyer?.familyName
+        email = payerInfo["email"].asString() ?? details["email"].asString() ?? approvalData?.buyer?.email
+        firstName = payerInfo["firstName"].asString() ?? approvalData?.buyer?.givenName
+        lastName = payerInfo["lastName"].asString() ?? approvalData?.buyer?.familyName
         phone = payerInfo["phone"].asString()
-        payerID = payerInfo["payerId"].asString() ?? approvalData.buyer?.userId
+        payerID = payerInfo["payerId"].asString() ?? approvalData?.buyer?.userId
 
         let shippingAddressJSON = details["payerInfo"]["shippingAddress"].asAddress()
         let accountAddressJSON =  details["payerInfo"]["accountAddress"].asAddress()

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
@@ -8,6 +8,8 @@ import BraintreeCore
 import BraintreePayPal
 #endif
 
+import PayPalCheckout
+
 /// Contains information about a PayPal payment method.
 @objcMembers public class BTPayPalNativeCheckoutAccountNonce: BTPaymentMethodNonce {
 
@@ -40,7 +42,7 @@ import BraintreePayPal
 
     // MARK: - Initializer
 
-    init?(json: BTJSON) {
+  init?(json: BTJSON, approvalData: ApprovalData) {
         let paypalAccounts = json["paypalAccounts"][0]
         guard let nonce = paypalAccounts["nonce"].asString() else {
             return nil
@@ -51,11 +53,11 @@ import BraintreePayPal
         let payerInfo = details["payerInfo"]
 
         clientMetadataID = details["correlationId"].asString()
-        email = payerInfo["email"].asString() ?? details["email"].asString()
-        firstName = payerInfo["firstName"].asString()
-        lastName = payerInfo["lastName"].asString()
+        email = payerInfo["email"].asString() ?? details["email"].asString() ?? approvalData.buyer?.email
+        firstName = payerInfo["firstName"].asString() ?? approvalData.buyer?.givenName
+        lastName = payerInfo["lastName"].asString() ?? approvalData.buyer?.familyName
         phone = payerInfo["phone"].asString()
-        payerID = payerInfo["payerId"].asString()
+        payerID = payerInfo["payerId"].asString() ?? approvalData.buyer?.userId
 
         let shippingAddressJSON = details["payerInfo"]["shippingAddress"].asAddress()
         let accountAddressJSON =  details["payerInfo"]["accountAddress"].asAddress()

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -170,7 +170,7 @@ import PayPalCheckout
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: apiClient)
-      tokenizationClient.tokenize(request: request, approvalData: approval.data) { result in
+        tokenizationClient.tokenize(request: request, approvalData: approval.data) { result in
             switch result {
             case .success(let nonce):
                 self.notifySuccess(with: nonce, completion: completion)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -170,7 +170,7 @@ import PayPalCheckout
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: apiClient)
-        tokenizationClient.tokenize(request: request, returnURL: approval.data.returnURL!.absoluteString) { result in
+      tokenizationClient.tokenize(request: request, approvalData: approval.data) { result in
             switch result {
             case .success(let nonce):
                 self.notifySuccess(with: nonce, completion: completion)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -18,7 +18,7 @@ class BTPayPalNativeTokenizationClient {
 
     func tokenize(
         request: BTPayPalRequest,
-        returnURL: String,
+        approvalData: ApprovalData,
         completion: @escaping (Result<BTPayPalNativeCheckoutAccountNonce, BTPayPalNativeCheckoutError>) -> Void)
     {
 
@@ -29,7 +29,7 @@ class BTPayPalNativeTokenizationClient {
 
         apiClient.post(
             "v1/payment_methods/paypal_accounts",
-            parameters: tokenizationRequest.parameters(returnURL: returnURL)
+            parameters: tokenizationRequest.parameters(returnURL: approvalData.returnURL!.absoluteString)
         ) { body, _, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeCheckoutError.invalidJSONResponse
@@ -37,7 +37,7 @@ class BTPayPalNativeTokenizationClient {
                 return
             }
 
-            guard let accountNonce = BTPayPalNativeCheckoutAccountNonce(json: json) else {
+            guard let accountNonce = BTPayPalNativeCheckoutAccountNonce(json: json, approvalData: approvalData) else {
                 completion(.failure(.parsingTokenizationResultFailed))
                 return
             }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -18,7 +18,7 @@ class BTPayPalNativeTokenizationClient {
 
     func tokenize(
         request: BTPayPalRequest,
-        approvalData: ApprovalData,
+        approvalData: ApprovalData? = nil,
         completion: @escaping (Result<BTPayPalNativeCheckoutAccountNonce, BTPayPalNativeCheckoutError>) -> Void)
     {
 
@@ -29,7 +29,7 @@ class BTPayPalNativeTokenizationClient {
 
         apiClient.post(
             "v1/payment_methods/paypal_accounts",
-            parameters: tokenizationRequest.parameters(returnURL: approvalData.returnURL!.absoluteString)
+            parameters: tokenizationRequest.parameters(returnURL: approvalData?.returnURL?.absoluteString)
         ) { body, _, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeCheckoutError.invalidJSONResponse

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeTokenizationClient_Tests.swift
@@ -33,7 +33,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
         // a successful response is vended through the completion handler
         // We don't need to use `waitForExpectations` here because the mock will vend a response
         // synchronously
-        tokenizationClient.tokenize(request: BTPayPalNativeCheckoutRequest(amount: "1"), returnURL: "a-fake-return-url") { result in
+        tokenizationClient.tokenize(request: BTPayPalNativeCheckoutRequest(amount: "1")) { result in
             switch result {
             case .success(let account):
                 XCTAssertEqual(account.nonce, mockNonce)
@@ -64,8 +64,7 @@ class BTPayPalNativeTokenizationClient_Tests: XCTestCase {
         """.data(using: .utf8))
         mockClient.cannedResponseBody = BTJSON(data: responseData)
         let tokenizationClient = BTPayPalNativeTokenizationClient(apiClient: mockClient)
-
-        tokenizationClient.tokenize(request: BTPayPalNativeVaultRequest(), returnURL: "a-fake-return-url") { result in
+        tokenizationClient.tokenize(request: BTPayPalNativeVaultRequest()) { result in
             switch result {
             case .success:
                 XCTFail("A response without a nonce string should be a failure")


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- Some payer info could be missing from the nonce. Use approval data while initializing the checkout account nonce to set payer info like first name, last name and email.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @nmehtapp
