### PR TITLE
Update PayPalCheckout to 1.0.0

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreePayPalNativeCheckout/*.swift"
     s.dependency "Braintree/Core"
     s.dependency "Braintree/PayPal"
-    s.dependency "PayPalCheckout", '0.110.0'
+    s.dependency "PayPalCheckout", '1.0.0'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -6144,7 +6144,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree iOS SDK Release Notes
 
-## Unreleased
+## unreleased
 * BraintreePayPalNativeCheckout (GA)!
   * Update PayPalCheckout from 0.110.0 to 1.0.0. This is our newly released GA version
      * _Note: This module will now be subject to semantic versioning_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* BraintreePayPalNativeCheckout (GA)!
-  * Update PayPalCheckout from 0.110.0 to 1.0.0. This is our newly released GA version
+* BraintreePayPalNativeCheckout (General Availability release)
+  * Update PayPalCheckout from 0.110.0 to 1.0.0. This is our newly released General Availability version
      * _Note: This module will now be subject to semantic versioning_
 
 ## 6.2.0 (2023-06-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## Unreleased
+* BraintreePayPalNativeCheckout (GA)!
+  * Update PayPalCheckout from 0.110.0 to 1.0.0. This is our newly released GA version
+
 ## 6.2.0 (2023-06-27)
 * BraintreePayPalNativeCheckout (BETA)
   * Fix bug where setting `userAction` does not update button as expected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * BraintreePayPalNativeCheckout (GA)!
   * Update PayPalCheckout from 0.110.0 to 1.0.0. This is our newly released GA version
+     * _Note: This module will now be subject to semantic versioning_
 
 ## 6.2.0 (2023-06-27)
 * BraintreePayPalNativeCheckout (BETA)

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-6
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.0-static
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 0.110.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 1.0.0

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -1204,7 +1204,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 0.110.0;
+				version = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.swift
+++ b/Package.swift
@@ -90,8 +90,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PayPalCheckout",
-            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/0.110.0/PayPalCheckout.xcframework.zip",
-            checksum: "e9895c202b090a7bde5c47685e96aef68b6f334e3f3798a79dd49b32c81fe130"
+            url: "https://github.com/paypal/paypalcheckout-ios/releases/download/1.0.0/PayPalCheckout.xcframework.zip",
+            checksum: "653381b514b6d5de1a85fe80d0085217a732c9de2da6ea0afe61f98295d1b67d"
         ),
         .target(
             name: "BraintreeSEPADirectDebit",


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

This build enables the native flows for buyers in the US and Canada. EU buyers will see a web fallback experience.

The following changes are included in this release:
Ensures return relevant billing information such as First Name, Last Name, and Email in the onApprove callback.
Removed extensions on Foundation types from our public interface.
Deprecated the following order actions:
- Patch
- Capture
- Authorize
- GetDetails
- ExecuteBillingAgreement
- onShippingChangeAction.Patch

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jonathajones 
