### PR TITLE
Un-hide public docs for BTAppContextSwitcher `handleOpenURL` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Expose reference documentation for `BTAppContextSwitcher.handleOpen(_:)` and `BTAppContextSwitcher.handleOpenURL(context:)`
+
 ## 6.2.0 (2023-06-27)
 * BraintreePayPalNativeCheckout (BETA)
   * Fix bug where setting `userAction` does not update button as expected

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -5,27 +5,32 @@ import UIKit
 /// When your app returns from app switch, the app delegate should call  `handleOpenURL` (or `handleOpen` if not using SceneDelegate)
 @objcMembers public class BTAppContextSwitcher: NSObject {
     
+    // MARK: - Public Properties
+    
     /// Singleton for shared instance of `BTAppContextSwitcher`
     public static let sharedInstance = BTAppContextSwitcher()
     
     /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
     /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
     public var returnURLScheme: String = ""
+    
+    // MARK: - Private Properties
+    
     private var appContextSwitchClients = [BTAppContextSwitchClient.Type]()
     
-    /// :nodoc: Determine whether the return URL can be handled.
+    // MARK: - Public Methods
+    
+    /// Determine whether the return URL can be handled.
     /// - Parameters: url the URL you receive in  `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate) when returning to your app
     /// - Returns: `true` when the SDK can process the return URL
-    @_documentation(visibility: private)
     @objc(handleOpenURLContext:)
     public func handleOpenURL(context: UIOpenURLContext) -> Bool {
         handleOpen(context.url)
     }
     
-    /// :nodoc: Complete payment flow after returning from app or browser switch.
+    /// Complete payment flow after returning from app or browser switch.
     /// - Parameter url:  The URL you receive in `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate)
     /// - Returns: `true` when the SDK has handled the URL successfully
-    @_documentation(visibility: private)
     @objc(handleOpenURL:)
     public func handleOpen(_ url: URL) -> Bool {
         for appContextSwitchClient in appContextSwitchClients {


### PR DESCRIPTION
### Summary of changes

- Remove `nodoc` and `@_documentation(visibility: private)` annotations from `BTAppContextSwitcher. handleOpen(_url:)` and `BTAppContextSwitcher.handleOpenURL(context:)`
- These were public in V5 ([see BTAppContextSwitcher.h](https://github.com/braintree/braintree_ios/blob/752a71f2381dbef641c1865c38ce2d88779013b4/Sources/BraintreeCore/Public/BraintreeCore/BTAppContextSwitcher.h#L62-L76))

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
