### PR TITLE
Update `Package.resolved` with Correct NXO Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ SampleApps/CarthageTest/Cartfile.resolved
 .swiftpm
 .build
 SampleApps/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-Braintree.xcworkspace/xcshareddata/swiftpm/
 
 *.pid

--- a/Braintree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Braintree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "paypalcheckout-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/paypal/paypalcheckout-ios",
+      "location" : "https://github.com/paypal/paypalcheckout-ios/",
       "state" : {
-        "revision" : "229f0b8b88970b04d13becd4a8c64e95f5969cab",
-        "version" : "0.110.0"
+        "revision" : "773568fbbffd54f900d6d78be7793ae1871d3b35",
+        "version" : "1.0.0"
       }
     }
   ],


### PR DESCRIPTION
### Summary of changes

- The [docs step of the release](https://github.com/braintree/braintree_ios/actions/runs/5512469326/jobs/10049340682) failed yesterday with the error `Your local changes to the following files would be overwritten by checkout: Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
    - Remove `xcshareddata` from `gitignore` so updates to NXO result in the `Package.resolved` file updating as expected - `xcshareddata` contains target configurations that we want to persist across all users of the target and should be checked in
    - Add missing `IDEWorkspaceChecks.plist`
    - Bump versions in `Package.resolved`

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
