### PR TITLE
Add `BTAppContextSwitcher.setReturnURLScheme` func missing from v5 conversion

### DIFF
--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -42,6 +42,14 @@ import UIKit
         return false
     }
     
+    ///  Sets the return URL scheme for your app.
+    ///
+    ///  This must be configured if your app integrates a payment option that may switch to either ASWebAuthenticationSession or to another app to finish the payment authorization workflow.
+    /// - Parameter scheme: The return URL scheme
+    public static func setReturnURLScheme(_ scheme: String) {
+        sharedInstance.returnURLScheme = scheme
+    }
+    
     /// Registers a class `Type` that can handle a return from app context switch with a static method.
     /// - Parameter client: A class `Type` that implements `BTAppContextSwitchClient`, the methods of which will be invoked statically on the class.
     @objc(registerAppContextSwitchClient:)

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -4,11 +4,6 @@ import XCTest
 class BTAppContextSwitcher_Tests: XCTestCase {
     var appSwitch = BTAppContextSwitcher.sharedInstance
 
-    override func setUp() {
-        super.setUp()
-        appSwitch = BTAppContextSwitcher.sharedInstance
-    }
-
     override func tearDown() {
         MockAppContextSwitchClient.cannedCanHandle = false
         MockAppContextSwitchClient.lastCanHandleURL = nil
@@ -17,7 +12,7 @@ class BTAppContextSwitcher_Tests: XCTestCase {
     }
 
     func testSetReturnURLScheme() {
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "com.some.scheme"
+        BTAppContextSwitcher.setReturnURLScheme("com.some.scheme")
         XCTAssertEqual(appSwitch.returnURLScheme, "com.some.scheme")
     }
 

--- a/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
+++ b/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
@@ -18,7 +18,7 @@ class BTLocalPaymentClient_UnitTests: XCTestCase {
         localPaymentRequest.paymentType = "ideal"
         mockAPIClient = MockAPIClient(authorization: tempClientToken)!
         localPaymentRequest.localPaymentFlowDelegate = mockLocalPaymentRequestDelegate
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "com.my-return-url-scheme"
+        BTAppContextSwitcher.setReturnURLScheme("com.my-return-url-scheme")
     }
     
     func testStartPayment_returnsErrorWhenConfigurationNil() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -35,7 +35,6 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenize_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "", code: 0, userInfo: nil)
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Tokenize fails with error")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -49,7 +48,6 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenVenmoConfigurationDisabled_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "tokenization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -64,7 +62,6 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenVenmoConfigurationMissing_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "tokenization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -94,7 +91,6 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenPaymentMethodUsageSet_createsPaymentContext() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.displayName = "app-display-name"
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -115,7 +111,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenDisplayNameNotSet_createsPaymentContextWithoutDisplayName() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -146,7 +141,6 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.collectCustomerBillingAddress = true
         venmoRequest.collectCustomerShippingAddress = true
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -173,7 +167,6 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.collectCustomerBillingAddress = true
         venmoRequest.collectCustomerShippingAddress = true
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -200,7 +193,6 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoRequest.subTotalAmount = "9"
         venmoRequest.totalAmount = "9"
         venmoRequest.lineItems = [BTVenmoLineItem(quantity: 1, unitAmount: "9", name: "name", kind: .debit)]
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -242,7 +234,6 @@ class BTVenmoClient_Tests: XCTestCase {
     
     func testTokenize_withoutLineItems_createsPaymentContextWithoutTransactionDetails() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -262,7 +253,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_opensVenmoURLWithPaymentContextID() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -289,7 +279,6 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseBody = BTJSON(value: ["random":["lady_gaga":"poker_face"]])
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -311,7 +300,6 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseError = NSError(domain: "Venmo Error", code: 100, userInfo: nil)
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -331,7 +319,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenVenmoIsEnabledInControlPanelAndConfiguredCorrectly_opensVenmoURLWithParams() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -354,7 +341,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenReturnURLContainsPaymentContextID_getsResultFromPaymentContext() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -382,7 +368,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenReturnURLContainsPaymentContextID_andFetchPaymentContextFails_returnsError() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -404,7 +389,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenUsingTokenizationKeyAndAppSwitchSucceeds_tokenizesVenmoAccount() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -430,7 +414,6 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.token(withVersion: 2))
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -453,7 +436,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenAppSwitchFails_callsBackWithError() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -471,7 +453,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_vaultTrue_setsShouldVaultProperty() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -490,7 +471,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_vaultFalse_setsVaultToFalse() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -511,7 +491,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -554,7 +533,6 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
 
@@ -596,7 +574,6 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
 
@@ -619,7 +596,6 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -634,7 +610,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testAuthorizeAccountWithProfileID_withNilProfileID_usesDefaultProfileIDAndAccessTokenFromConfiguration() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -649,7 +624,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testAuthorizeAccountWithProfileID_withProfileID_usesProfileIDToAppSwitch() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -680,7 +654,6 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.bundle = FakeBundle()
 
         mockAPIClient.cannedConfigurationResponseBody = nil
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         do {
             let _ = try await venmoClient.tokenize(venmoRequest)
@@ -695,7 +668,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenVenmoURL_returnsTrue() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         fakeApplication.cannedCanOpenURL = false
         fakeApplication.canOpenURLWhitelist.append(URL(string: "com.venmo.touch.v2://x-callback-url/path")!)
@@ -706,7 +678,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testIsiOSAppSwitchAvailable_whenApplicationCantOpenVenmoURL_returnsFalse() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         fakeApplication.cannedCanOpenURL = false
         venmoClient.application = fakeApplication
@@ -739,8 +710,6 @@ class BTVenmoClient_Tests: XCTestCase {
     func testAuthorizeAccountWithTokenizationKey_vaultTrue_willNotAttemptToVault() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
 
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
-
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -770,7 +739,6 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testGotoVenmoInAppStore_opensVenmoAppStoreURL_andSendsAnalyticsEvent() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -28,12 +28,14 @@ class BTVenmoClient_Tests: XCTestCase {
                 ]
             ]
         ])
+        
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
     }
 
     func testTokenize_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "", code: 0, userInfo: nil)
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Tokenize fails with error")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -47,7 +49,7 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenVenmoConfigurationDisabled_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "tokenization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -62,7 +64,7 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenVenmoConfigurationMissing_callsBackWithError() {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String: Any?])
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "tokenization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -76,7 +78,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenReturnURLSchemeIsNil_andCallsBackWithError() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = ""
+        BTAppContextSwitcher.setReturnURLScheme("")
         
         let expectation = expectation(description: "authorization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -92,7 +94,7 @@ class BTVenmoClient_Tests: XCTestCase {
     func testTokenizeVenmoAccount_whenPaymentMethodUsageSet_createsPaymentContext() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.displayName = "app-display-name"
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -113,7 +115,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenDisplayNameNotSet_createsPaymentContextWithoutDisplayName() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -144,7 +146,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.collectCustomerBillingAddress = true
         venmoRequest.collectCustomerShippingAddress = true
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -171,7 +173,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.collectCustomerBillingAddress = true
         venmoRequest.collectCustomerShippingAddress = true
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -198,7 +200,7 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoRequest.subTotalAmount = "9"
         venmoRequest.totalAmount = "9"
         venmoRequest.lineItems = [BTVenmoLineItem(quantity: 1, unitAmount: "9", name: "name", kind: .debit)]
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -240,7 +242,7 @@ class BTVenmoClient_Tests: XCTestCase {
     
     func testTokenize_withoutLineItems_createsPaymentContextWithoutTransactionDetails() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -260,7 +262,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_opensVenmoURLWithPaymentContextID() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -287,7 +289,7 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseBody = BTJSON(value: ["random":["lady_gaga":"poker_face"]])
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -309,7 +311,7 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseError = NSError(domain: "Venmo Error", code: 100, userInfo: nil)
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -329,7 +331,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenVenmoIsEnabledInControlPanelAndConfiguredCorrectly_opensVenmoURLWithParams() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -352,7 +354,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenReturnURLContainsPaymentContextID_getsResultFromPaymentContext() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -380,7 +382,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenReturnURLContainsPaymentContextID_andFetchPaymentContextFails_returnsError() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -402,7 +404,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenUsingTokenizationKeyAndAppSwitchSucceeds_tokenizesVenmoAccount() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -428,7 +430,7 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.tokenizationKey = nil
         mockAPIClient.clientToken = try! BTClientToken(clientToken: TestClientTokenFactory.token(withVersion: 2))
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -451,7 +453,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_whenAppSwitchFails_callsBackWithError() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -469,7 +471,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_vaultTrue_setsShouldVaultProperty() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
 
@@ -488,7 +490,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testTokenizeVenmoAccount_vaultFalse_setsVaultToFalse() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -509,7 +511,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
         
@@ -552,7 +554,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
 
@@ -594,7 +596,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
 
@@ -617,7 +619,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         let expectation = expectation(description: "Callback invoked")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
@@ -632,7 +634,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testAuthorizeAccountWithProfileID_withNilProfileID_usesDefaultProfileIDAndAccessTokenFromConfiguration() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -647,7 +649,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testAuthorizeAccountWithProfileID_withProfileID_usesProfileIDToAppSwitch() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()
@@ -678,7 +680,7 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.bundle = FakeBundle()
 
         mockAPIClient.cannedConfigurationResponseBody = nil
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         do {
             let _ = try await venmoClient.tokenize(venmoRequest)
@@ -693,7 +695,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenVenmoURL_returnsTrue() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         fakeApplication.cannedCanOpenURL = false
         fakeApplication.canOpenURLWhitelist.append(URL(string: "com.venmo.touch.v2://x-callback-url/path")!)
@@ -704,7 +706,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testIsiOSAppSwitchAvailable_whenApplicationCantOpenVenmoURL_returnsFalse() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         fakeApplication.cannedCanOpenURL = false
         venmoClient.application = fakeApplication
@@ -737,7 +739,7 @@ class BTVenmoClient_Tests: XCTestCase {
     func testAuthorizeAccountWithTokenizationKey_vaultTrue_willNotAttemptToVault() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
 
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
 
         venmoClient.application = FakeApplication()
         venmoClient.bundle = FakeBundle()
@@ -768,7 +770,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     func testGotoVenmoInAppStore_opensVenmoAppStoreURL_andSendsAnalyticsEvent() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+        BTAppContextSwitcher.setReturnURLScheme("scheme")
         let fakeApplication = FakeApplication()
         venmoClient.application = fakeApplication
         venmoClient.bundle = FakeBundle()


### PR DESCRIPTION
### Summary

We got an [inbound](https://github.com/braintree/braintree_ios/discussions/1070) about this function missing when using our V6 SDK from a Swift app

### Changes
- [Add `setReturnURLScheme` func](https://github.com/braintree/braintree_ios/blob/752a71f2381dbef641c1865c38ce2d88779013b4/Sources/BraintreeCore/Public/BraintreeCore/BTAppContextSwitcher.h#L52-L60), like we had in V5
- Cleanup tests to use this setter over accessing `sharedInstance` directly

### Discussion

What used to be static in V5 (which is all of the public methods on [BTAppContextSwitcher](https://github.com/braintree/braintree_ios/blob/5.x/Sources/BraintreeCore/Public/BraintreeCore/BTAppContextSwitcher.h)) are class methods in V6. So currently in V6, merchants need to call these functions like this: `BTAppContextSwitcher.sharedInstance().handleOpenURL(context: UIOpenURLContext)` or `BTAppContextSwitcher.sharedInstance.handleOpenURL(URL)`.

I am guessing this was not intentional, since it isn't capture in our migration guide?

IMO merchants should not have access to `sharedInstance` and all methods on `BTAppContextSwitcher` should be static.

If folks agree, we'll have to decide how we want to proceed. A few options:
- Treat this as a "bug fix" and hide `sharedInstance` & convert methods back to static (most generous)
- Deprecate class methods & `sharedInstance` property + add new static methods that merchants should use

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
