### PR TITLE
Add Additional Venmo Error Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeVenmo
+  * Add additional error parsing for Venmo errors
+
 ## 6.4.0 (2023-07-18)
 * Expose reference documentation for `BTAppContextSwitcher.handleOpen(_:)` and `BTAppContextSwitcher.handleOpenURL(context:)`
 * Fixed a bug to return `firstName`, `lastName`, `email`, and `payerID` on `BTPayPalNativeCheckoutAccountNonce` when available.

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -170,10 +170,13 @@ class BTGraphQLHTTP: BTHTTP {
                 errorBody["error"] = ["message": message]
             }
             error = .clientError(errorBody)
-        } else {
-            statusCode = body["extensions"].asDictionary() != nil ? 403 : 500
-            let errorMessage = body["extensions"].asDictionary() != nil ? errorJSON["message"].asString() : "An unexpected error occurred"
+        } else if body["extensions"].asDictionary() != nil, let errorMessage = errorJSON["message"].asString() {
+            statusCode = 403
             errorBody["error"] = ["message": errorMessage]
+            error = .clientError(errorBody)
+        } else {
+            statusCode = 500
+            errorBody["error"] = ["message": "An unexpected error occurred"]
             error = .serverError(errorBody)
         }
         

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -159,12 +159,11 @@ class BTGraphQLHTTP: BTHTTP {
         var error: BTHTTPError = .unknown
         var errorBody: [String: Any] = [:]
 
-        if let errorType = errorType, errorType == "user_error" {
+        if let errorType, errorType == "user_error" {
             statusCode = 422
             errorBody = parseGraphQLError(fromJSON: body)
             error = .clientError(errorBody)
-
-        } else if let errorType = errorType, errorType == "developer_error" {
+        } else if let errorType, errorType == "developer_error" {
             statusCode = 403
 
             if let message = errorJSON["message"].asString() {
@@ -172,8 +171,9 @@ class BTGraphQLHTTP: BTHTTP {
             }
             error = .clientError(errorBody)
         } else {
-            statusCode = 500
-            errorBody["error"] = ["message": "An unexpected error occurred"]
+            statusCode = body["extensions"].asDictionary() != nil ? 403 : 500
+            let errorMessage = body["extensions"].asDictionary() != nil ? errorJSON["message"].asString() : "An unexpected error occurred"
+            errorBody["error"] = ["message": errorMessage]
             error = .serverError(errorBody)
         }
         


### PR DESCRIPTION
### Summary of changes

- The errors returned from custom actions for Venmo is slightly different than the GraphQL errors we are parsing for
    - Updated to check extensions ([similar to Android](https://github.com/braintree/braintree_android/blob/cde19fad7946aceb67da20557b647eab840bbb2e/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeGraphQLResponseParser.kt#L29-L37)) to parse these errors as expected when present and return a helpful message to the merchant
    - Add unit test for this additional case

| Before | After |
|-----|-----|
|![Simulator Screenshot - iPhone 14 - 2023-07-21 at 11 24 16](https://github.com/braintree/braintree_ios/assets/20733831/3630d703-978c-4798-a316-e006a62c1597)|![Simulator Screenshot - iPhone 14 - 2023-07-21 at 10 01 58](https://github.com/braintree/braintree_ios/assets/20733831/59b26463-2883-4137-a0c5-874a2e7d60ed)|

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
