### PR TITLE
update DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,9 +13,6 @@ Each module has a corresponding unit test target. These can be run individually,
 To run the tests:
 1. Fetch test dependencies
     * `pod install`
-1. Fetch PayPal Checkout SPM package
-    * `swift package resolve`
-    * **OR** via the Xcode UI "File" > "Packages" > "Resolve Package Versions"
 1. Run tests
     * `xcodebuild test -workspace Braintree.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 14'`
     * **OR** via the Xcode UI by selecting the `UnitTests` scheme + `⌘U`
@@ -23,37 +20,6 @@ To run the tests:
 _Note:_ Running the `UI` and `IntegrationTests` schemes follows the same steps as above, just replacing the `UnitTests` scheme name in step 3.
 
 ## Importing Header Files
-
-To maintain support for CocoaPods, Swift Package Manager, and Carthage, our Objective-C import statements need specific attention.
-
-While SPM, Carthage, and manual integrations use the same import style (`#import <BraintreeCore/BraintreeCore.h>`), CocoaPods requires a different syntax (`#import <Braintree/BraintreeCore.h>`). This is because CocoaPods creates a single Braintree framework out of the subspecs the merchant includes, whereas SPM, Carthage, and manual integrations treat each module as a separate framework, i.e., BraintreeCore, BraintreeCard, etc.
-
-Public headers for each module must live in the directory `Public/<MODULE_NAME>`. This allows SPM to use the same import syntax as Carthage (e.g., `<BraintreeCore/BraintreCore.h>`).
-
-We use if-else preprocessor directives to satisfy each dependency manager. See the below example for importing a **public header file**.
-
-```objc
-#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
-#import <Braintree/BraintreeCore.h>
-#else // SPM or Carthage
-#import <BraintreeCore/BraintreeCore.h>
-#endif
-```
-
-### Importing internal headers
-
-In general, we avoid importing **internal headers from other modules**, but occasionally it's necessary. See the below example for importing an internal header file from another module:
-```objc
-#if __has_include(<Braintree/BraintreeAmericanExpress.h>) // CocoaPods
-#import <Braintree/BTAPIClient_Internal.h>
-
-#elif SWIFT_PACKAGE // SPM
-#import "../BraintreeCore/BTAPIClient_Internal.h"
-
-#else // Carthage
-#import <BraintreeCore/BTAPIClient_Internal.h>
-#endif
-```
 
 ### Importing a Swift module into Obj-C
 
@@ -72,13 +38,13 @@ To import a Braintree framework written in **Swift** into an Objective-C file, u
 /* Use @import for SPM support
  * See https://forums.swift.org/t/using-a-swift-package-in-a-mixed-swift-and-objective-c-project/27348
  */
-@import PayPalDataCollector;
+@import BraintreeCore;
 
 #else                                            // Carthage
-#import <PayPalDataCollector/PayPalDataCollector-Swift.h>
+#import <BraintreeCore/BraintreeCore-Swift.h>
 #endif
 ```
 
 ## Releasing
 
-Refer to the `ios/releases` section in the SDK Knowledge Repo.
+Refer to the `ios/releases` section in the internal SDK Knowledge Repo.


### PR DESCRIPTION
### Summary of changes

- Remove SPM step from running tests - no longer needed since NXO is a binary dependency
- Remove Obj-C header file import steps 🥳 

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
