### PR TITLE
Send `live` over `production` in FPTI payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeVenmo
   * Add additional error parsing for Venmo errors
+* BraintreeCore
+  * Send `live` instead of `production` for the `merchant_sdk_env` tag to PayPal's analytics service (FPTI)
 
 ## 6.4.0 (2023-07-18)
 * Expose reference documentation for `BTAppContextSwitcher.handleOpen(_:)` and `BTAppContextSwitcher.handleOpenURL(context:)`

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -154,7 +154,7 @@ class BTAnalyticsService: Equatable {
     func createAnalyticsEvent(config: BTConfiguration, sessionID: String) -> Codable {
         let batchMetadata = FPTIBatchData.Metadata(
             authorizationFingerprint: apiClient.clientToken?.authorizationFingerprint,
-            environment: config.environment,
+            environment: config.fptiEnvironment,
             integrationType: apiClient.metadata.integration.stringValue,
             merchantID: config.merchantID,
             sessionID: sessionID,

--- a/Sources/BraintreeCore/BTConfiguration.swift
+++ b/Sources/BraintreeCore/BTConfiguration.swift
@@ -14,6 +14,14 @@ import Foundation
     public var environment: String? {
         json?["environment"].asString()
     }
+    
+    /// The environment name sent to PayPal's FPTI analytics service
+    var fptiEnvironment: String? {
+        if environment == "production" {
+            return "live"
+        }
+        return environment
+    }
 
     /// :nodoc: This initalizer is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     ///  Used to initialize a `BTConfiguration`

--- a/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
@@ -36,9 +36,17 @@ class BTConfiguration_Tests: XCTestCase {
 
     func testEnvironment_returnsEnvironment() {
         let configurationJSON = BTJSON(value: [
-            "environment": "sandbox"
+            "environment": "fake-env"
         ])
         let configuration = BTConfiguration(json: configurationJSON)
-        XCTAssertEqual(configuration.environment, "sandbox")
+        XCTAssertEqual(configuration.environment, "fake-env")
+    }
+    
+    func testFPTIEnvironment_whenProduction_returnsLive() {
+        let configurationJSON = BTJSON(value: [
+            "environment": "production"
+        ])
+        let configuration = BTConfiguration(json: configurationJSON)
+        XCTAssertEqual(configuration.fptiEnvironment, "live")
     }
 }


### PR DESCRIPTION
### Summary
While creating analytics dashboards, we realized that the BT & PPCP SDKs differ in the values we are sending for the `merchant_sdk_env` key to FPTI. BT Mobile SDKs are sending: production & sandbox; PPCP mobile SDKs are sending live & sandbox. 

To easily look at our analytics cross products, we want to keep things the same as much as possible.

### Changes

- Send `live` instead of `production` in the FPTI payload
- This makes more sense to me than sending `production` from the PPCP SDKs for a few reasons
    - In FPTI, "live" is the accepted name for the FPTI Data Service's "live" environment
    - Alignment with existing PP products already on FPTI (PP JS, NXO, etc)


### Changes

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
