### PR TITLE
[5.x] Add Venmo Enriched Customer Data to BTVenmoRequest

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 		BE642DAB27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */; };
 		BE9F444427C6C75E00A117D5 /* BTCacheDateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9F444327C6C75E00A117D5 /* BTCacheDateValidator.m */; };
 		BE9F444627C6C78A00A117D5 /* BTCacheDateValidator_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = BE9F444527C6C78A00A117D5 /* BTCacheDateValidator_Internal.h */; };
+		BEB6335D2A7BFD0500FDF4E6 /* BTVenmoLineItem_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB6335C2A7BFD0500FDF4E6 /* BTVenmoLineItem_Tests.swift */; };
 		BEDB820629B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */; };
 		BEE2E4B72900436600C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B62900436600C03FDD /* PayPalCheckout */; };
 		BEE2E4B9290043A200C03FDD /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BEE2E4B8290043A200C03FDD /* PayPalCheckout */; };
@@ -1157,6 +1158,7 @@
 		BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitNonce_Tests.swift; sourceTree = "<group>"; };
 		BE9F444327C6C75E00A117D5 /* BTCacheDateValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTCacheDateValidator.m; sourceTree = "<group>"; };
 		BE9F444527C6C78A00A117D5 /* BTCacheDateValidator_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTCacheDateValidator_Internal.h; sourceTree = "<group>"; };
+		BEB6335C2A7BFD0500FDF4E6 /* BTVenmoLineItem_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoLineItem_Tests.swift; sourceTree = "<group>"; };
 		BEDB820529B13F9500075AF3 /* BTPayPalNativeCheckoutAccountNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalNativeCheckoutAccountNonce_Tests.swift; sourceTree = "<group>"; };
 		BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitClient.swift; sourceTree = "<group>"; };
 		BEF3F17C27CE9EC600072467 /* BraintreeSEPADirectDebit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreeSEPADirectDebit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2213,6 +2215,7 @@
 				428F48E32624C9B700EC8DB4 /* BTVenmoAppSwitchRequestURL_Tests.swift */,
 				4245D668256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift */,
 				A71F7DE61B6180A3005DA1B0 /* BTVenmoDriver_Tests.swift */,
+				BEB6335C2A7BFD0500FDF4E6 /* BTVenmoLineItem_Tests.swift */,
 				4228D8682624E5C3001D2564 /* BTVenmoRequest_Tests.swift */,
 				A948D6F424FAC8F900F4F178 /* Info.plist */,
 			);
@@ -3830,6 +3833,7 @@
 			files = (
 				A977A04324FEC3C9006049AB /* BTPaymentMethodNonceParser_Venmo_Tests.swift in Sources */,
 				A9589DDA24FEA45C00AF4FF7 /* BTConfiguration+Venmo_Tests.swift in Sources */,
+				BEB6335D2A7BFD0500FDF4E6 /* BTVenmoLineItem_Tests.swift in Sources */,
 				4228D8692624E5C3001D2564 /* BTVenmoRequest_Tests.swift in Sources */,
 				428F48E42624C9B700EC8DB4 /* BTVenmoAppSwitchRequestURL_Tests.swift in Sources */,
 				4245D669256C255F00F1A413 /* BTVenmoAppSwitchReturnURL_Tests.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -370,6 +370,8 @@
 		BC4850E32385FB3C005DD925 /* BTPreferredPaymentMethodsResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BC4850E12385FB3C005DD925 /* BTPreferredPaymentMethodsResult.m */; };
 		BE0B163D27E0CC7400868C77 /* CreateMandateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0B163C27E0CC7400868C77 /* CreateMandateResult.swift */; };
 		BE0B163F27E0CD7C00868C77 /* SEPADirectDebitAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0B163E27E0CD7C00868C77 /* SEPADirectDebitAPI.swift */; };
+		BE2E9E192A7AF0470042A240 /* BTVenmoLineItem.h in Headers */ = {isa = PBXBuildFile; fileRef = BE2E9E172A7AF0470042A240 /* BTVenmoLineItem.h */; };
+		BE2E9E1A2A7AF0470042A240 /* BTVenmoLineItem.m in Sources */ = {isa = PBXBuildFile; fileRef = BE2E9E182A7AF0470042A240 /* BTVenmoLineItem.m */; };
 		BE4F788527ECE2BD00FF4C0E /* WebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE6DAB27E28DFF002BE9C8 /* WebAuthenticationSession.swift */; };
 		BE642D7727CEB8C600694A5B /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE12F091B59BE0100EA1BCF /* BraintreeCore.framework */; };
 		BE642D8627D0047800694A5B /* BTSEPADirectDebitRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE642D8527D0047800694A5B /* BTSEPADirectDebitRequest.swift */; };
@@ -1145,6 +1147,8 @@
 		BC6F67D02386EA63009838E9 /* BTPreferredPaymentMethods_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPreferredPaymentMethods_Tests.swift; sourceTree = "<group>"; };
 		BE0B163C27E0CC7400868C77 /* CreateMandateResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMandateResult.swift; sourceTree = "<group>"; };
 		BE0B163E27E0CD7C00868C77 /* SEPADirectDebitAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADirectDebitAPI.swift; sourceTree = "<group>"; };
+		BE2E9E172A7AF0470042A240 /* BTVenmoLineItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTVenmoLineItem.h; sourceTree = "<group>"; };
+		BE2E9E182A7AF0470042A240 /* BTVenmoLineItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTVenmoLineItem.m; sourceTree = "<group>"; };
 		BE642D8527D0047800694A5B /* BTSEPADirectDebitRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitRequest.swift; sourceTree = "<group>"; };
 		BE642D8727D0094600694A5B /* BTSEPADirectDebitNonce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitNonce.swift; sourceTree = "<group>"; };
 		BE642D8927D00F1300694A5B /* BTSEPADirectDebitMandateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitMandateType.swift; sourceTree = "<group>"; };
@@ -1703,6 +1707,7 @@
 				A7B1C1451B66D94600ED063C /* BTConfiguration+Venmo.h */,
 				A7F96D061B6043B7005A4A09 /* BTVenmoAccountNonce.h */,
 				A7C889FA1B5F0C00007A0E9C /* BTVenmoDriver.h */,
+				BE2E9E172A7AF0470042A240 /* BTVenmoLineItem.h */,
 				80A79DD425CA04CB00A9E9A2 /* BTVenmoRequest.h */,
 			);
 			path = BraintreeVenmo;
@@ -2070,6 +2075,7 @@
 				A7F96D0D1B604C1C005A4A09 /* BTVenmoAppSwitchReturnURL.m */,
 				A77AA2B51B61936A00217B73 /* BTVenmoDriver_Internal.h */,
 				A7C889FB1B5F0C00007A0E9C /* BTVenmoDriver.m */,
+				BE2E9E182A7AF0470042A240 /* BTVenmoLineItem.m */,
 				4228D83A2624E439001D2564 /* BTVenmoRequest_Internal.h */,
 				80A79DD525CA04CB00A9E9A2 /* BTVenmoRequest.m */,
 				41777D471B8D028C0026F987 /* Public */,
@@ -2456,6 +2462,7 @@
 				A7B1C1471B66D94600ED063C /* BTConfiguration+Venmo.h in Headers */,
 				A77AA2AB1B618CFB00217B73 /* BTVenmoDriver.h in Headers */,
 				A77AA2A81B618CFB00217B73 /* BTVenmoAppSwitchReturnURL.h in Headers */,
+				BE2E9E192A7AF0470042A240 /* BTVenmoLineItem.h in Headers */,
 				A77AA2A61B618CFB00217B73 /* BTVenmoAppSwitchRequestURL.h in Headers */,
 				A77AA2AA1B618CFB00217B73 /* BraintreeVenmo.h in Headers */,
 				03D294FF1BE835C8004F90DA /* BTVenmoAccountNonce_Internal.h in Headers */,
@@ -3669,6 +3676,7 @@
 				A77AA2A71B618CFB00217B73 /* BTVenmoAppSwitchRequestURL.m in Sources */,
 				A77AA2AC1B618CFB00217B73 /* BTVenmoDriver.m in Sources */,
 				A77AA2A91B618CFB00217B73 /* BTVenmoAppSwitchReturnURL.m in Sources */,
+				BE2E9E1A2A7AF0470042A240 /* BTVenmoLineItem.m in Sources */,
 				80A79DD725CA04CB00A9E9A2 /* BTVenmoRequest.m in Sources */,
 				A77AA2AE1B618CFB00217B73 /* BTVenmoAccountNonce.m in Sources */,
 				A7B1C1481B66D94600ED063C /* BTConfiguration+Venmo.m in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 		BC4850E32385FB3C005DD925 /* BTPreferredPaymentMethodsResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BC4850E12385FB3C005DD925 /* BTPreferredPaymentMethodsResult.m */; };
 		BE0B163D27E0CC7400868C77 /* CreateMandateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0B163C27E0CC7400868C77 /* CreateMandateResult.swift */; };
 		BE0B163F27E0CD7C00868C77 /* SEPADirectDebitAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0B163E27E0CD7C00868C77 /* SEPADirectDebitAPI.swift */; };
-		BE2E9E192A7AF0470042A240 /* BTVenmoLineItem.h in Headers */ = {isa = PBXBuildFile; fileRef = BE2E9E172A7AF0470042A240 /* BTVenmoLineItem.h */; };
+		BE2E9E192A7AF0470042A240 /* BTVenmoLineItem.h in Headers */ = {isa = PBXBuildFile; fileRef = BE2E9E172A7AF0470042A240 /* BTVenmoLineItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BE2E9E1A2A7AF0470042A240 /* BTVenmoLineItem.m in Sources */ = {isa = PBXBuildFile; fileRef = BE2E9E182A7AF0470042A240 /* BTVenmoLineItem.m */; };
 		BE4F788527ECE2BD00FF4C0E /* WebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE6DAB27E28DFF002BE9C8 /* WebAuthenticationSession.swift */; };
 		BE642D7727CEB8C600694A5B /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE12F091B59BE0100EA1BCF /* BraintreeCore.framework */; };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeVenmo
+  * Allow merchants to collect enriched customer data if enabled in the Braintree Control Panel
+  * Add the following properties to `BTVenmoRequest`
+    * `collectCustomerBillingAddress`
+    * `collectCustomerShippingAddress`
+    * `totalAmount`
+    * `subTotalAmount`
+    * `discountAmount`
+    * `taxAmount`
+    * `shippingAmount`
+    * `lineItems`
+
 ## 5.22.0 (2023-06-08)
 * Require Xcode 14.1 (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Deprecate 3DS v1. Any attempt to use 3DS v1 will now throw an error. See [Migrating to 3D Secure 2](https://developer.paypal.com/braintree/docs/guides/3d-secure/migration) for more information.

--- a/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
+++ b/Demo/Application/Features/Venmo - Custom Button/BraintreeDemoCustomVenmoButtonViewController.m
@@ -29,6 +29,17 @@
     BTVenmoRequest *venmoRequest = [[BTVenmoRequest alloc] init];
     [venmoRequest setVault:YES];
     [venmoRequest setPaymentMethodUsage:BTVenmoPaymentMethodUsageMultiUse];
+
+    [venmoRequest setCollectCustomerShippingAddress:YES];
+    [venmoRequest setCollectCustomerBillingAddress:YES];
+    [venmoRequest setTotalAmount:@"30"];
+    [venmoRequest setTaxAmount:@"1.1"];
+    [venmoRequest setDiscountAmount:@"1.1"];
+    [venmoRequest setShippingAmount:@"0"];
+    BTVenmoLineItem *lineItem = [[BTVenmoLineItem alloc] initWithQuantity:@1 unitAmount:@"30" name:@"item-1" kind: BTVenmoLineItemKindDebit];
+    [lineItem setUnitTaxAmount:@"1"];
+    [venmoRequest setLineItems:[NSArray arrayWithObject: lineItem]];
+
     [self.venmoDriver tokenizeVenmoAccountWithVenmoRequest:venmoRequest completion:^(BTVenmoAccountNonce * _Nullable venmoAccount, NSError * _Nullable error) {
         if (venmoAccount) {
             self.progressBlock(@"Got a nonce 💎!");

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -69,8 +69,8 @@ static NSString *BraintreeVersion = @"2018-03-06";
 
     if (data == nil) {
         NSError *error = [[NSError alloc] initWithDomain:BTHTTPErrorDomain
-                                                            code:BTHTTPErrorCodeUnknown
-                            userInfo:@{NSLocalizedDescriptionKey: @"An unexpected error occurred with the HTTP request."}];
+                                                    code:BTHTTPErrorCodeUnknown
+                                                userInfo:@{NSLocalizedDescriptionKey: @"An unexpected error occurred with the HTTP request."}];
         [self callCompletionBlock:completionBlock body:nil response:(NSHTTPURLResponse *)response error:error];
         return;
     }
@@ -99,8 +99,13 @@ static NSString *BraintreeVersion = @"2018-03-06";
         for (NSUInteger i = 0; i < errorCount; i++) {
             BTJSON *error = body[@"errors"][i];
             NSArray *inputPath = [error[@"extensions"][@"inputPath"] asStringArray];
-            // Defensive programming
-            if (!inputPath) {
+
+            // TODO: is this right?
+            if ([[errorJSON[@"extensions"][@"errorClass"] asString] isEqual: @"VALIDATION"]) {
+                [self addErrorForInputPath:[inputPath subarrayWithRange:NSMakeRange(1, inputPath.count - 1)]
+                          withGraphQLError:[errorJSON[@"message"] asDictionary]
+                                   toArray:errors];
+            } else { // Defensive programming
                 continue;
             }
             [self addErrorForInputPath:[inputPath subarrayWithRange:NSMakeRange(1, inputPath.count - 1)]
@@ -118,6 +123,10 @@ static NSString *BraintreeVersion = @"2018-03-06";
         if ([errorJSON[@"message"] asString]) {
             errorBody[@"error"] = @{@"message": [errorJSON[@"message"] asString]};
         }
+    } else if ([body[@"extensions"] asDictionary]) {
+        statusCode = 403;
+        errorCode = BTHTTPErrorCodeClientError;
+        errorBody[@"error"] = @{@"message": [errorJSON[@"message"] asString]};
     } else {
         statusCode = 500;
         errorCode = BTHTTPErrorCodeServerError;

--- a/Sources/BraintreeCore/BTGraphQLHTTP.m
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.m
@@ -100,14 +100,13 @@ static NSString *BraintreeVersion = @"2018-03-06";
             BTJSON *error = body[@"errors"][i];
             NSArray *inputPath = [error[@"extensions"][@"inputPath"] asStringArray];
 
-            // TODO: is this right?
-            if ([[errorJSON[@"extensions"][@"errorClass"] asString] isEqual: @"VALIDATION"]) {
-                [self addErrorForInputPath:[inputPath subarrayWithRange:NSMakeRange(1, inputPath.count - 1)]
-                          withGraphQLError:[errorJSON[@"message"] asDictionary]
-                                   toArray:errors];
-            } else { // Defensive programming
-                continue;
+            if (!inputPath) {
+                if ([[errorJSON[@"extensions"][@"errorClass"] asString] isEqual: @"VALIDATION"]) {
+                    errorBody[@"error"] = @{@"message": [errorJSON[@"message"] asString]};
+                }
+                continue; // Defensive programming
             }
+
             [self addErrorForInputPath:[inputPath subarrayWithRange:NSMakeRange(1, inputPath.count - 1)]
                       withGraphQLError:[error asDictionary]
                                toArray:errors];

--- a/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
+++ b/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
@@ -23,7 +23,7 @@
 }
 
 - (BOOL)isVenmoEnrichedCustomerDataEnabled {
-    return [self.json[@"payWithVenmo"][@"enrichedCustomerDataEnabled"] isTrue] ?: FALSE;
+    return [self.json[@"payWithVenmo"][@"enrichedCustomerDataEnabled"] isTrue] ?: NO;
 }
 
 @end

--- a/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
+++ b/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
@@ -22,4 +22,8 @@
     return [self.json[@"payWithVenmo"][@"environment"] asString];
 }
 
+- (BOOL)isVenmoEnrichedCustomerDataEnabled {
+    return [self.json[@"payWithVenmo"][@"enrichedCustomerDataEnabled"] isTrue];
+}
+
 @end

--- a/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
+++ b/Sources/BraintreeVenmo/BTConfiguration+Venmo.m
@@ -23,7 +23,7 @@
 }
 
 - (BOOL)isVenmoEnrichedCustomerDataEnabled {
-    return [self.json[@"payWithVenmo"][@"enrichedCustomerDataEnabled"] isTrue];
+    return [self.json[@"payWithVenmo"][@"enrichedCustomerDataEnabled"] isTrue] ?: FALSE;
 }
 
 @end

--- a/Sources/BraintreeVenmo/BTVenmoAccountNonce.m
+++ b/Sources/BraintreeVenmo/BTVenmoAccountNonce.m
@@ -13,6 +13,8 @@
 @property (nonatomic, readwrite, copy) NSString *lastName;
 @property (nonatomic, readwrite, copy) NSString *phoneNumber;
 @property (nonatomic, readwrite, copy) NSString *username;
+@property (nonatomic, readwrite, copy) BTPostalAddress *billingAddress;
+@property (nonatomic, readwrite, copy) BTPostalAddress *shippingAddress;
 @end
 
 @implementation BTVenmoAccountNonce
@@ -37,6 +39,9 @@
         accountNonce.firstName = [paymentContextJSON[@"data"][@"node"][@"payerInfo"][@"firstName"] asString];
         accountNonce.lastName = [paymentContextJSON[@"data"][@"node"][@"payerInfo"][@"lastName"] asString];
         accountNonce.phoneNumber = [paymentContextJSON[@"data"][@"node"][@"payerInfo"][@"phoneNumber"] asString];
+        accountNonce.shippingAddress = [self.class shippingOrBillingAddressFromJSON:paymentContextJSON[@"data"][@"node"][@"payerInfo"][@"shippingAddress"]];
+        accountNonce.billingAddress = [self.class shippingOrBillingAddressFromJSON:paymentContextJSON[@"data"][@"node"][@"payerInfo"][@"billingAddress"]];
+
     }
 
     return accountNonce;
@@ -46,6 +51,23 @@
     return [[[self class] alloc] initWithPaymentMethodNonce:[venmoAccountJSON[@"nonce"] asString]
                                                    username:[venmoAccountJSON[@"details"][@"username"] asString]
                                                   isDefault:[venmoAccountJSON[@"default"] isTrue]];
+}
+
++ (BTPostalAddress *)shippingOrBillingAddressFromJSON:(BTJSON *)addressJSON {
+    if (!addressJSON.isObject) {
+        return nil;
+    }
+
+    BTPostalAddress *address = [[BTPostalAddress alloc] init];
+    address.recipientName = [addressJSON[@"recipientName"] asString]; // Likely to be nil
+    address.streetAddress = [addressJSON[@"line1"] asString];
+    address.extendedAddress = [addressJSON[@"line2"] asString];
+    address.locality = [addressJSON[@"city"] asString];
+    address.region = [addressJSON[@"state"] asString];
+    address.postalCode = [addressJSON[@"postalCode"] asString];
+    address.countryCodeAlpha2 = [addressJSON[@"countryCode"] asString];
+
+    return address;
 }
 
 @end

--- a/Sources/BraintreeVenmo/BTVenmoAccountNonce.m
+++ b/Sources/BraintreeVenmo/BTVenmoAccountNonce.m
@@ -59,11 +59,11 @@
     }
 
     BTPostalAddress *address = [[BTPostalAddress alloc] init];
-    address.recipientName = [addressJSON[@"recipientName"] asString]; // Likely to be nil
-    address.streetAddress = [addressJSON[@"line1"] asString];
-    address.extendedAddress = [addressJSON[@"line2"] asString];
-    address.locality = [addressJSON[@"city"] asString];
-    address.region = [addressJSON[@"state"] asString];
+    address.recipientName = [addressJSON[@"recipientName"] asString] ?: [addressJSON[@"fullName"] asString]; // Likely to be nil
+    address.streetAddress = [addressJSON[@"line1"] asString] ?: [addressJSON[@"addressLine1"] asString];
+    address.extendedAddress = [addressJSON[@"line2"] asString] ?: [addressJSON[@"addressLine2"] asString];
+    address.locality = [addressJSON[@"city"] asString] ?: [addressJSON[@"adminArea2"] asString];
+    address.region = [addressJSON[@"state"] asString] ?: [addressJSON[@"adminArea1"] asString];
     address.postalCode = [addressJSON[@"postalCode"] asString];
     address.countryCodeAlpha2 = [addressJSON[@"countryCode"] asString];
 

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.m
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.m
@@ -56,5 +56,4 @@
     return [requestParameters copy];
 }
 
-
 @end

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.m
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.m
@@ -1,0 +1,58 @@
+#if __has_include(<Braintree/BraintreeVenmo.h>)
+#import <Braintree/BTVenmoLineItem.h>
+#else
+#import <BraintreeVenmo/BTVenmoLineItem.h>
+#endif
+
+@implementation BTVenmoLineItem
+
+- (instancetype)initWithQuantity:(NSInteger *)quantity
+                      unitAmount:(NSString *)unitAmount
+                            name:(NSString *)name
+                            kind:(BTVenmoLineItemKind)kind {
+    self = [super init];
+    if (self) {
+        _quantity = quantity;
+        _unitAmount = unitAmount;
+        _name = name;
+        _kind = kind;
+    }
+
+    return self;
+}
+
+- (NSDictionary *)requestParameters {
+    NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
+    requestParameters[@"quantity"] = [NSNumber numberWithInteger:*(self.quantity)];
+    requestParameters[@"unit_amount"] = self.unitAmount;
+    requestParameters[@"name"] = self.name;
+
+    NSString *kindString;
+    switch (self.kind) {
+        case BTVenmoLineItemKindDebit:
+            kindString = @"debit";
+            break;
+        case BTVenmoLineItemKindCredit:
+            kindString = @"credit";
+            break;
+    }
+
+    requestParameters[@"kind"] = kindString;
+    if (self.unitTaxAmount) {
+        requestParameters[@"unit_tax_amount"] = self.unitTaxAmount;
+    }
+    if (self.itemDescription) {
+        requestParameters[@"description"] = self.itemDescription;
+    }
+    if (self.productCode) {
+        requestParameters[@"product_code"] = self.productCode;
+    }
+    if (self.url) {
+        requestParameters[@"url"] = self.url.absoluteString;
+    }
+
+    return [requestParameters copy];
+}
+
+
+@end

--- a/Sources/BraintreeVenmo/BTVenmoLineItem.m
+++ b/Sources/BraintreeVenmo/BTVenmoLineItem.m
@@ -6,7 +6,7 @@
 
 @implementation BTVenmoLineItem
 
-- (instancetype)initWithQuantity:(NSInteger *)quantity
+- (instancetype)initWithQuantity:(NSNumber *)quantity
                       unitAmount:(NSString *)unitAmount
                             name:(NSString *)name
                             kind:(BTVenmoLineItemKind)kind {
@@ -23,31 +23,33 @@
 
 - (NSDictionary *)requestParameters {
     NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
-    requestParameters[@"quantity"] = [NSNumber numberWithInteger:*(self.quantity)];
-    requestParameters[@"unit_amount"] = self.unitAmount;
+    requestParameters[@"quantity"] = self.quantity;
+    requestParameters[@"unitAmount"] = self.unitAmount;
     requestParameters[@"name"] = self.name;
 
     NSString *kindString;
+
     switch (self.kind) {
         case BTVenmoLineItemKindDebit:
-            kindString = @"debit";
+            kindString = @"DEBIT";
             break;
         case BTVenmoLineItemKindCredit:
-            kindString = @"credit";
+            kindString = @"CREDIT";
             break;
     }
 
-    requestParameters[@"kind"] = kindString;
+    requestParameters[@"type"] = kindString;
+
     if (self.unitTaxAmount) {
-        requestParameters[@"unit_tax_amount"] = self.unitTaxAmount;
+        requestParameters[@"unitTaxAmount"] = self.unitTaxAmount;
     }
     if (self.itemDescription) {
         requestParameters[@"description"] = self.itemDescription;
     }
     if (self.productCode) {
-        requestParameters[@"product_code"] = self.productCode;
+        requestParameters[@"productCode"] = self.productCode;
     }
-    if (self.url) {
+    if (self.url && self.url != [NSURL URLWithString:@""]) {
         requestParameters[@"url"] = self.url.absoluteString;
     }
 

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTConfiguration+Venmo.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTConfiguration+Venmo.h
@@ -29,4 +29,9 @@
  */
 @property (nonatomic, readonly, strong) NSString *venmoEnvironment;
 
+/**
+ Indicates whether Enriched Customer Data (ECD) is enabled for the Venmo merchant.
+*/
+@property (nonatomic, readonly, assign) BOOL isVenmoEnrichedCustomerDataEnabled;
+
 @end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoAccountNonce.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoAccountNonce.h
@@ -44,4 +44,14 @@
 */
 @property (nonatomic, nullable, readonly, copy) NSString *username;
 
+/**
+ TThe primary billing address associated with the Venmo account
+*/
+@property (nonatomic, nullable, readonly, copy) BTPostalAddress *billingAddress;
+
+/**
+ The primary shipping address associated with the Venmo account
+*/
+@property (nonatomic, nullable, readonly, copy) BTPostalAddress *shippingAddress;
+
 @end

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoDriver.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoDriver.h
@@ -42,6 +42,9 @@ typedef NS_ENUM(NSInteger, BTVenmoDriverErrorType) {
     
     /// Request URL was invalid, configuration may be missing required values
     BTVenmoDriverErrorTypeInvalidRequestURL,
+
+    /// Enriched Customer Data is disabled
+    BTVenmoDriverErrorTypeEnrichedCustomerDataDisabled
 };
 
 /**

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
@@ -76,6 +76,13 @@ typedef NS_ENUM(NSInteger, BTVenmoLineItemKind) {
  */
 - (instancetype)init __attribute__((unavailable("Please use initWithQuantity:unitAmount:name:kind:")));
 
+/**
+ Returns the line item in a dictionary.
+
+ @return A dictionary with the line item information formatted for a request.
+ */
+- (NSDictionary *)requestParameters;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSInteger, BTVenmoLineItemKind) {
 /**
  Number of units of the item purchased. This value must be a whole number and can't be negative or zero.
  */
-@property (nonatomic, readonly) NSInteger *quantity;
+@property (nonatomic, readonly) NSNumber *quantity;
 
 /**
  Per-unit price of the item. Can include up to 2 decimal places. This value can't be negative or zero.
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSInteger, BTVenmoLineItemKind) {
  @param kind Indicates whether the line item is a debit (sale) or credit (refund) to the customer.
  @return A PayPalLineItem.
  */
-- (instancetype)initWithQuantity:(NSInteger *)quantity
+- (instancetype)initWithQuantity:(NSNumber *)quantity
                       unitAmount:(NSString *)unitAmount
                             name:(NSString *)name
                             kind:(BTVenmoLineItemKind)kind;

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoLineItem.h
@@ -1,0 +1,81 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A Venmo line item to be displayed in the Venmo Paysheet.
+ */
+@interface BTVenmoLineItem : NSObject
+
+/**
+ Use this option to specify whether a line item is a debit (sale) or credit (refund) to the customer.
+*/
+typedef NS_ENUM(NSInteger, BTVenmoLineItemKind) {
+    /// Debit
+    BTVenmoLineItemKindDebit = 0,
+    /// Credit
+    BTVenmoLineItemKindCredit = 1,
+};
+
+/**
+ Number of units of the item purchased. This value must be a whole number and can't be negative or zero.
+ */
+@property (nonatomic, readonly) NSInteger *quantity;
+
+/**
+ Per-unit price of the item. Can include up to 2 decimal places. This value can't be negative or zero.
+*/
+@property (nonatomic, nullable, copy) NSString *unitAmount;
+
+/**
+ Item name. Maximum 127 characters.
+*/
+@property (nonatomic, nullable, copy) NSString *name;
+
+/**
+ Indicates whether the line item is a debit (sale) or credit (refund) to the customer.
+*/
+@property (nonatomic, readonly, assign) BTVenmoLineItemKind kind;
+
+/**
+ Optional: Per-unit tax price of the item. Can include up to 2 decimal places. This value can't be negative or zero.
+*/
+@property (nonatomic, nullable, copy) NSString *unitTaxAmount;
+
+/**
+ Optional: Item description. Maximum 127 characters.
+*/
+@property (nonatomic, nullable, copy) NSString *itemDescription;
+
+/**
+ Optional: Product or UPC code for the item. Maximum 127 characters.
+*/
+@property (nonatomic, nullable, copy) NSString *productCode;
+
+/**
+ Optional: The URL to product information.
+*/
+@property (nonatomic, nullable, copy) NSURL *url;
+
+/**
+ Initialize a VenmoLineItem
+
+ @param quantity Number of units of the item purchased. Can include up to 4 decimal places. This value can't be negative or zero.
+ @param unitAmount Per-unit price of the item. Can include up to 4 decimal places. This value can't be negative or zero.
+ @param name Item name. Maximum 127 characters.
+ @param kind Indicates whether the line item is a debit (sale) or credit (refund) to the customer.
+ @return A PayPalLineItem.
+ */
+- (instancetype)initWithQuantity:(NSInteger *)quantity
+                      unitAmount:(NSString *)unitAmount
+                            name:(NSString *)name
+                            kind:(BTVenmoLineItemKind)kind;
+
+/**
+ Base initializer - do not use.
+ */
+- (instancetype)init __attribute__((unavailable("Please use initWithQuantity:unitAmount:name:kind:")));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 *
 * Defaults to false.
 */
-@property (nonatomic) BOOL collectBillingAddress;
+@property (nonatomic) BOOL collectCustomerBillingAddress;
 
 /**
 *
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
 *
 * Defaults to false.
 */
-@property (nonatomic) BOOL collectShippingAddress;
+@property (nonatomic) BOOL collectCustomerShippingAddress;
 
 /**
  * Optional. The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BTVenmoRequest.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+@class BTVenmoLineItem;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -46,6 +48,52 @@ typedef NS_ENUM(NSInteger, BTVenmoPaymentMethodUsage) {
  * Optional. The business name that will be displayed in the Venmo app payment approval screen. Only used by merchants onboarded as PayFast channel partners.
  */
 @property (nonatomic, nullable, copy) NSString *displayName;
+
+/**
+*
+* Whether the customer's billing address should be collected and displayed on the Venmo paysheet.
+*
+* Defaults to false.
+*/
+@property (nonatomic) BOOL collectBillingAddress;
+
+/**
+*
+* Whether the customer's shipping address should be collected and displayed on the Venmo paysheet.
+*
+* Defaults to false.
+*/
+@property (nonatomic) BOOL collectShippingAddress;
+
+/**
+ * Optional. The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
+ */
+@property (nonatomic, nullable, copy) NSString *subTotalAmount;
+
+/**
+ * Optional. The grand total amount on the transaction that should be displayed on the paysheet.
+ */
+@property (nonatomic, nullable, copy) NSString *totalAmount;
+
+/**
+ * Optional. The total discount amount applied on the transaction to be displayed on the paysheet.
+ */
+@property (nonatomic, nullable, copy) NSString *discountAmount;
+
+/**
+ * Optional. The shipping amount for the transaction to be displayed on the paysheet.
+ */
+@property (nonatomic, nullable, copy) NSString *shippingAmount;
+
+/**
+ * Optional. The total tax amount for the transaction to be displayed on the paysheet.
+ */
+@property (nonatomic, nullable, copy) NSString *taxAmount;
+
+/**
+ * Optional. The line items for this transaction. It can include up to 249 line items.
+ */
+@property (nonatomic, nullable) NSArray<BTVenmoLineItem *> *lineItems;
 
 @end
 

--- a/Sources/BraintreeVenmo/Public/BraintreeVenmo/BraintreeVenmo.h
+++ b/Sources/BraintreeVenmo/Public/BraintreeVenmo/BraintreeVenmo.h
@@ -12,10 +12,12 @@ FOUNDATION_EXPORT const unsigned char BraintreeVenmoVersionString[];
 #import <Braintree/BTVenmoDriver.h>
 #import <Braintree/BTVenmoAccountNonce.h>
 #import <Braintree/BTVenmoRequest.h>
+#import <Braintree/BTVenmoLineItem.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>
 #import <BraintreeVenmo/BTConfiguration+Venmo.h>
 #import <BraintreeVenmo/BTVenmoDriver.h>
 #import <BraintreeVenmo/BTVenmoAccountNonce.h>
 #import <BraintreeVenmo/BTVenmoRequest.h>
+#import <BraintreeVenmo/BTVenmoLineItem.h>
 #endif

--- a/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import PassKit
-import BraintreeVenmo
 
 class BTConfiguration_Tests: XCTestCase {
     func testInitWithJSON_setsJSON() {
@@ -39,26 +38,5 @@ class BTConfiguration_Tests: XCTestCase {
         ])
         let configuration = BTConfiguration(json: configurationJSON)
         XCTAssertEqual(configuration.environment, "sandbox")
-    }
-
-    func testVenmoEnrichedCustomerDataEnabled_returnsEcd() {
-        var configurationJSON = BTJSON(value: [
-            "payWithVenmo": ["enrichedCustomerDataEnabled": true]
-        ])
-        var configuration = BTConfiguration(json: configurationJSON)
-
-        XCTAssertTrue(configuration.isVenmoEnrichedCustomerDataEnabled)
-
-        configurationJSON = BTJSON(value: [
-            "payWithVenmo": ["enrichedCustomerDataEnabled": false]
-        ])
-        configuration = BTConfiguration(json: configurationJSON)
-
-        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
-
-        configurationJSON = BTJSON(value: ["payWithVenmo": [:]])
-        configuration = BTConfiguration(json: configurationJSON)
-
-        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTConfiguration_Tests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import PassKit
+import BraintreeVenmo
 
 class BTConfiguration_Tests: XCTestCase {
     func testInitWithJSON_setsJSON() {
@@ -38,5 +39,26 @@ class BTConfiguration_Tests: XCTestCase {
         ])
         let configuration = BTConfiguration(json: configurationJSON)
         XCTAssertEqual(configuration.environment, "sandbox")
+    }
+
+    func testVenmoEnrichedCustomerDataEnabled_returnsEcd() {
+        var configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled": true]
+        ])
+        var configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertTrue(configuration.isVenmoEnrichedCustomerDataEnabled)
+
+        configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled": false]
+        ])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
+
+        configurationJSON = BTJSON(value: ["payWithVenmo": [:]])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -495,6 +495,33 @@
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
+- (void)testErrorResponse_withNoErrorTypeAndContainsExtension_sendsErrorMessage {
+    id stubGraphQLErrorResponse = @{
+                                    @"errors": @[
+                                            @{
+                                                @"message": @"Error message that is helpful",
+                                                @"extensions": @{@"requestId": @"a-fake-request-id"}
+                                                }
+                                            ],
+                                    };
+
+    id expectedErrorBody = @{@"error": @{@"message": @"Error message that is helpful"}};
+
+    [HTTPStubs stubRequestsPassingTest:^BOOL(__unused NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^HTTPStubsResponse *(__unused NSURLRequest *request) {
+        return [HTTPStubsResponse responseWithData:[NSJSONSerialization dataWithJSONObject:stubGraphQLErrorResponse options:NSJSONWritingPrettyPrinted error:NULL] statusCode:200 headers:@{@"Content-Type": @"application/json"}];
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback invoked"];
+    [http POST:@"" completion:^(BTJSON *body, __unused NSHTTPURLResponse *response, __unused NSError *error) {
+        XCTAssertEqualObjects(body.asDictionary, expectedErrorBody);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
 - (void)testNetworkError_returnsError {
     [HTTPStubs stubRequestsPassingTest:^BOOL(__unused NSURLRequest *request) {
         return YES;

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.m
@@ -500,9 +500,9 @@
                                     @"errors": @[
                                             @{
                                                 @"message": @"Error message that is helpful",
-                                                @"extensions": @{@"requestId": @"a-fake-request-id"}
                                                 }
                                             ],
+                                    @"extensions": @{@"requestId": @"a-fake-request-id"}
                                     };
 
     id expectedErrorBody = @{@"error": @{@"message": @"Error message that is helpful"}};

--- a/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import BraintreeVenmo
 
 class BTConfiguration_Venmo_Tests: XCTestCase {
     func testVenmoIsEnabled_whenAccessTokenIsPresent_returnsTrue() {

--- a/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTConfiguration+Venmo_Tests.swift
@@ -36,4 +36,25 @@ class BTConfiguration_Venmo_Tests: XCTestCase {
 
         XCTAssertEqual(configuration.venmoEnvironment, "rockbox")
     }
+
+    func testVenmoEnrichedCustomerDataEnabled_returnsEcd() {
+        var configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled": true]
+        ])
+        var configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertTrue(configuration.isVenmoEnrichedCustomerDataEnabled)
+
+        configurationJSON = BTJSON(value: [
+            "payWithVenmo": ["enrichedCustomerDataEnabled": false]
+        ])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
+
+        configurationJSON = BTJSON(value: ["payWithVenmo": [:]])
+        configuration = BTConfiguration(json: configurationJSON)
+
+        XCTAssertFalse(configuration.isVenmoEnrichedCustomerDataEnabled)
+    }
 }

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
@@ -30,7 +30,25 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
                         "externalId": "venmo-external-id",
                         "firstName": "venmo-first-name",
                         "lastName": "venmo-last-name",
-                        "phoneNumber": "venmo-phone-number"
+                        "phoneNumber": "venmo-phone-number",
+                        "billingAddress": [
+                            "fullName": "Bar Foo",
+                            "addressLine1": "1 Foo Ct",
+                            "addressLine2": "Apt Foo",
+                            "adminArea2": "Barfoo",
+                            "adminArea1": "BF",
+                            "postalCode": "20",
+                            "countryCode": "AU"
+                        ],
+                        "shippingAddress": [
+                            "fullName": "Some Dude",
+                            "addressLine1": "2 Foo Ct",
+                            "addressLine2": "Apt 5",
+                            "adminArea2": "Dudeville",
+                            "adminArea1": "CA",
+                            "postalCode": "30",
+                            "countryCode": "US"
+                        ]
                     ]
                 ]
             ]
@@ -45,5 +63,25 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
         XCTAssertEqual(venmoAccountNonce?.firstName, "venmo-first-name")
         XCTAssertEqual(venmoAccountNonce?.lastName, "venmo-last-name")
         XCTAssertEqual(venmoAccountNonce?.phoneNumber, "venmo-phone-number")
+
+        let billingAddress = venmoAccountNonce?.billingAddress
+        XCTAssertNotNil(billingAddress)
+        XCTAssertEqual(billingAddress?.recipientName, "Bar Foo")
+        XCTAssertEqual(billingAddress?.streetAddress, "1 Foo Ct")
+        XCTAssertEqual(billingAddress?.extendedAddress, "Apt Foo")
+        XCTAssertEqual(billingAddress?.locality, "Barfoo")
+        XCTAssertEqual(billingAddress?.region, "BF")
+        XCTAssertEqual(billingAddress?.postalCode, "20")
+        XCTAssertEqual(billingAddress?.countryCodeAlpha2, "AU")
+
+        let shippingAddress = venmoAccountNonce?.shippingAddress
+        XCTAssertNotNil(shippingAddress)
+        XCTAssertEqual(shippingAddress?.recipientName, "Some Dude")
+        XCTAssertEqual(shippingAddress?.streetAddress, "2 Foo Ct")
+        XCTAssertEqual(shippingAddress?.extendedAddress, "Apt 5")
+        XCTAssertEqual(shippingAddress?.locality, "Dudeville")
+        XCTAssertEqual(shippingAddress?.region, "CA")
+        XCTAssertEqual(shippingAddress?.postalCode, "30")
+        XCTAssertEqual(shippingAddress?.countryCodeAlpha2, "US")
     }
 }

--- a/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoDriver_Tests.swift
@@ -130,18 +130,16 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
-        XCTAssertEqual(mockAPIClient.lastPOSTParameters as NSObject?, [
-            "query": "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
-            "variables": [
-                "input" : [
-                    "customerClient": "MOBILE_APP",
-                    "intent": "CONTINUE",
-                    "merchantProfileId": "venmo_merchant_id",
-                    "paymentMethodUsage": "MULTI_USE",
-                    "displayName": "app-display-name"
-                ]
-            ]
-        ] as NSObject)
+
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+            XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+            XCTAssertEqual("MULTI_USE", input["paymentMethodUsage"] as? String)
+            XCTAssertEqual("CONTINUE",input["intent"] as? String)
+            XCTAssertEqual("app-display-name",input["displayName"] as? String)
+        }
     }
 
     func testTokenizeVenmoAccount_whenDisplayNameNotSet_createsPaymentContextWithoutDisplayName() {
@@ -155,17 +153,123 @@ class BTVenmoDriver_Tests: XCTestCase {
         venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
-        XCTAssertEqual(mockAPIClient.lastPOSTParameters as NSObject?, [
-            "query": "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
-            "variables": [
-                "input" : [
-                    "customerClient": "MOBILE_APP",
-                    "intent": "CONTINUE",
-                    "merchantProfileId": "venmo_merchant_id",
-                    "paymentMethodUsage": "MULTI_USE"
-                ]
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+         if let inputDict = params?["variables"] as? NSDictionary,
+            let input = inputDict["input"] as? [String: Any] {
+             XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+             XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+             XCTAssertEqual("MULTI_USE", input["paymentMethodUsage"] as? String)
+             XCTAssertEqual("CONTINUE",input["intent"] as? String)
+         }
+     }
+
+    func testTokenizeVenmoAccount_whenEnrichedCustomerDataDisabled_doesNotAllowCollectingAddresses() {
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
+            "payWithVenmo" : [
+                "environment": "sandbox",
+                "merchantId": "venmo_merchant_id",
+                "accessToken": "venmo-access-token",
+                "enrichedCustomerDataEnabled": false
             ]
-        ] as NSObject)
+        ])
+
+        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
+        venmoRequest.collectCustomerBillingAddress = true
+        venmoRequest.collectCustomerShippingAddress = true
+        BTAppContextSwitcher.sharedInstance().returnURLScheme = "scheme"
+        let fakeApplication = FakeApplication()
+        venmoDriver.application = fakeApplication
+        venmoDriver.bundle = FakeBundle()
+        let expectation = expectation(description: "Tokenize fails with error")
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { venmoAccount, error in
+            guard let error = error as NSError? else { return }
+            XCTAssertEqual(error.code, BTVenmoDriverErrorType.enrichedCustomerDataDisabled.rawValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+
+    func testTokenizeVenmoAccount_whenCollectAddressFlagsSet_createsPaymentContextWithTheRightFlags() {
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
+            "payWithVenmo" : [
+                "environment": "sandbox",
+                "merchantId": "venmo_merchant_id",
+                "accessToken": "venmo-access-token",
+                "enrichedCustomerDataEnabled": true
+            ]
+        ])
+        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
+        venmoRequest.paymentMethodUsage = .multiUse
+        venmoRequest.collectCustomerBillingAddress = true
+        venmoRequest.collectCustomerShippingAddress = true
+        BTAppContextSwitcher.sharedInstance().returnURLScheme = "scheme"
+        let fakeApplication = FakeApplication()
+        venmoDriver.application = fakeApplication
+        venmoDriver.bundle = FakeBundle()
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String: Any] {
+            if let paysheetDetails = input["paysheetDetails"] as? String {
+                if let jsonData = paysheetDetails.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                    XCTAssertEqual("true",json["collectCustomerShippingAddress"] as? String)
+                    XCTAssertEqual("true",json["collectCustomerBillingAddress"] as? String)
+                }
+            }
+        }
+    }
+
+    func testTokenizeVenmoAccount_withAmountsAndLineItemsSet_createsPaymentContext() {
+        let venmoDriver = BTVenmoDriver(apiClient: mockAPIClient)
+        venmoRequest.paymentMethodUsage = .multiUse
+        venmoRequest.subTotalAmount = "9"
+        venmoRequest.totalAmount = "9"
+        venmoRequest.lineItems = [BTVenmoLineItem(quantity: 1, unitAmount: "9", name: "name", kind: .debit)]
+        BTAppContextSwitcher.sharedInstance().returnURLScheme = "scheme"
+        let fakeApplication = FakeApplication()
+        venmoDriver.application = fakeApplication
+        venmoDriver.bundle = FakeBundle()
+
+        venmoDriver.tokenizeVenmoAccount(with: venmoRequest) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String: Any] {
+            XCTAssertEqual("MOBILE_APP", input["customerClient"] as? String)
+            XCTAssertEqual("venmo_merchant_id",input["merchantProfileId"] as? String)
+
+            if let paysheetDetails = input["paysheetDetails"] as? String {
+                if let jsonData = paysheetDetails.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                    XCTAssertEqual("false",json["collectCustomerShippingAddress"] as? String)
+                    XCTAssertEqual("false",json["collectCustomerBillingAddress"] as? String)
+
+                    if let transactionDetailsString = json["transactionDetails"] as? String {
+                        if let jsonData = transactionDetailsString.data(using: .utf8),
+                           let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                            XCTAssertEqual(json["totalAmount"] as? String, "9")
+                            XCTAssertEqual(json["subTotalAmount"] as? String, "9")
+                            if let lineItems = json["lineItems"] as? String {
+                                XCTAssertTrue(lineItems.contains("\"quantity\":1"))
+                                XCTAssertTrue(lineItems.contains("\"name\":\"name"))
+                                XCTAssertTrue(lineItems.contains("\"unit_amount\":\"9\""))
+                                XCTAssertTrue(lineItems.contains("\"kind\":\"debit\""))
+                                XCTAssertTrue(lineItems.contains("\"unit_tax_amount\":\"0\""))
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     func testTokenizeVenmoAccount_whenPaymentMethodUsageNotSet_doesNotCreatePaymentContext() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoLineItem_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoLineItem_Tests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+@testable import BraintreeVenmo
+
+class BTVenmoLineItem_Tests: XCTestCase {
+
+    func testRequestParameters() {
+        let lineItem = BTVenmoLineItem(quantity: 1, unitAmount: "10", name: "item-name", kind: BTVenmoLineItemKind.debit);
+        lineItem.unitTaxAmount = "10";
+        let requestParams = lineItem.requestParameters();
+        XCTAssertEqual(requestParams["name"] as! String, "item-name");
+        XCTAssertEqual(requestParams["type"] as! String, "DEBIT");
+        XCTAssertEqual(requestParams["unitAmount"] as! String, "10");
+        XCTAssertEqual(requestParams["quantity"] as! Int, 1);
+        XCTAssertEqual(requestParams["unitTaxAmount"] as! String, "10");
+    }
+}

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -19,4 +19,11 @@ class BTVenmoRequest_Tests: XCTestCase {
         let request = BTVenmoRequest()
         XCTAssertEqual(request.paymentMethodUsageAsString, nil)
     }
+
+    func testCollectAddressFlags_setsDefaultValues() {
+        let request = BTVenmoRequest()
+        request.paymentMethodUsage = .singleUse
+        XCTAssertEqual(request.collectCustomerShippingAddress, false)
+        XCTAssertEqual(request.collectCustomerBillingAddress, false)
+    }
 }


### PR DESCRIPTION
### Summary of changes

This is the same change as PR #974, #1081, and #1075 - these new parameters are required in the Drop-in. Since there is not a plan to update Drop-in to v6 due to the Swift > Obj-C > Swift bug, we need to make the same changes in v5 to port these parameters to the Drop-in.

- Add `BTVenmoLineItem`
- Add new parameters to `BTVenmoRequest`
- Add `isVenmoEnrichedCustomerDataEnabled` to `BTConfiguration+Venmo`
- Update error parsing in `BTGraphQLHTTP`
- Add `billingAddress` and `shippingAddress` to `BTVenmoAccountNonce`
- Add logic to build ECD request in `BTVenmoDriver`
- Add new `BTVenmoDriverErrorTypeEnrichedCustomerDataDisabled` error
- Add ECD to Demo app
- Add new `BTConfiguration+Venmo_Tests` for ECD
- Add new `BTVenmoLineItem_Tests`
- Add error test for alternatively constructed GQL request to `BTGraphQLHTTP_Tests`
- Add additional parameters to `BTVenmoAccountNonce_Tests`
- Add additional ECD tests to `BTVenmoDriver_Tests`
- Add additional `BTVenmoRequest_Tests`

The flow has been tested with and without ECD parameters to ensure no regressions to the standard Venmo flow

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
