### PR TITLE
Fix Giant Apple Pay Button in Demo App

### DIFF
--- a/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.m
+++ b/Demo/Application/Base/Base View Controllers/BraintreeDemoPaymentButtonBaseViewController.m
@@ -23,8 +23,8 @@
     [self.view addSubview:self.paymentButton];
 
     [NSLayoutConstraint activateConstraints:@[
-        [self.paymentButton.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-        [self.paymentButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.paymentButton.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:20],
+        [self.paymentButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-20],
         [self.paymentButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:self.centerYConstant],
         [self.paymentButton.heightAnchor constraintEqualToConstant:100.0]
     ]];

--- a/Demo/Application/Features/Apple Pay - PassKit/BraintreeDemoApplePayViewController.swift
+++ b/Demo/Application/Features/Apple Pay - PassKit/BraintreeDemoApplePayViewController.swift
@@ -21,6 +21,8 @@ class BraintreeDemoApplePayPassKitViewController: BraintreeDemoPaymentButtonBase
         let applePayButton = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .automatic)
         applePayButton.addTarget(self, action: #selector(tappedApplePayButton), for: .touchUpInside)
 
+        NSLayoutConstraint.activate([applePayButton.heightAnchor.constraint(equalToConstant: 50)])
+
         return applePayButton
     }
 


### PR DESCRIPTION
### Summary of changes

- When updating the constraints in `BraintreeDemoPaymentButtonBaseViewController` recently, it made the Apple Pay button in the demo app giant - all other buttons render as expected
    - Added leading and trailing constraints that will apply to all buttons
    - Added a height constraint to the Apple Pay button so it doesn't look wild
    - All of the other UIButtons render as the correct size

### Visuals
| Before | After |
|-----|-----|
|![Simulator Screenshot - iPhone 15 Pro - 2023-09-22 at 11 59 00](https://github.com/braintree/braintree_ios/assets/20733831/f190bc5d-66a2-4f9a-a854-cae10153d218)|![Simulator Screenshot - iPhone 15 Pro - 2023-09-22 at 10 36 06](https://github.com/braintree/braintree_ios/assets/20733831/a4f95a34-7eb6-43a9-9d1f-eaa288b80a45)|

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 