### PR TITLE
Send PayPal `correlation_id` in analytics payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `component` from `btmobilesdk` to `braintreeclientsdk` for PayPal's analytics service (FPTI)
 * BraintreeCore
   * Fix bug where `type` was always returned as `Unknown` in `fetchPaymentMethodNonces` (fixes #1099)
+* Send `correlation_id`, when possible, in PayPal analytic events
 
 ## 6.6.0 (2023-08-22)
 * BraintreePayPalNativeCheckout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Send `tenant_name` in `event_params` to PayPal's analytics service (FPTI)
-* Update `component` from `btmobilesdk` to `braintreeclientsdk` for PayPal's analytics service (FPTI)
 * BraintreeCore
   * Fix bug where `type` was always returned as `Unknown` in `fetchPaymentMethodNonces` (fixes #1099)
-* Send `correlation_id`, when possible, in PayPal analytic events
+  * Analytics
+    * Send `tenant_name` in `event_params` to PayPal's analytics service (FPTI)
+    * Update `component` from `btmobilesdk` to `braintreeclientsdk` for PayPal's analytics service (FPTI)
+    * Send `correlation_id`, when possible, in PayPal analytic events
 
 ## 6.6.0 (2023-08-22)
 * BraintreePayPalNativeCheckout

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -48,9 +48,9 @@ class BTAnalyticsService: Equatable {
     ///  Events are queued and sent in batches to the analytics service, based on the status of the app and
     ///  the number of queued events. After exiting this method, there is no guarantee that the event has been sent.
     /// - Parameter eventName: String representing the event name
-    func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil) {
+    func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
         DispatchQueue.main.async {
-            self.enqueueEvent(eventName, errorDescription: errorDescription)
+            self.enqueueEvent(eventName, errorDescription: errorDescription, correlationID: correlationID)
             self.flushIfAtThreshold()
         }
     }
@@ -59,10 +59,11 @@ class BTAnalyticsService: Equatable {
     func sendAnalyticsEvent(
         _ eventName: String,
         errorDescription: String? = nil,
+        correlationID: String? = nil,
         completion: @escaping (Error?) -> Void = { _ in }
     ) {
         DispatchQueue.main.async {
-            self.enqueueEvent(eventName, errorDescription: errorDescription)
+            self.enqueueEvent(eventName, errorDescription: errorDescription, correlationID: correlationID)
             self.flush(completion)
         }
     }
@@ -117,9 +118,10 @@ class BTAnalyticsService: Equatable {
     // MARK: - Helpers
 
     /// Adds an event to the queue
-    func enqueueEvent(_ eventName: String, errorDescription: String?) {
+    func enqueueEvent(_ eventName: String, errorDescription: String?, correlationID: String?) {
         let timestampInMilliseconds = UInt64(Date().timeIntervalSince1970 * 1000)
         let event = FPTIBatchData.Event(
+            correlationID: correlationID,
             errorDescription: errorDescription,
             eventName: eventName,
             timestamp: String(timestampInMilliseconds)

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -27,12 +27,14 @@ struct FPTIBatchData: Codable {
     /// Encapsulates a single event by it's name and timestamp.
     struct Event: Codable {
         
+        let correlationID: String?
         let errorDescription: String?
         let eventName: String
         let timestamp: String
         let tenantName: String = "Braintree"
 
         enum CodingKeys: String, CodingKey {
+            case correlationID = "correlation_id"
             case errorDescription = "error_desc"
             case eventName = "event_name"
             case timestamp = "t"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -323,10 +323,11 @@ import Foundation
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     @_documentation(visibility: private)
-    public func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil) {
+    public func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
         analyticsService?.sendAnalyticsEvent(
             eventName,
             errorDescription: errorDescription,
+            correlationID: correlationID,
             completion: { _ in }
         )
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -406,7 +406,8 @@ import BraintreeDataCollector
     private func notifyFailure(with error: Error, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.tokenizeFailed,
-            errorDescription: error.localizedDescription
+            errorDescription: error.localizedDescription,
+            correlationID: clientMetadataID
         )
         completion(nil, error)
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -398,7 +398,7 @@ import BraintreeDataCollector
         with result: BTPayPalAccountNonce,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeSucceeded)
+        apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeSucceeded, correlationID: clientMetadataID)
         completion(result, nil)
     }
 
@@ -411,7 +411,7 @@ import BraintreeDataCollector
     }
 
     private func notifyCancel(completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled)
+        self.apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled, correlationID: clientMetadataID)
         completion(nil, BTPayPalError.canceled)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -19,7 +19,8 @@ import BraintreeDataCollector
     /// Exposed for testing the approvalURL construction
     var approvalURL: URL? = nil
 
-    /// Exposed for testing the clientMetadataID associated with this request
+    /// Exposed for testing the clientMetadataID associated with this request.
+    /// Used in POST body for FPTI analytics & `/paypal_account` fetch.
     var clientMetadataID: String? = nil
     
     /// Exposed for testing the intent associated with this request

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -120,6 +120,7 @@ import PayPalCheckout
 
             switch result {
             case .success(let order):
+                // TODO: - Refactor NXO setup to use custom protocol for mocking
                 let payPalNativeConfig = PayPalCheckout.CheckoutConfig(
                     clientID: order.payPalClientID,
                     createOrder: { [weak self] action in

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -152,7 +152,7 @@ import PayPalCheckout
                     },
                     onError: { error in
                         self.clientMetadataID = error.correlationIDs.riskCorrelationID
-                        self.notifyFailure(with: BTPayPalNativeCheckoutError.checkoutSDKFailed, completion: completion)
+                        self.notifyFailure(with: BTPayPalNativeCheckoutError.checkoutSDKFailed(error), completion: completion)
                     },
                     environment: order.environment
                 )

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -210,7 +210,7 @@ import PayPalCheckout
     }
 
     private func notifyCancel(completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled)
+        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, correlationID: clientMetadataID)
         completion(nil, BTPayPalNativeCheckoutError.canceled)
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -142,6 +142,7 @@ import PayPalCheckout
                             completion(nil, BTPayPalNativeCheckoutError.deallocated)
                             return
                         }
+                        self.clientMetadataID = approval.data.correlationIDs.riskCorrelationID
 
                         tokenize(approval: approval, request: request, completion: completion)
                     },
@@ -181,10 +182,8 @@ import PayPalCheckout
         ) { result in
             switch result {
             case .success(let nonce):
-                self.clientMetadataID = nonce.clientMetadataID
                 self.notifySuccess(with: nonce, completion: completion)
             case .failure(let error):
-                self.clientMetadataID = approval.data.correlationIDs.riskCorrelationID
                 self.notifyFailure(with: error, completion: completion)
             }
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -15,8 +15,8 @@ import PayPalCheckout
 
     private let apiClient: BTAPIClient
     
-    /// Exposed for testing the clientMetadataID associated with this request
-    var clientMetadataID: String? = nil
+    /// Used in POST body for FPTI analytics.
+    private var clientMetadataID: String? = nil
 
     ///  Initializes a PayPal Native client.
     /// - Parameter apiClient: The Braintree API client
@@ -120,7 +120,6 @@ import PayPalCheckout
 
             switch result {
             case .success(let order):
-                // TODO: - Refactor NXO setup to use custom protocol for mocking
                 let payPalNativeConfig = PayPalCheckout.CheckoutConfig(
                     clientID: order.payPalClientID,
                     createOrder: { [weak self] action in

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -41,7 +41,6 @@ import PayPalCheckout
         _ request: BTPayPalNativeCheckoutRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
-        clientMetadataID = request.riskCorrelationID ?? State.correlationIDs.riskCorrelationID
         tokenize(request: request, completion: completion)
     }
 
@@ -110,7 +109,9 @@ import PayPalCheckout
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
+        clientMetadataID = request.riskCorrelationID ?? State.correlationIDs.riskCorrelationID
         self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeStarted)
+        
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
         orderCreationClient.createOrder(with: request) { [weak self] result in
             guard let self else {

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PayPalCheckout
 
 /// Error returned from the native PayPal flow
 enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatable  {
@@ -28,7 +29,7 @@ enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatabl
     case canceled
 
     /// 7. PayPalCheckout SDK returned an error
-    case checkoutSDKFailed
+    case checkoutSDKFailed(PayPalCheckout.ErrorInfo)
 
     /// 8. Tokenization with the Braintree Gateway failed
     case tokenizationFailed(Error)
@@ -96,8 +97,8 @@ enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatabl
             return "Failed to create PayPal order: \(error.localizedDescription)"
         case .canceled:
             return "PayPal flow was canceled by the user."
-        case .checkoutSDKFailed:
-            return "PayPalCheckout SDK returned an error."
+        case .checkoutSDKFailed(let error):
+            return "PayPalCheckout SDK returned an error: \(error.description)"
         case .tokenizationFailed(let error):
             return "Tokenization with the Braintree Gateway failed: \(error.localizedDescription)"
         case .parsingTokenizationResultFailed:

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PayPalCheckout
 
 #if canImport(BraintreeCore)
 import BraintreeCore

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PayPalCheckout
 
 #if canImport(BraintreeCore)
 import BraintreeCore

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -17,11 +17,13 @@ final class FPTIBatchData_Tests: XCTestCase {
     
     let eventParams = [
         FPTIBatchData.Event(
+            correlationID: "fake-correlation-id-1",
             errorDescription: "fake-error-description-1",
             eventName: "fake-event-1",
             timestamp: "fake-time-1"
         ),
         FPTIBatchData.Event(
+            correlationID: nil,
             errorDescription: nil,
             eventName: "fake-event-2",
             timestamp: "fake-time-2"
@@ -81,5 +83,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(eventParams[1]["tenant_name"] as? String, "Braintree")
         XCTAssertEqual(eventParams[0]["error_desc"] as? String, "fake-error-description-1")
         XCTAssertNil(eventParams[1]["error_desc"])
+        XCTAssertEqual(eventParams[0]["correlation_id"] as? String, "fake-correlation-id-1")
+        XCTAssertNil(eventParams[1]["correlation_id"])
     }
 }

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -5,7 +5,7 @@ class FakeAnalyticsService: BTAnalyticsService {
     var lastEvent: String = ""
     var didLastFlush: Bool = false
 
-    override func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil) {
+    override func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
         self.lastEvent = eventName
         self.didLastFlush = false
     }
@@ -13,6 +13,7 @@ class FakeAnalyticsService: BTAnalyticsService {
     override func sendAnalyticsEvent(
         _ eventName: String,
         errorDescription: String? = nil,
+        correlationID: String? = nil,
         completion: @escaping (Error?) -> Void = { _ in }
     ) {
         self.lastEvent = eventName

--- a/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
+++ b/UnitTests/BraintreePayPalNativeCheckoutTests/BTPayPalNativeCheckoutClient_Tests.swift
@@ -28,4 +28,6 @@ class BTPayPalNativeCheckoutClient_Tests: XCTestCase {
             XCTAssertEqual(self.apiClient.postedAnalyticsEvents.last, BTPayPalNativeCheckoutAnalytics.tokenizeFailed)
         }
     }
+    
+    // TODO: - Add remaining unit tests DTBTSDK-3076
 }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -77,7 +77,7 @@ public class MockAPIClient: BTAPIClient {
         completion([], nil)
     }
 
-    public override func sendAnalyticsEvent(_ name: String, errorDescription: String? = nil) {
+    public override func sendAnalyticsEvent(_ name: String, errorDescription: String? = nil, correlationID: String? = nil) {
         postedAnalyticsEvents.append(name)
     }
 


### PR DESCRIPTION
### Summary

Currently, we cannot tie our analytics to a PayPal correlationID (aka clientMetadataID) because we are not sending the value in our analytics batch payload. We recently had a Slack inbound where this data would be extremely helpful for handoff to the underlying PP Web or PP NXO team to do further investigation on the specific PayPal transaction.

### Changes
- Update `FPTIBatchData` to send `correlation_id` at the event level (I verified that I can see these values populate in FPTI event explorer)
- Update `BTAnalyticsService` to accept an optional `correlationID` param
- Send already-existant `clientMetadataID` in BTPayPalWebClient
- Collect `clientMetadataID` & send in analytics for BTPayPalNativeCheckoutClient

### Feedback/Questions
- We don't have a testing infrastructure for BTPayPalNativeCheckoutClient set up right now, which I left a TODO for. It will be a handful of work, since MXO is hard to test (ticket DTBTSDK-3076)
- We don't have testing in place for our analytics (ticket DTBTSDK-2441)
- We _could_ block this PR until the above ^ are taken care of, if folks feel strongly? What do you think?

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo
