### PR TITLE
Remove Duplicate Tokenize Call in NXO Demo

### DIFF
--- a/Demo/Application/Features/PayPal - Native Checkout/BraintreeDemoPayPalNativeCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPal - Native Checkout/BraintreeDemoPayPalNativeCheckoutViewController.swift
@@ -68,16 +68,6 @@ class BraintreeDemoPayPalNativeCheckoutViewController: BraintreeDemoPaymentButto
 			}
 			self.completionBlock(nonce)
 		}
-
-		payPalNativeCheckoutClient.tokenize(request) { nonce, error in
-			sender.isEnabled = true
-
-			guard let nonce else {
-				self.progressBlock(error?.localizedDescription)
-				return
-			}
-			self.completionBlock(nonce)
-		}
 	}
 
 	@objc func tappedCheckoutWithVault(_ sender: UIButton) {


### PR DESCRIPTION
### Summary of changes

- We were calling tokenize twice in `tappedVaultCheckout` method of the `BraintreeDemoPayPalNativeCheckoutViewController`

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
