### PR TITLE
[DO NOT REVIEW] Remove xcbeautify Pod

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcpretty
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-13

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_14.3.app
       - name: Install Package dependencies
         run: swift package resolve
-      - name: Install CocoaPod dependencies
-        run: pod install
+      - name: Install test dependencies
+        run: pod install & brew install xcbeautify
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcbeautify
   ui_test_job:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcpretty
   ui_test_job:
     name: UI
     runs-on: macOS-13
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcpretty
   integration_test_job:
     name: Integration
     runs-on: macOS-13
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 14,OS=16.4,platform=iOS Simulator'  test | xcpretty

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -8,4 +8,3 @@ This project uses the following dependencies for our Demo app and test suites:
 * [Expecta](https://github.com/specta/expecta), MIT License
 * [OCMock](https://github.com/erikdoe/ocmock), Apache License 2.0
 * [OHHTTPStubs](https://github.com/AliSoftware/OHHTTPStubs), MIT License
-* [xcbeautify](https://github.com/thii/xcbeautify), Copyright (c) 2018 Thi Doãn

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,6 @@ end
 abstract_target 'Tests' do
   pod 'OCMock'
   pod 'OHHTTPStubs/Swift'
-  pod 'xcbeautify'
 
   target 'IntegrationTests'
   target 'BraintreeCoreTests'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,27 +14,23 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - xcbeautify (0.8.1)
 
 DEPENDENCIES:
   - InAppSettingsKit
   - OCMock
   - OHHTTPStubs/Swift
-  - xcbeautify
 
 SPEC REPOS:
   trunk:
     - InAppSettingsKit
     - OCMock
     - OHHTTPStubs
-    - xcbeautify
 
 SPEC CHECKSUMS:
   InAppSettingsKit: 01fb9774c74a11fefc521f29cb2338909e1c2b61
   OCMock: 75fbeaa46a9b11f8c182bbb1d1f7e9a35ccc9955
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  xcbeautify: a3b03e4a38eb1a5766a83a7a3c53915a233572e3
 
-PODFILE CHECKSUM: 224cc2d6666b79d3d6adb45cccd6dfbc6fe74d18
+PODFILE CHECKSUM: 8c6d3006146f9dd5b83180c2148e1a7894b80fb8
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
### Summary of changes

- Use `xcpretty` [already installed in GH Actions macOS image ](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode-support-tools)versus pulling in `xcbeautify` pod. 
- (These libraries are used to format xcodebuild test output)

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 