### PR TITLE
Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeThreeDSecure
+  * Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
+
 ## 6.8.0 (2023-10-24)
 * BraintreeDataCollector
   * Update PPRiskMagnes with 5.4.1 - staging removed (fixes #1107)

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureCardAddChallenge.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureCardAddChallenge.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// NEXT_MAJOR_VERSION remove BTThreeDSecureCardAddChallenge
 /// The card add challenge request
 @objc public enum BTThreeDSecureCardAddChallenge: Int {
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -351,7 +351,7 @@ import BraintreeCore
                 "dataOnlyRequested": request.dataOnlyRequested
             ]
 
-            if request.cardAddChallenge == .requested {
+            if request.cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
                 requestParameters["cardAdd"] = true
             } else if request.cardAddChallenge == .notRequested {
                 requestParameters["cardAdd"] = false

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -49,6 +49,7 @@ import BraintreeCore
     /// Non-Mastercard cardholders will fallback to a normal 3DS flow.
     public var dataOnlyRequested: Bool = false
 
+    // NEXT_MAJOR_VERSION remove cardAddChallenge in favor of cardAddChallengeRequested
     /// Optional. An authentication created using this property should only be used for adding a payment method to the merchant's vault and not for creating transactions.
     ///
     /// Defaults to `.unspecified.`
@@ -57,7 +58,14 @@ import BraintreeCore
     /// If set to `.notRequested` the authentication challenge will not be requested from the issuer.
     /// If set to `.unspecified`, when the amount is 0, the authentication challenge will be requested from the issuer.
     /// If set to `.unspecified`, when the amount is greater than 0, the authentication challenge will not be requested from the issuer.
+    @available(*, deprecated, renamed: "cardAddChallengeRequested", message: "Use cardAddChallengeRequested. This property will be removed in our next major version.")
     public var cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
+
+    /// Optional.  An authentication created using this flag should only be used for vaulting operations (creation of customers' credit cards or payment methods) and not for creating transactions.
+    /// If set to `true`, a card-add challenge will be requested from the issuer.
+    /// If set to `false`, a card-add challenge will not be requested. 
+    /// If the parameter is missing, a card-add challenge will only be requested for $0 amount.
+    public var cardAddChallengeRequested: Bool = false
 
     /// Optional. UI Customization for 3DS2 challenge views.
     public var v2UICustomization: BTThreeDSecureV2UICustomization?

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -58,7 +58,6 @@ import BraintreeCore
     /// If set to `.notRequested` the authentication challenge will not be requested from the issuer.
     /// If set to `.unspecified`, when the amount is 0, the authentication challenge will be requested from the issuer.
     /// If set to `.unspecified`, when the amount is greater than 0, the authentication challenge will not be requested from the issuer.
-    @available(*, deprecated, renamed: "cardAddChallengeRequested", message: "Use cardAddChallengeRequested. This property will be removed in our next major version.")
     public var cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
 
     /// Optional.  An authentication created using this flag should only be used for vaulting operations (creation of customers' credit cards or payment methods) and not for creating transactions.

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -122,6 +122,24 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    func testPerformThreeDSecureLookup_whenCardAddChallengeRequested_sendsCardAddTrue() {
+        let expectation = self.expectation(description: "willCallCompletion")
+
+        threeDSecureRequest.nonce = "fake-card-nonce"
+        threeDSecureRequest.amount = 9.97
+        threeDSecureRequest.dfReferenceID = "df-reference-id"
+
+        threeDSecureRequest.cardAddChallengeRequested = true
+
+        client.performThreeDSecureLookup(threeDSecureRequest) { _, _ in
+            XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as! Bool)
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
     func testPerformThreeDSecureLookup_whenSuccessful_callsBackWithResult() {
         let responseBody =
             """

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -123,17 +123,15 @@ class BTThreeDSecureClient_Tests: XCTestCase {
     }
 
     func testPerformThreeDSecureLookup_whenCardAddChallengeRequested_sendsCardAddTrue() {
-        let expectation = self.expectation(description: "willCallCompletion")
-
         threeDSecureRequest.nonce = "fake-card-nonce"
         threeDSecureRequest.amount = 9.97
         threeDSecureRequest.dfReferenceID = "df-reference-id"
-
         threeDSecureRequest.cardAddChallengeRequested = true
+
+        let expectation = expectation(description: "willCallCompletion")
 
         client.performThreeDSecureLookup(threeDSecureRequest) { _, _ in
             XCTAssertTrue(self.mockAPIClient.lastPOSTParameters!["cardAdd"] as! Bool)
-
             expectation.fulfill()
         }
 


### PR DESCRIPTION
### Summary of changes

- Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
- Deprecate `cardAddChallenge`
- Add unit test for `cardAddChallengeRequested`

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
