### PR TITLE
Deprecate `cardAddChallenge` & add internal property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreeThreeDSecure
   * Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
+  * Deprecate `BTThreeDSecureRequest.cardAddChallenge`
 
 ## 5.24.0 (2023-10-30)
 * BraintreePayPalDataCollector

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -351,9 +351,9 @@ import BraintreeCore
                 "dataOnlyRequested": request.dataOnlyRequested
             ]
 
-            if request.cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
+            if request._cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
                 requestParameters["cardAdd"] = true
-            } else if request.cardAddChallenge == .notRequested {
+            } else if request._cardAddChallenge == .notRequested {
                 requestParameters["cardAdd"] = false
             }
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -58,8 +58,14 @@ import BraintreeCore
     /// If set to `.notRequested` the authentication challenge will not be requested from the issuer.
     /// If set to `.unspecified`, when the amount is 0, the authentication challenge will be requested from the issuer.
     /// If set to `.unspecified`, when the amount is greater than 0, the authentication challenge will not be requested from the issuer.
-    public var cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
+    @available(*, deprecated, message: "Use `cardAddChallengeRequested` instead")
+    public var cardAddChallenge: BTThreeDSecureCardAddChallenge {
+        get { return _cardAddChallenge }
+        set { _cardAddChallenge = newValue }
+    }
 
+    var _cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
+    
     /// Optional.  An authentication created using this flag should only be used for vaulting operations (creation of customers' credit cards or payment methods) and not for creating transactions.
     /// If set to `true`, a card-add challenge will be requested from the issuer.
     /// If set to `false`, a card-add challenge will not be requested. 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -58,9 +58,9 @@ import BraintreeCore
     /// If set to `.notRequested` the authentication challenge will not be requested from the issuer.
     /// If set to `.unspecified`, when the amount is 0, the authentication challenge will be requested from the issuer.
     /// If set to `.unspecified`, when the amount is greater than 0, the authentication challenge will not be requested from the issuer.
-    @available(*, deprecated, message: "Use `cardAddChallengeRequested` instead")
+    @available(*, deprecated, renamed: "cardAddChallengeRequested", message: "Use the `cardAddChallengeRequested` boolean property instead")
     public var cardAddChallenge: BTThreeDSecureCardAddChallenge {
-        get { return _cardAddChallenge }
+        get { _cardAddChallenge }
         set { _cardAddChallenge = newValue }
     }
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -64,6 +64,8 @@ import BraintreeCore
         set { _cardAddChallenge = newValue }
     }
 
+    /// Internal property for `cardAddChallenge`. Created to avoid deprecation warnings upon accessing
+    /// `cardAddChallenge` directly within our SDK. Use this value internally instead.
     var _cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
     
     /// Optional.  An authentication created using this flag should only be used for vaulting operations (creation of customers' credit cards or payment methods) and not for creating transactions.


### PR DESCRIPTION
Follow up to PR #1122 & [this comment](https://github.com/braintree/braintree_ios/pull/1122#discussion_r1376494256)

### Summary of changes

- Deprecate `BTThreeDSecure.cardAddChallenge`
- Create internal variable for `cardAddChallenge` to use within the SDK
    - Since we cannot silence deprecation warnings in Swift, Jax's PR above revealed that referencing deprecated methods & properties internally will surface errors to merchants
    - This works around that limitation by only accessing the _internal_ variable for `cardAddChallenge` throughout the SDK, while still deprecating the merchant-facing public property
    - Since the internal property is not deprecated, our SDK will not trigger warnings

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 