### PR TITLE
Remove Old Bridging Headers

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -761,7 +761,6 @@
 		A948D6CA24FAB79B00F4F178 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A948D6DC24FAC6C000F4F178 /* BraintreeApplePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeApplePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A948D6E024FAC6C000F4F178 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A948D6EB24FAC7F100F4F178 /* BraintreeApplePayTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BraintreeApplePayTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		A948D6F024FAC8F900F4F178 /* BraintreeVenmoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeVenmoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A948D6F424FAC8F900F4F178 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A948D70224FACF4E00F4F178 /* FakeHTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHTTP.swift; sourceTree = "<group>"; };
@@ -770,17 +769,14 @@
 		A9589DD924FEA45C00AF4FF7 /* BTConfiguration+Venmo_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BTConfiguration+Venmo_Tests.swift"; sourceTree = "<group>"; };
 		A95C410824FAEF2100045045 /* BraintreeCardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeCardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A95C410C24FAEF2100045045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A977A06924FECBAF006049AB /* BraintreeThreeDSecureTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BraintreeThreeDSecureTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		A977A06A24FECFC3006049AB /* NonceValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceValidator.swift; sourceTree = "<group>"; };
 		A9A76CA624F9E92E0044EAEE /* TestClientTokenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestClientTokenFactory.swift; sourceTree = "<group>"; };
 		A9E5C19E24FD5A7C00EE691F /* BraintreeDataCollectorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeDataCollectorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E5C1A224FD5A7C00EE691F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A9E5C1E024FD665D00EE691F /* BraintreePayPalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreePayPalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E5C1E424FD665D00EE691F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A9E5C1F724FD672A00EE691F /* BraintreePayPalTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BraintreePayPalTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		A9E5C22424FD6D0800EE691F /* BraintreeCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E5C22824FD6D0800EE691F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A9E5C23524FD703B00EE691F /* BraintreeCoreTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BraintreeCoreTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		A9E80AA224FEF4D800196BD3 /* MockLocalPaymentRequestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalPaymentRequestDelegate.swift; sourceTree = "<group>"; };
 		BC17F9B328D23C5C004B18CC /* BTGraphQLMultiErrorNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLMultiErrorNode.swift; sourceTree = "<group>"; };
 		BC17F9BB28D24C9E004B18CC /* BTGraphQLErrorTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLErrorTree.swift; sourceTree = "<group>"; };
@@ -1547,7 +1543,6 @@
 			isa = PBXGroup;
 			children = (
 				80FF7D9625882648001C32EF /* ThreeDSecureV2Customization_Tests */,
-				A977A06924FECBAF006049AB /* BraintreeThreeDSecureTests-Bridging-Header.h */,
 				80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */,
 				3BEB03C629FD5669001133D5 /* BTThreeDSecureAnalytics_Tests.swift */,
 				42F75E5A24D48138007DC5E7 /* BTThreeDSecureClient_Tests.swift */,
@@ -1578,7 +1573,6 @@
 		A948D6DD24FAC6C000F4F178 /* BraintreeApplePayTests */ = {
 			isa = PBXGroup;
 			children = (
-				A948D6EB24FAC7F100F4F178 /* BraintreeApplePayTests-Bridging-Header.h */,
 				A7D64ABB1B4C93B6005168EF /* BTApplePay_Tests.swift */,
 				BEDB820329B10ADA00075AF3 /* BTApplePayAnalytics_Tests.swift */,
 				800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */,
@@ -1631,7 +1625,6 @@
 		A9E5C1E124FD665D00EE691F /* BraintreePayPalTests */ = {
 			isa = PBXGroup;
 			children = (
-				A9E5C1F724FD672A00EE691F /* BraintreePayPalTests-Bridging-Header.h */,
 				A95229C624FD949D006F7D25 /* BTConfiguration+PayPal_Tests.swift */,
 				BEDEAF102AC1D049004EA970 /* BTPayPalAccountNonce_Tests.swift */,
 				3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */,
@@ -1663,7 +1656,6 @@
 				A7E93E571B601EE900957223 /* BTURLUtils_Tests.swift */,
 				A7B861BE1C24B19300A2422E /* BTVersion_Tests.swift */,
 				8053F05629FAD4790076F988 /* Encodable+Dictionary_Tests.swift */,
-				A9E5C23524FD703B00EE691F /* BraintreeCoreTests-Bridging-Header.h */,
 				A908436924FD88C3004134CA /* Helpers */,
 				A9E5C22824FD6D0800EE691F /* Info.plist */,
 			);
@@ -5064,7 +5056,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreeThreeDSecureTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5110,7 +5102,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreeThreeDSecureTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -5246,7 +5238,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreeApplePayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreeApplePayTests/BraintreeApplePayTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5289,7 +5281,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreeApplePayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreeApplePayTests/BraintreeApplePayTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "${PROJECT_DIR}/Demo/**";
@@ -5604,7 +5596,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreePayPalTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreePayPalTests/BraintreePayPalTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5646,7 +5638,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreePayPalTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/BraintreePayPalTests/BraintreePayPalTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import PassKit
+@testable import BraintreeCore
 @testable import BraintreeTestShared
 @testable import BraintreeApplePay
 

--- a/UnitTests/BraintreeApplePayTests/BraintreeApplePayTests-Bridging-Header.h
+++ b/UnitTests/BraintreeApplePayTests/BraintreeApplePayTests-Bridging-Header.h
@@ -1,1 +1,0 @@
-#import <BraintreeCore/BraintreeCore-Swift.h>

--- a/UnitTests/BraintreePayPalTests/BTConfiguration+PayPal_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTConfiguration+PayPal_Tests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import BraintreeTestShared
+@testable import BraintreeCore
 @testable import BraintreePayPal
 
 class BTConfiguration_PayPal_Tests : XCTestCase {

--- a/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreePayPal
 
 final class BTPayPalAccountNonce_Tests: XCTestCase {

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreePayPal
 
 class BTPayPalRequest_Tests: XCTestCase {

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreePayPal
 
 class BTPayPalVaultRequest_Tests: XCTestCase {

--- a/UnitTests/BraintreePayPalTests/BraintreePayPalTests-Bridging-Header.h
+++ b/UnitTests/BraintreePayPalTests/BraintreePayPalTests-Bridging-Header.h
@@ -1,1 +1,0 @@
-#import <BraintreeCore/BraintreeCore-Swift.h>

--- a/UnitTests/BraintreeThreeDSecureTests/BTConfiguration+ThreeDSecure_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTConfiguration+ThreeDSecure_Tests.swift
@@ -1,5 +1,5 @@
-import Foundation
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreeThreeDSecure
 
 class BTConfiguration_ThreeDSecure_Tests: XCTestCase {

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
@@ -1,5 +1,6 @@
 import UIKit
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreeTestShared
 @testable import BraintreeThreeDSecure
 

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureLookup_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureLookup_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import BraintreeCore
 @testable import BraintreeThreeDSecure
 
 class BTThreeDSecureLookup_Tests: XCTestCase {

--- a/UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h
+++ b/UnitTests/BraintreeThreeDSecureTests/BraintreeThreeDSecureTests-Bridging-Header.h
@@ -1,3 +1,0 @@
-#import <BraintreeCore/BraintreeCore-Swift.h>
-#import <BraintreeCard/BraintreeCard-Swift.h>
-#import <BraintreeThreeDSecure/BraintreeThreeDSecure-Swift.h>


### PR DESCRIPTION
### Summary of changes

- We had some old bridging headers in our tests that were no longer needed
    - Removed these files where possible
    - Replaced with imports where needed without bridging headers

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
