### PR TITLE
Add Cardinal UI Type and Render Types

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -1531,16 +1531,16 @@
 				BE01A84229D32EA9000DFA24 /* BTThreeDSecureError.swift */,
 				BE01A82C29CCCDE9000DFA24 /* BTThreeDSecureLookup.swift */,
 				BE01A83429D1F7B9000DFA24 /* BTThreeDSecurePostalAddress.swift */,
+				BEBF0C212B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift */,
 				80482F7F29D39A1D007E5F50 /* BTThreeDSecureRequest.swift */,
 				80482F8129D39BF5007E5F50 /* BTThreeDSecureRequestDelegate.swift */,
 				80482F8729D3A571007E5F50 /* BTThreeDSecureRequestedExemptionType.swift */,
 				BE80C00229C549BE00793A6C /* BTThreeDSecureResult.swift */,
 				80482F8529D3A498007E5F50 /* BTThreeDSecureShippingMethod.swift */,
+				BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */,
 				BE01A83E29D32CA0000DFA24 /* BTThreeDSecureV2Provider.swift */,
 				80CD33FF2A6042FC009545F5 /* CardinalSessionTestable.swift */,
 				801A0A1725890DF200DAF851 /* V2UICustomization */,
-				BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */,
-				BEBF0C212B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift */,
 			);
 			path = BraintreeThreeDSecure;
 			sourceTree = "<group>";

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -253,6 +253,8 @@
 		BEBC6F3329380B82004E25A0 /* BTExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BEBC6F3129380B82004E25A0 /* BTExceptionCatcher.m */; };
 		BEBD05222A1FE8BE0003C15C /* BTWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBD05212A1FE8BE0003C15C /* BTWebAuthenticationSession.swift */; };
 		BEBD05242A1FEE150003C15C /* MockWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBD05232A1FEE150003C15C /* MockWebAuthenticationSession.swift */; };
+		BEBF0C202B02793B0079DA74 /* BTThreeDSecureUIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */; };
+		BEBF0C222B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF0C212B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift */; };
 		BEC3F11328A4401E0074DF0F /* BTHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */; };
 		BEC66DBE2901CC9E0030B6B2 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BECBA0E62AEABC99002518AC /* BTCardClient_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */; };
@@ -858,6 +860,8 @@
 		BEBC6F3429380BA6004E25A0 /* BTExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTExceptionCatcher.h; sourceTree = "<group>"; };
 		BEBD05212A1FE8BE0003C15C /* BTWebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTWebAuthenticationSession.swift; sourceTree = "<group>"; };
 		BEBD05232A1FEE150003C15C /* MockWebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebAuthenticationSession.swift; sourceTree = "<group>"; };
+		BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureUIType.swift; sourceTree = "<group>"; };
+		BEBF0C212B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureRenderTypes.swift; sourceTree = "<group>"; };
 		BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTHTTPError.swift; sourceTree = "<group>"; };
 		BECA56C929C3F0A80098EC3C /* BTThreeDSecureV2UICustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2UICustomization.swift; sourceTree = "<group>"; };
 		BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient_IntegrationTests.swift; sourceTree = "<group>"; };
@@ -1535,6 +1539,8 @@
 				BE01A83E29D32CA0000DFA24 /* BTThreeDSecureV2Provider.swift */,
 				80CD33FF2A6042FC009545F5 /* CardinalSessionTestable.swift */,
 				801A0A1725890DF200DAF851 /* V2UICustomization */,
+				BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */,
+				BEBF0C212B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift */,
 			);
 			path = BraintreeThreeDSecure;
 			sourceTree = "<group>";
@@ -2884,11 +2890,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE48CE4829D5DDA600F0825C /* BTThreeDSecureV2TextBoxCustomization.swift in Sources */,
+				BEBF0C222B0279F10079DA74 /* BTThreeDSecureRenderTypes.swift in Sources */,
 				80D1638729E75CF1001D880E /* BTThreeDSecureClient.swift in Sources */,
 				BEEBC3C129D5DD68009C7F77 /* BTThreeDSecureV2LabelCustomization.swift in Sources */,
 				BEEBC3C029D5DD16009C7F77 /* BTThreeDSecureV2UICustomization.swift in Sources */,
 				80482F8029D39A1D007E5F50 /* BTThreeDSecureRequest.swift in Sources */,
 				BE01A83D29D23833000DFA24 /* BTThreeDSecureAdditionalInformation.swift in Sources */,
+				BEBF0C202B02793B0079DA74 /* BTThreeDSecureUIType.swift in Sources */,
 				BE01A83F29D32CA0000DFA24 /* BTThreeDSecureV2Provider.swift in Sources */,
 				BE82E73F29C4A06B0059FE97 /* BTThreeDSecureV2ToolbarCustomization.swift in Sources */,
 				BE01A84129D32CE1000DFA24 /* BTThreeDSecureAuthenticateJWT.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeThreeDSecure
-  * Add `cardAddChallengeRequested` to `BTThreeDSecureRequest`
+  * Add `cardAddChallengeRequested`, `uiType`, and `renderTypes` to `BTThreeDSecureRequest`
   * Deprecate `BTThreeDSecureRequest.cardAddChallenge`
   * Fix bug where defaults for `BTThreeDSecureRequest.accountType`, `BTThreeDSecureRequest.requestedExemptionType`, and `BTThreeDSecureRequest.dfReferenceID` were improperly returning an error if not passed into the request
 * BraintreeCard

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -100,11 +100,11 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
         request.shippingMethod = .sameDay
         request.uiType = .both
         request.renderTypes = [
-            BTThreeDSecureRenderTypes.otp,
-            BTThreeDSecureRenderTypes.singleSelect,
-            BTThreeDSecureRenderTypes.multiSelect,
-            BTThreeDSecureRenderTypes.oob,
-            BTThreeDSecureRenderTypes.html
+            BTThreeDSecureRenderType.otp,
+            BTThreeDSecureRenderType.singleSelect,
+            BTThreeDSecureRenderType.multiSelect,
+            BTThreeDSecureRenderType.oob,
+            BTThreeDSecureRenderType.html
         ]
 
         let billingAddress = BTThreeDSecurePostalAddress()

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -98,6 +98,14 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
         request.requestedExemptionType = .lowValue
         request.email = "test@example.com"
         request.shippingMethod = .sameDay
+        request.uiType = .both
+        request.renderTypes = [
+            BTThreeDSecureRenderTypes.otp,
+            BTThreeDSecureRenderTypes.singleSelect,
+            BTThreeDSecureRenderTypes.multiSelect,
+            BTThreeDSecureRenderTypes.oob,
+            BTThreeDSecureRenderTypes.html
+        ]
 
         let billingAddress = BTThreeDSecurePostalAddress()
         billingAddress.givenName = "Jill"

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRenderTypes.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRenderTypes.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
-@objcMembers public class BTThreeDSecureRenderTypes: NSObject {
+@objcMembers public class BTThreeDSecureRenderType: NSObject {
 
     public typealias StringValue = String
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRenderTypes.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRenderTypes.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+@objcMembers public class BTThreeDSecureRenderTypes: NSObject {
+
+    public typealias StringValue = String
+
+    /// OTP
+    public static let otp: StringValue = "CardinalSessionRenderTypeOTP"
+
+    /// HTML
+    public static let html: StringValue = "CardinalSessionRenderTypeHTML"
+
+    /// Single select
+    public static let singleSelect: StringValue = "CardinalSessionRenderTypeSingleSelect"
+
+    /// Multi Select
+    public static let multiSelect: StringValue = "CardinalSessionRenderTypeMultiSelect"
+
+    /// OOB
+    public static let oob: StringValue = "CardinalSessionRenderTypeOOB"
+}

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -86,7 +86,7 @@ import BraintreeCore
     ///
     /// - Note: When using `BTThreeDSecureUIType.both` or `BTThreeDSecureUIType.html`, all `BTThreeDSecureRenderType` options must be set.
     /// When using `BTThreeDSecureUIType.native`, all `BTThreeDSecureRenderType` options except `BTThreeDSecureRenderType.html` must be set.
-    public var renderTypes: [BTThreeDSecureRenderTypes.StringValue]?
+    public var renderTypes: [BTThreeDSecureRenderType.StringValue]?
 
     /// A delegate for receiving information about the ThreeDSecure payment flow.
     public weak var threeDSecureRequestDelegate: BTThreeDSecureRequestDelegate?

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -77,6 +77,17 @@ import BraintreeCore
     /// Optional. UI Customization for 3DS2 challenge views.
     public var v2UICustomization: BTThreeDSecureV2UICustomization?
 
+    /// Optional. Sets all UI types that the device supports for displaying specific challenge user interfaces in the 3D Secure challenge.
+    ///
+    /// Defaults to `.both`
+    public var uiType: BTThreeDSecureUIType = .both
+
+    /// Optional. List of all the render types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+    ///
+    /// - Note: When using `BTThreeDSecureUIType.both` or `BTThreeDSecureUIType.html`, all `BTThreeDSecureRenderType` options must be set.
+    /// When using `BTThreeDSecureUIType.native`, all `BTThreeDSecureRenderType` options except `BTThreeDSecureRenderType.html` must be set.
+    public var renderTypes: [BTThreeDSecureRenderTypes.StringValue]?
+
     /// A delegate for receiving information about the ThreeDSecure payment flow.
     public weak var threeDSecureRequestDelegate: BTThreeDSecureRequestDelegate?
     

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureUIType.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureUIType.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CardinalMobile
 
 /// The interface types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
 @objc public enum BTThreeDSecureUIType: Int {
@@ -11,4 +12,15 @@ import Foundation
 
     /// Both
     case both
+
+    var cardinalValue: CardinalSessionUIType {
+        switch self {
+        case .native:
+            return .native
+        case .html:
+            return .HTML
+        case .both:
+            return .both
+        }
+    }
 }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureUIType.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureUIType.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// The interface types that the device supports for displaying specific challenge user interfaces within the 3D Secure challenge.
+@objc public enum BTThreeDSecureUIType: Int {
+
+    /// Native
+    case native
+
+    /// HTML
+    case html
+
+    /// Both
+    case both
+}

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
@@ -39,6 +39,12 @@ class BTThreeDSecureV2Provider {
             cardinalEnvironment = .production
         }
 
+        cardinalConfiguration.uiType = request.uiType.cardinalValue
+
+        if let renderTypes = request.renderTypes {
+            cardinalConfiguration.renderType = renderTypes
+        }
+
         guard let cardinalAuthenticationJWT = configuration.cardinalAuthenticationJWT else {
             completion(nil)
             return

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CardinalMobile
 @testable import BraintreeTestShared
 @testable import BraintreeThreeDSecure
 
@@ -113,5 +114,49 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
     func testRequestedExemptionTypeAsString_whenAccountTypeIsNotSet_returnsNil() {
         let request = BTThreeDSecureRequest()
         XCTAssertEqual(request.requestedExemptionType.stringValue, nil)
+    }
+
+    // MARK: - UIType
+
+    func testUIType_whenUITypeNative_setsCardinalUITypeNative() {
+        let request = BTThreeDSecureRequest()
+        request.uiType = .native
+        XCTAssertEqual(request.uiType.cardinalValue, CardinalSessionUIType.native)
+    }
+
+    func testUIType_whenUITypeHTML_setsCardinalUITypeHTML() {
+        let request = BTThreeDSecureRequest()
+        request.uiType = .html
+        XCTAssertEqual(request.uiType.cardinalValue, CardinalSessionUIType.HTML)
+    }
+
+    func testUIType_whenUITypeBoth_setsCardinalUITypeBoth() {
+        let request = BTThreeDSecureRequest()
+        request.uiType = .native
+        XCTAssertEqual(request.uiType.cardinalValue, CardinalSessionUIType.both)
+    }
+
+    // MARK: RenderTypes
+
+    func testRenderTypes_whenAllRenderTypesAreSet_setsAllCardinalRenderTypes() {
+        let request = BTThreeDSecureRequest()
+        request.renderTypes = [
+            BTThreeDSecureRenderType.otp,
+            BTThreeDSecureRenderType.singleSelect,
+            BTThreeDSecureRenderType.multiSelect,
+            BTThreeDSecureRenderType.oob,
+            BTThreeDSecureRenderType.html
+        ]
+
+        XCTAssertEqual(
+            request.renderTypes,
+            [
+                "CardinalSessionRenderTypeOTP",
+                "CardinalSessionRenderTypeSingleSelect",
+                "CardinalSessionRenderTypeMultiSelect",
+                "CardinalSessionRenderTypeOOB",
+                "CardinalSessionRenderTypeHTML"
+            ]
+        )
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add `uiType` to `BTThreeDSecureRequest`
- Add `renderTypes` to `BTThreeDSecureRequest`
- Set default parameters in Demo app ([from Cardinal docs](https://cardinaldocs.atlassian.net/wiki/spaces/CMSDK/pages/2005696619/Setting+up+CardinalMobileSDK+-+iOS#Available-Configurations--%5BinlineExtension%5D))
- Add unit tests
- Android PR for this change: https://github.com/braintree/braintree_android/pull/738 - we finally heard back from the merchants that these worked as expected, so exposing them on iOS

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
