### PR TITLE
Consolidate duplicate `BTAPIClient` HTTP methods

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -256,36 +256,19 @@ import Foundation
     /// - Parameters:
     ///   - path: The endpoint URI path.
     ///   - parameters: Optional set of query parameters to be encoded with the request.
+    ///   - httpType: The underlying `BTAPIClientHTTPService` of the HTTP request. Defaults to `.gateway`.
     ///   - completion:  A block object to be executed when the request finishes.
     ///   On success, `body` and `response` will contain the JSON body response and the
     ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
     ///   `nil` and `error` will contain the error that occurred.
-    @_documentation(visibility: private)
-    @objc(GET:parameters:completion:)
-    public func get(_ path: String, parameters: [String: String]? = nil, completion: @escaping RequestCompletion) {
-        get(path, parameters: parameters, httpType: .gateway, completion: completion)
-    }
-
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    ///
-    /// Perfom an HTTP POST on a URL composed of the configured from environment and the given path.
-    /// - Parameters:
-    ///   - path: The endpoint URI path.
-    ///   - parameters: Optional set of query parameters to be encoded with the request.
-    ///   - completion:  A block object to be executed when the request finishes.
-    ///   On success, `body` and `response` will contain the JSON body response and the
-    ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
-    ///   `nil` and `error` will contain the error that occurred.
-    @_documentation(visibility: private)
-    @objc(POST:parameters:completion:)
-    public func post(_ path: String, parameters: [String: Any]? = nil, completion: @escaping RequestCompletion) {
-        post(path, parameters: parameters, httpType: .gateway, completion: completion)
-    }
-
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     @_documentation(visibility: private)
     @objc(GET:parameters:httpType:completion:)
-    public func get(_ path: String, parameters: [String: String]? = nil, httpType: BTAPIClientHTTPService, completion: @escaping RequestCompletion) {
+    public func get(
+        _ path: String,
+        parameters: [String: String]? = nil,
+        httpType: BTAPIClientHTTPService = .gateway, 
+        completion: @escaping RequestCompletion
+    ) {
         fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
             guard let self else {
                 completion(nil, nil, BTAPIClientError.deallocated)
@@ -302,9 +285,24 @@ import Foundation
     }
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    ///
+    /// Perfom an HTTP POST on a URL composed of the configured from environment and the given path.
+    /// - Parameters:
+    ///   - path: The endpoint URI path.
+    ///   - parameters: Optional set of query parameters to be encoded with the request.
+    ///   - httpType: The underlying `BTAPIClientHTTPService` of the HTTP request. Defaults to `.gateway`.
+    ///   - completion:  A block object to be executed when the request finishes.
+    ///   On success, `body` and `response` will contain the JSON body response and the
+    ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
+    ///   `nil` and `error` will contain the error that occurred.
     @_documentation(visibility: private)
     @objc(POST:parameters:httpType:completion:)
-    public func post(_ path: String, parameters: [String: Any]? = nil, httpType: BTAPIClientHTTPService, completion: @escaping RequestCompletion) {
+    public func post(
+        _ path: String,
+        parameters: [String: Any]? = nil,
+        httpType: BTAPIClientHTTPService = .gateway,
+        completion: @escaping RequestCompletion
+    ) {
         fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
             guard let self else {
                 completion(nil, nil, BTAPIClientError.deallocated)

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -26,14 +26,6 @@ public class MockAPIClient: BTAPIClient {
     override init?(authorization: String, sendAnalyticsEvent: Bool = false) {
         super.init(authorization: authorization, sendAnalyticsEvent: sendAnalyticsEvent)
     }
-    
-    public override func get(_ path: String, parameters: [String: String]?, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        self.get(path, parameters: parameters, httpType:.gateway, completion: completionBlock)
-    }
-
-    public override func post(_ path: String, parameters: [String: Any]?, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        self.post(path, parameters: parameters, httpType:.gateway, completion: completionBlock)
-    }
 
     public override func get(_ path: String, parameters: [String: String]?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         lastGETPath = path


### PR DESCRIPTION
### Summary of changes

- Remove overload methods for BTAPIClient.post() and BTAPIClient.get()
- Instead use single method signature for each with default param value for `BTAPIClientHTTPService`

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 