### PR TITLE
Remove `BTAPIClientHTTPType.braintreeAPI` enum case

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -25,7 +25,6 @@ import Foundation
     var configurationHTTP: BTHTTP?
 
     var http: BTHTTP?
-    var apiHTTP: BTAPIHTTP?
     var graphQLHTTP: BTGraphQLHTTP?
 
     var session: URLSession {
@@ -110,10 +109,6 @@ import Foundation
             http?.session.finishTasksAndInvalidate()
         }
 
-        if apiHTTP != nil && apiHTTP?.session != nil {
-            apiHTTP?.session.finishTasksAndInvalidate()
-        }
-
         if graphQLHTTP != nil && graphQLHTTP?.session != nil {
             graphQLHTTP?.session.finishTasksAndInvalidate()
         }
@@ -165,15 +160,6 @@ import Foundation
                 return
             } else {
                 configuration = BTConfiguration(json: body)
-
-                if apiHTTP == nil {
-                    let apiURL: URL? = configuration?.json?["clientApiUrl"].asURL()
-                    let accessToken: String? = configuration?.json?["braintreeApi"]["accessToken"].asString()
-
-                    if let apiURL, let accessToken {
-                        apiHTTP = BTAPIHTTP(url: apiURL, accessToken: accessToken)
-                    }
-                }
 
                 if http == nil {
                     let baseURL: URL? = configuration?.json?["clientApiUrl"].asURL()
@@ -338,8 +324,6 @@ import Foundation
         switch httpType {
         case .gateway:
             return parameters?.merging(["_meta": metadata.parameters]) { $1 }
-        case .braintreeAPI:
-            return parameters
         case .graphQLAPI:
             return parameters?.merging(["clientSdkMetadata": metadata.parameters]) { $1 }
         }
@@ -459,8 +443,6 @@ import Foundation
         switch httpType {
         case .gateway:
             return http
-        case .braintreeAPI:
-            return apiHTTP
         case .graphQLAPI:
             return graphQLHTTP
         }

--- a/Sources/BraintreeCore/BTAPIClientHTTPType.swift
+++ b/Sources/BraintreeCore/BTAPIClientHTTPType.swift
@@ -6,9 +6,6 @@ import Foundation
     /// Use the Gateway
     case gateway
 
-    /// Use the Braintree API
-    case braintreeAPI
-
     /// Use the GraphQL API
     case graphQLAPI
 }

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -422,23 +422,6 @@ class BTAPIClient_Tests: XCTestCase {
 
         waitForExpectations(timeout: 2)
     }
-    func testPOST_whenUsingBraintreeAPI_doesNotIncludeMetadata() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockAPIHTTP = FakeAPIHTTP.fakeHTTP()
-        let mockHTTP = FakeHTTP.fakeHTTP()
-
-        apiClient?.apiHTTP = mockAPIHTTP
-        apiClient?.configurationHTTP = mockHTTP
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
-
-        let expectation = expectation(description: "POST callback")
-        apiClient?.post("/", parameters: [:], httpType: .braintreeAPI) { _, _, _ in
-            XCTAssertEqual(mockAPIHTTP.lastRequestParameters as? [String: String], [:])
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
 
     func testPOST_whenUsingGraphQLAPI_includesMetadata() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")


### PR DESCRIPTION
### Summary of changes

- There were no API requests in the SDK using the `BTAPIClientHTTPType.braintreeAPI` enum case
- I double checked that DropIn isn't using this enum case, as well

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
