### PR TITLE
Fixup - remove reference to PayPal ID Token

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -56,7 +56,7 @@ import Foundation
     // MARK: - Initializers
 
     /// Initialize a new API client.
-    /// - Parameter authorization: Your tokenization key, client token, or PayPal ID Token. Passing an invalid value may return `nil`.
+    /// - Parameter authorization: Your tokenization key or client token. Passing an invalid value may return `nil`.
     @objc(initWithAuthorization:)
     public convenience init?(authorization: String) {
         self.init(authorization: authorization, sendAnalyticsEvent: true)


### PR DESCRIPTION
### Summary of changes

- Looks like we forgot to remove a reference to "PayPal ID Token". This auth type is not supported.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 