### PR TITLE
Move Analytics to Caseless Enum

### DIFF
--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressAnalytics.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressAnalytics.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-class BTAmericanExpressAnalytics {
-    
+enum BTAmericanExpressAnalytics {
+
     // MARK: - Get Rewards Balance Events
     
     static let started = "amex:rewards-balance:started"

--- a/Sources/BraintreeApplePay/BTApplePayAnalytics.swift
+++ b/Sources/BraintreeApplePay/BTApplePayAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTApplePayAnalytics {
+enum BTApplePayAnalytics {
 
     // MARK: - Payment Request Events
 

--- a/Sources/BraintreeCard/BTCardAnalytics.swift
+++ b/Sources/BraintreeCard/BTCardAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTCardAnalytics {
+enum BTCardAnalytics {
 
     // MARK: - Tokenize Events
 

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentAnalytics.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTLocalPaymentAnalytics {
+enum BTLocalPaymentAnalytics {
     
     // MARK: - Conversion Events
       

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTPayPalAnalytics {
+enum BTPayPalAnalytics {
     
     // MARK: - Tokenize Events
     

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTPayPalNativeCheckoutAnalytics {
+enum BTPayPalNativeCheckoutAnalytics {
     
     // MARK: - Conversion Events
     

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectAnalytics.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTSEPADirectAnalytics {
+enum BTSEPADirectAnalytics {
     
     // MARK: - Conversion Events
     

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAnalytics.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class BTThreeDSecureAnalytics {
+enum BTThreeDSecureAnalytics {
     
     // MARK: Conversion Events
     

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-class BTVenmoAnalytics {
-    
+enum BTVenmoAnalytics {
+
     // MARK: - Conversion Events
     
     static let tokenizeStarted = "venmo:tokenize:started"


### PR DESCRIPTION
### Summary of changes

When we initially added the analytics classes we still had some modules in Obj-C. Caseless string enums are not a thing in Obj-C so we opted to use classes for the time being. Now that the SDK is fully Swift we can use caseless enums for these constants. These are safer because they cannot be constructed and do not contain initializers. This also tends to be preferred for storing constant values (Apple has also established this pattern for namespacing in newer frameworks such as Combine).

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
