### PR TITLE
Create PayPal Messaging Module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,9 +110,10 @@ jobs:
           sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeCard -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-card.json
           sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPal -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-paypal.json
           sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeVenmo -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-venmo.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPalMessaging -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-paypal-messaging.json
 
           # merge sourcekitten output
-          jq -s '.[0] + .[1] + .[2] + .[3] + .[4] + .[5] + .[6] + .[7] + .[8] + .[9] + .[10]' braintree-core.json braintree-pay-pal-native-checkout.json braintree-sepa-direct-debit.json braintree-american-express.json braintree-data-collector.json braintree-apple-pay.json braintree-local-payment.json braintree-three-d-secure.json braintree-card.json braintree-paypal.json braintree-venmo.json > swiftDoc.json
+          jq -s '.[0] + .[1] + .[2] + .[3] + .[4] + .[5] + .[6] + .[7] + .[8] + .[9] + .[10] + .[11]' braintree-core.json braintree-pay-pal-native-checkout.json braintree-sepa-direct-debit.json braintree-american-express.json braintree-data-collector.json braintree-apple-pay.json braintree-local-payment.json braintree-three-d-secure.json braintree-card.json braintree-paypal.json braintree-venmo.json braintree-paypal-messaging.json > swiftDoc.json
 
           jazzy \
             --sourcekitten-sourcefile swiftDoc.json \

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -75,7 +75,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalMessaging" do |s|
     s.source_files = "Sources/BraintreePayPalMessaging/*.swift"
     s.dependency "Braintree/Core"
-    s.dependency "PayPalMessages", '0.1.0'
+    s.dependency "PayPalMessages", '1.0.0-prerelease.3'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -72,6 +72,12 @@ Pod::Spec.new do |s|
     s.dependency "PayPalCheckout", '1.2.0'
   end
 
+  s.subspec "PayPalMessaging" do |s|
+    s.source_files = "Sources/BraintreePayPalMessaging/*.swift"
+    s.dependency "Braintree/Core"
+    s.dependency "PayPalMessages", '0.1.0'
+  end
+
   s.subspec "ThreeDSecure" do |s|
     s.source_files = "Sources/BraintreeThreeDSecure/**/*.{swift}"
     s.dependency "Braintree/Card"

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -895,6 +895,7 @@
 		BECC918E2B20DE7C00A2EE42 /* BraintreeVenmoTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BraintreeVenmoTests copy-Info.plist"; path = "/Users/jdesmarais/Desktop/PayPal/braintree_ios/BraintreeVenmoTests copy-Info.plist"; sourceTree = "<absolute>"; };
 		BECC91962B20E01F00A2EE42 /* BTPayPalMessagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalMessagingView.swift; sourceTree = "<group>"; };
 		BECC91982B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalMessagingView_Tests.swift; sourceTree = "<group>"; };
+		BECC919C2B20E87D00A2EE42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BED00CAD28A5419900D74AEC /* BTBinData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBinData.swift; sourceTree = "<group>"; };
 		BED00CAF28A579D700D74AEC /* BTClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientToken.swift; sourceTree = "<group>"; };
 		BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientTokenError.swift; sourceTree = "<group>"; };
@@ -1745,6 +1746,7 @@
 			isa = PBXGroup;
 			children = (
 				BECC91982B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift */,
+				BECC919C2B20E87D00A2EE42 /* Info.plist */,
 			);
 			path = BraintreePayPalMessagingTests;
 			sourceTree = "<group>";
@@ -6083,6 +6085,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = UnitTests/BraintreePayPalMessagingTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -6125,6 +6128,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = UnitTests/BraintreePayPalMessagingTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -257,6 +257,9 @@
 		BEC3F11328A4401E0074DF0F /* BTHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */; };
 		BEC66DBE2901CC9E0030B6B2 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BECBA0E62AEABC99002518AC /* BTCardClient_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */; };
+		BECC91702B20DDFF00A2EE42 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
+		BECC91872B20DE7C00A2EE42 /* BraintreeTestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A903E1A624F9D34000C314E1 /* BraintreeTestShared.framework */; };
+		BECC918F2B20DE9900A2EE42 /* BraintreePayPalMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECC91762B20DDFF00A2EE42 /* BraintreePayPalMessaging.framework */; platformFilter = ios; };
 		BED00CAC28A4504E00D74AEC /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BED00CAE28A5419900D74AEC /* BTBinData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAD28A5419900D74AEC /* BTBinData.swift */; };
 		BED00CB028A579D700D74AEC /* BTClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAF28A579D700D74AEC /* BTClientToken.swift */; };
@@ -562,6 +565,27 @@
 			remoteGlobalIDString = 570B936A285397520041BAFE;
 			remoteInfo = BraintreeCoreSwift;
 		};
+		BECC91642B20DDFF00A2EE42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A75DA344192138F000D997A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 570B936A285397520041BAFE;
+			remoteInfo = BraintreeCoreSwift;
+		};
+		BECC917A2B20DE7C00A2EE42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A75DA344192138F000D997A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A903E1A524F9D34000C314E1;
+			remoteInfo = BraintreeTestShared;
+		};
+		BECC91912B20DE9900A2EE42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A75DA344192138F000D997A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BECC91622B20DDFF00A2EE42;
+			remoteInfo = BraintreePayPalMessaging;
+		};
 		BED00CAA28A4504700D74AEC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A75DA344192138F000D997A2 /* Project object */;
@@ -863,6 +887,10 @@
 		BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTHTTPError.swift; sourceTree = "<group>"; };
 		BECA56C929C3F0A80098EC3C /* BTThreeDSecureV2UICustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2UICustomization.swift; sourceTree = "<group>"; };
 		BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient_IntegrationTests.swift; sourceTree = "<group>"; };
+		BECC91762B20DDFF00A2EE42 /* BraintreePayPalMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreePayPalMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BECC91772B20DE0000A2EE42 /* BraintreeVenmo copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BraintreeVenmo copy-Info.plist"; path = "/Users/jdesmarais/Desktop/PayPal/braintree_ios/BraintreeVenmo copy-Info.plist"; sourceTree = "<absolute>"; };
+		BECC918D2B20DE7C00A2EE42 /* BraintreePayPalMessagingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreePayPalMessagingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BECC918E2B20DE7C00A2EE42 /* BraintreeVenmoTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BraintreeVenmoTests copy-Info.plist"; path = "/Users/jdesmarais/Desktop/PayPal/braintree_ios/BraintreeVenmoTests copy-Info.plist"; sourceTree = "<absolute>"; };
 		BED00CAD28A5419900D74AEC /* BTBinData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBinData.swift; sourceTree = "<group>"; };
 		BED00CAF28A579D700D74AEC /* BTClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientToken.swift; sourceTree = "<group>"; };
 		BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientTokenError.swift; sourceTree = "<group>"; };
@@ -1089,6 +1117,23 @@
 			files = (
 				BE642DA227D0137000694A5B /* BraintreeSEPADirectDebit.framework in Frameworks */,
 				BE642D9A27D0132A00694A5B /* BraintreeTestShared.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC916F2B20DDFF00A2EE42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BECC91702B20DDFF00A2EE42 /* BraintreeCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC91862B20DE7C00A2EE42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BECC91872B20DE7C00A2EE42 /* BraintreeTestShared.framework in Frameworks */,
+				BECC918F2B20DE9900A2EE42 /* BraintreePayPalMessaging.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1343,6 +1388,8 @@
 				80824659252C19F5000AD8FF /* Sources */,
 				808249F8252C1F97000AD8FF /* UnitTests */,
 				BECE564728F99FAD001B0F25 /* Recovered References */,
+				BECC91772B20DE0000A2EE42 /* BraintreeVenmo copy-Info.plist */,
+				BECC918E2B20DE7C00A2EE42 /* BraintreeVenmoTests copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1373,6 +1420,8 @@
 				9CE5179B282D54030013C740 /* BraintreePayPalNativeCheckoutTests.xctest */,
 				BE642DA027D0132A00694A5B /* BraintreeSEPADirectDebitTests.xctest */,
 				BEF3F17C27CE9EC600072467 /* BraintreeSEPADirectDebit.framework */,
+				BECC91762B20DDFF00A2EE42 /* BraintreePayPalMessaging.framework */,
+				BECC918D2B20DE7C00A2EE42 /* BraintreePayPalMessagingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1776,6 +1825,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A91E1EA624FEEF21007540E5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC91712B20DDFF00A2EE42 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2245,6 +2301,44 @@
 			productReference = BE642DA027D0132A00694A5B /* BraintreeSEPADirectDebitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		BECC91622B20DDFF00A2EE42 /* BraintreePayPalMessaging */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BECC91732B20DDFF00A2EE42 /* Build configuration list for PBXNativeTarget "BraintreePayPalMessaging" */;
+			buildPhases = (
+				BECC91652B20DDFF00A2EE42 /* Sources */,
+				BECC916F2B20DDFF00A2EE42 /* Frameworks */,
+				BECC91712B20DDFF00A2EE42 /* Headers */,
+				BECC91722B20DDFF00A2EE42 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BECC91632B20DDFF00A2EE42 /* PBXTargetDependency */,
+			);
+			name = BraintreePayPalMessaging;
+			productName = BraintreeVenmo;
+			productReference = BECC91762B20DDFF00A2EE42 /* BraintreePayPalMessaging.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		BECC91782B20DE7C00A2EE42 /* BraintreePayPalMessagingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BECC918A2B20DE7C00A2EE42 /* Build configuration list for PBXNativeTarget "BraintreePayPalMessagingTests" */;
+			buildPhases = (
+				BECC917D2B20DE7C00A2EE42 /* Sources */,
+				BECC91862B20DE7C00A2EE42 /* Frameworks */,
+				BECC91892B20DE7C00A2EE42 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BECC91792B20DE7C00A2EE42 /* PBXTargetDependency */,
+				BECC91922B20DE9900A2EE42 /* PBXTargetDependency */,
+			);
+			name = BraintreePayPalMessagingTests;
+			productName = BraintreeVenmoTests;
+			productReference = BECC918D2B20DE7C00A2EE42 /* BraintreePayPalMessagingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BEF3F17227CE9EC600072467 /* BraintreeSEPADirectDebit */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BEF3F17927CE9EC600072467 /* Build configuration list for PBXNativeTarget "BraintreeSEPADirectDebit" */;
@@ -2387,6 +2481,8 @@
 				A91E1E8924FEDD7F007540E5 /* BraintreeLocalPaymentTests */,
 				2D941D371B59C76A0016EFB4 /* BraintreePayPal */,
 				A9E5C1DF24FD665D00EE691F /* BraintreePayPalTests */,
+				BECC91622B20DDFF00A2EE42 /* BraintreePayPalMessaging */,
+				BECC91782B20DE7C00A2EE42 /* BraintreePayPalMessagingTests */,
 				9CE51766282D51DD0013C740 /* BraintreePayPalNativeCheckout */,
 				9CE5179A282D54030013C740 /* BraintreePayPalNativeCheckoutTests */,
 				BE642D8E27D0132A00694A5B /* BraintreeSEPADirectDebitTests */,
@@ -2557,6 +2653,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BE642D9C27D0132A00694A5B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC91722B20DDFF00A2EE42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC91892B20DE7C00A2EE42 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3049,6 +3159,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BECC91652B20DDFF00A2EE42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BECC917D2B20DE7C00A2EE42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BEF3F17327CE9EC600072467 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3276,6 +3400,22 @@
 			isa = PBXTargetDependency;
 			target = 570B936A285397520041BAFE /* BraintreeCore */;
 			targetProxy = BEC66DBC2901CC990030B6B2 /* PBXContainerItemProxy */;
+		};
+		BECC91632B20DDFF00A2EE42 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 570B936A285397520041BAFE /* BraintreeCore */;
+			targetProxy = BECC91642B20DDFF00A2EE42 /* PBXContainerItemProxy */;
+		};
+		BECC91792B20DE7C00A2EE42 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A903E1A524F9D34000C314E1 /* BraintreeTestShared */;
+			targetProxy = BECC917A2B20DE7C00A2EE42 /* PBXContainerItemProxy */;
+		};
+		BECC91922B20DE9900A2EE42 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = BECC91622B20DDFF00A2EE42 /* BraintreePayPalMessaging */;
+			targetProxy = BECC91912B20DE9900A2EE42 /* PBXContainerItemProxy */;
 		};
 		BED00CAB28A4504700D74AEC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5768,6 +5908,209 @@
 			};
 			name = Release;
 		};
+		BECC91742B20DDFF00A2EE42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.BraintreePayPalMessaging;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BECC91752B20DDFF00A2EE42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.BraintreePayPalMessaging;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BECC918B2B20DE7C00A2EE42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 43253H4X22;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UnitTests/BraintreePayPalMessagingTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreePayPalMessagingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BECC918C2B20DE7C00A2EE42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43253H4X22;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UnitTests/BraintreePayPalMessagingTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.braintree.BraintreePayPalMessagingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		BEF3F17A27CE9EC600072467 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6117,6 +6460,24 @@
 			buildConfigurations = (
 				BE0B163A27DFF95900868C77 /* Debug */,
 				BE0B163B27DFF95900868C77 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BECC91732B20DDFF00A2EE42 /* Build configuration list for PBXNativeTarget "BraintreePayPalMessaging" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BECC91742B20DDFF00A2EE42 /* Debug */,
+				BECC91752B20DDFF00A2EE42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BECC918A2B20DE7C00A2EE42 /* Build configuration list for PBXNativeTarget "BraintreePayPalMessagingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BECC918B2B20DE7C00A2EE42 /* Debug */,
+				BECC918C2B20DE7C00A2EE42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -260,6 +260,8 @@
 		BECC91702B20DDFF00A2EE42 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BECC91872B20DE7C00A2EE42 /* BraintreeTestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A903E1A624F9D34000C314E1 /* BraintreeTestShared.framework */; };
 		BECC918F2B20DE9900A2EE42 /* BraintreePayPalMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECC91762B20DDFF00A2EE42 /* BraintreePayPalMessaging.framework */; platformFilter = ios; };
+		BECC91972B20E01F00A2EE42 /* BTPayPalMessagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECC91962B20E01F00A2EE42 /* BTPayPalMessagingView.swift */; };
+		BECC91992B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECC91982B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift */; };
 		BED00CAC28A4504E00D74AEC /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BED00CAE28A5419900D74AEC /* BTBinData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAD28A5419900D74AEC /* BTBinData.swift */; };
 		BED00CB028A579D700D74AEC /* BTClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAF28A579D700D74AEC /* BTClientToken.swift */; };
@@ -891,6 +893,8 @@
 		BECC91772B20DE0000A2EE42 /* BraintreeVenmo copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BraintreeVenmo copy-Info.plist"; path = "/Users/jdesmarais/Desktop/PayPal/braintree_ios/BraintreeVenmo copy-Info.plist"; sourceTree = "<absolute>"; };
 		BECC918D2B20DE7C00A2EE42 /* BraintreePayPalMessagingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreePayPalMessagingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BECC918E2B20DE7C00A2EE42 /* BraintreeVenmoTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BraintreeVenmoTests copy-Info.plist"; path = "/Users/jdesmarais/Desktop/PayPal/braintree_ios/BraintreeVenmoTests copy-Info.plist"; sourceTree = "<absolute>"; };
+		BECC91962B20E01F00A2EE42 /* BTPayPalMessagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalMessagingView.swift; sourceTree = "<group>"; };
+		BECC91982B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalMessagingView_Tests.swift; sourceTree = "<group>"; };
 		BED00CAD28A5419900D74AEC /* BTBinData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBinData.swift; sourceTree = "<group>"; };
 		BED00CAF28A579D700D74AEC /* BTClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientToken.swift; sourceTree = "<group>"; };
 		BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientTokenError.swift; sourceTree = "<group>"; };
@@ -1284,6 +1288,7 @@
 				A76D7C011BB1CAB00000FA6A /* BraintreeDataCollector */,
 				038C7FBB1EA1648900241ABE /* BraintreeLocalPayment */,
 				2D941D391B59C76A0016EFB4 /* BraintreePayPal */,
+				BECC91942B20DF7F00A2EE42 /* BraintreePayPalMessaging */,
 				9CE51786282D527E0013C740 /* BraintreePayPalNativeCheckout */,
 				BEF3F17027CE9E2600072467 /* BraintreeSEPADirectDebit */,
 				A91E1EAC24FEEF21007540E5 /* BraintreeThreeDSecure */,
@@ -1301,6 +1306,7 @@
 				A9E5C22524FD6D0800EE691F /* BraintreeCoreTests */,
 				A9E5C19F24FD5A7C00EE691F /* BraintreeDataCollectorTests */,
 				A91E1E8B24FEDD7F007540E5 /* BraintreeLocalPaymentTests */,
+				BECC91952B20DF9800A2EE42 /* BraintreePayPalMessagingTests */,
 				9CE5179C282D54030013C740 /* BraintreePayPalNativeCheckoutTests */,
 				A9E5C1E124FD665D00EE691F /* BraintreePayPalTests */,
 				BE642D8B27D0129D00694A5B /* BraintreeSEPADirectDebitTests */,
@@ -1725,6 +1731,22 @@
 				BEFE6DA927E28A0B002BE9C8 /* MockViewController.swift */,
 			);
 			path = BraintreeSEPADirectDebitTests;
+			sourceTree = "<group>";
+		};
+		BECC91942B20DF7F00A2EE42 /* BraintreePayPalMessaging */ = {
+			isa = PBXGroup;
+			children = (
+				BECC91962B20E01F00A2EE42 /* BTPayPalMessagingView.swift */,
+			);
+			path = BraintreePayPalMessaging;
+			sourceTree = "<group>";
+		};
+		BECC91952B20DF9800A2EE42 /* BraintreePayPalMessagingTests */ = {
+			isa = PBXGroup;
+			children = (
+				BECC91982B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift */,
+			);
+			path = BraintreePayPalMessagingTests;
 			sourceTree = "<group>";
 		};
 		BECE564728F99FAD001B0F25 /* Recovered References */ = {
@@ -2447,6 +2469,12 @@
 					A9E5C22324FD6D0800EE691F = {
 						CreatedOnToolsVersion = 12.0;
 					};
+					BECC91622B20DDFF00A2EE42 = {
+						LastSwiftMigration = 1500;
+					};
+					BECC91782B20DE7C00A2EE42 = {
+						LastSwiftMigration = 1500;
+					};
 				};
 			};
 			buildConfigurationList = A75DA347192138F000D997A2 /* Build configuration list for PBXProject "Braintree" */;
@@ -3163,6 +3191,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BECC91972B20E01F00A2EE42 /* BTPayPalMessagingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3170,6 +3199,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BECC91992B20E1E400A2EE42 /* BTPayPalMessagingView_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6028,6 +6058,7 @@
 		BECC918B2B20DE7C00A2EE42 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -6074,6 +6105,7 @@
 		BECC918C2B20DE7C00A2EE42 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/BraintreePayPalMessaging.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/BraintreePayPalMessaging.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BECC91622B20DDFF00A2EE42"
+               BuildableName = "BraintreePayPalMessaging.framework"
+               BlueprintName = "BraintreePayPalMessaging"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BECC91622B20DDFF00A2EE42"
+            BuildableName = "BraintreePayPalMessaging.framework"
+            BlueprintName = "BraintreePayPalMessaging"
+            ReferencedContainer = "container:Braintree.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BECC91782B20DE7C00A2EE42"
+               BuildableName = "BraintreePayPalMessagingTests.xctest"
+               BlueprintName = "BraintreePayPalMessagingTests"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -130,6 +146,16 @@
                BlueprintIdentifier = "BE642D8E27D0132A00694A5B"
                BuildableName = "BraintreeSEPADirectDebitTests.xctest"
                BlueprintName = "BraintreeSEPADirectDebitTests"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BECC91782B20DE7C00A2EE42"
+               BuildableName = "BraintreePayPalMessagingTests.xctest"
+               BlueprintName = "BraintreePayPalMessagingTests"
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -252,6 +252,16 @@
                ReferencedContainer = "container:../Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BECC91782B20DE7C00A2EE42"
+               BuildableName = "BraintreePayPalMessagingTests.xctest"
+               BlueprintName = "BraintreePayPalMessagingTests"
+               ReferencedContainer = "container:../Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,10 @@ let package = Package(
             targets: ["BraintreePayPal", "PPRiskMagnes"]
         ),
         .library(
+            name: "BraintreePayPalMessaging",
+            targets: ["BraintreePayPalMessaging"]
+        ),
+        .library(
             name: "BraintreePayPalNativeCheckout",
             targets: ["BraintreePayPalNativeCheckout"]
         ),
@@ -82,6 +86,15 @@ let package = Package(
         .target(
             name: "BraintreePayPal",
             dependencies: ["BraintreeCore", "BraintreeDataCollector"]
+        ),
+        .target(
+            name: "BraintreePayPalMessaging",
+            dependencies: ["BraintreeCore"]
+        ),
+        .binaryTarget(
+            name: "PayPalMessages",
+            url: "https://github.com/paypal/paypal-messages-ios/releases/download/1.0.0-prerelease.3/PayPalMessages.xcframework.zip",
+            checksum: "da7dad716b567c7b39946c34ad9acd7bf15a23d8f16b554ef0f3a036b9adda29"
         ),
         .target(
             name: "BraintreePayPalNativeCheckout",

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif
+
+public class BTPayPalMessagingView {
+
+    // TODO: will be implemented in a future PR
+}

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import BraintreePayPalMessaging
+
+final class BTPayPalMessagingView_Tests: XCTestCase {
+
+    // TODO: will be implemented in a future PR
+}

--- a/UnitTests/BraintreePayPalMessagingTests/Info.plist
+++ b/UnitTests/BraintreePayPalMessagingTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
### Summary of changes

- Create `BraintreePayPalMessaging` module shell
    - `BraintreePayPalMessaging` directory with empty file
    - `BraintreePayPalMessagingTests` with empty file and `Info/plist`
- Update `release.yml` workflow to publish reference docs once merged
- Add scheme for `BraintreePayPalMessaging`
- Add `BraintreePayPalMessagingTests` to app scheme for running tests
- Add `BraintreePayPalMessaging` to `Braintree.podspec`, `Package.swift`
    - Note: the Messages SDK is not currently published for Carthage (we have raised this as a blocker to that team)
    - Will update with the Cartfile updates in a future PR
- 

This work is going into the `paypal-messaging-feature` branch

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @agedd @jaxdesmarais 
