### PR TITLE
Add `URLOpener` protocol for mocking `UIApplication.shared`

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		8053F05929FB2F700076F988 /* URL+IsPayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8053F05829FB2F700076F988 /* URL+IsPayPal.swift */; };
 		80581A8C25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */; };
 		80581B1D2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */; };
+		80A6C6192B21205900416D50 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A6C6182B21205900416D50 /* UIApplication+URLOpener.swift */; };
 		80BA64AC29D788E000E15264 /* BTLocalPaymentResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA64AB29D788E000E15264 /* BTLocalPaymentResult.swift */; };
 		80BA64B229D7937E00E15264 /* BTLocalPaymentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA64B129D7937E00E15264 /* BTLocalPaymentRequest.swift */; };
 		80BA64B429D795D000E15264 /* BTLocalPaymentRequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA64B329D795D000E15264 /* BTLocalPaymentRequestDelegate.swift */; };
@@ -698,6 +699,7 @@
 		80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLHTTP_SSLPinning_IntegrationTests.swift; sourceTree = "<group>"; };
 		805FD35B2331780F0000B514 /* BTPostalAddress_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPostalAddress_Tests.swift; sourceTree = "<group>"; };
 		80A1EE3D2236AAC600F6218B /* BTThreeDSecureAdditionalInformation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAdditionalInformation_Tests.swift; sourceTree = "<group>"; };
+		80A6C6182B21205900416D50 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
 		80B6190C28C9535F00FB5022 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = Frameworks/XCFrameworks/PayPalCheckout.xcframework; sourceTree = "<group>"; };
 		80BA64AB29D788E000E15264 /* BTLocalPaymentResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentResult.swift; sourceTree = "<group>"; };
 		80BA64B129D7937E00E15264 /* BTLocalPaymentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentRequest.swift; sourceTree = "<group>"; };
@@ -1188,6 +1190,7 @@
 				BEBD05212A1FE8BE0003C15C /* BTWebAuthenticationSession.swift */,
 				BEB9BF522A26872B00A3673E /* BTWebAuthenticationSessionClient.swift */,
 				80F86FEF29FC2ED6003297FF /* Encodable+Dictionary.swift */,
+				80A6C6182B21205900416D50 /* UIApplication+URLOpener.swift */,
 				8053F05829FB2F700076F988 /* URL+IsPayPal.swift */,
 				BE7FA4C5291AC9B6003C6B63 /* Info.plist */,
 				BEBC6E5D2927CF59004E25A0 /* Braintree.h */,
@@ -2734,6 +2737,7 @@
 				BE24C67528E7491E0067B11A /* BTAPIClientAuthorization.swift in Sources */,
 				BE32ACBC2907744400A61FED /* BTCardNetwork.swift in Sources */,
 				570B93D92853C6180041BAFE /* BTLogLevel.swift in Sources */,
+				80A6C6192B21205900416D50 /* UIApplication+URLOpener.swift in Sources */,
 				579DAEC5286E04A700FCE87F /* BTAppContextSwitcher.swift in Sources */,
 				570B93D72853C29A0041BAFE /* BTLogLevelDescription.swift in Sources */,
 				57CBBCE828B033760037F4EE /* BTGraphQLHTTP.swift in Sources */,

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -1,20 +1,11 @@
-//
-//  UIApplication+URLOpener.swift
-//  BraintreeCore
-//
-//  Created by Samantha Cannillo on 12/6/23.
-//
-
 import UIKit
 
+/// :nodoc: This protocol is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
 public protocol URLOpener {
     
     func canOpenURL(_ url: URL) -> Bool
-    func open(
-        _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey : Any],
-        completionHandler completion: ((Bool) -> Void)?
-    )
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
 }
 
 extension UIApplication: URLOpener { }

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 /// :nodoc: This protocol is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+///
+/// Used to mock `UIApplication`.
 @_documentation(visibility: private)
 public protocol URLOpener {
     

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -1,0 +1,20 @@
+//
+//  UIApplication+URLOpener.swift
+//  BraintreeCore
+//
+//  Created by Samantha Cannillo on 12/6/23.
+//
+
+import UIKit
+
+public protocol URLOpener {
+    
+    func canOpenURL(_ url: URL) -> Bool
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey : Any],
+        completionHandler completion: ((Bool) -> Void)?
+    )
+}
+
+extension UIApplication: URLOpener { }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -15,8 +15,7 @@ import BraintreeCore
     var apiClient: BTAPIClient
 
     /// Defaults to `UIApplication.shared`, but exposed for unit tests to inject test doubles
-    /// to prevent calls to openURL. Its type is `id` and not `UIApplication` because trying to subclass
-    /// UIApplication is not possible, since it enforces that only one instance can ever exist
+    /// to prevent calls to openURL. Subclassing UIApplication is not possible, since it enforces that only one instance can ever exist.
     var application: URLOpener = UIApplication.shared
 
     /// Defaults to `Bundle.main`, but exposed for unit tests to inject test doubles to stub values in infoDictionary

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -17,7 +17,7 @@ import BraintreeCore
     /// Defaults to `UIApplication.shared`, but exposed for unit tests to inject test doubles
     /// to prevent calls to openURL. Its type is `id` and not `UIApplication` because trying to subclass
     /// UIApplication is not possible, since it enforces that only one instance can ever exist
-    var application: AnyObject = UIApplication.shared
+    var application: URLOpener = UIApplication.shared
 
     /// Defaults to `Bundle.main`, but exposed for unit tests to inject test doubles to stub values in infoDictionary
     var bundle: Bundle = .main
@@ -221,25 +221,17 @@ import BraintreeCore
 
     /// Returns true if the proper Venmo app is installed and configured correctly, returns false otherwise.
     @objc public func isVenmoAppInstalled() -> Bool {
-        if let _ = application as? UIApplication {
-            guard let appSwitchURL = BTVenmoAppSwitchRedirectURL().baseAppSwitchURL else {
-                return false
-            }
-
-            return UIApplication.shared.canOpenURL(appSwitchURL)
-        } else {
-            return application.canOpenURL(BTVenmoAppSwitchRedirectURL().baseAppSwitchURL ?? URL(string: "")!)
+        guard let appSwitchURL = BTVenmoAppSwitchRedirectURL().baseAppSwitchURL else {
+            return false
         }
+        
+        return application.canOpenURL(appSwitchURL)
     }
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
         apiClient.sendAnalyticsEvent("ios.pay-with-venmo.app-store.invoked")
-        if let _ = application as? UIApplication {
-            UIApplication.shared.open(appStoreURL)
-        } else {
-            application.open(appStoreURL)
-        }
+        application.open(appStoreURL, options: [:], completionHandler: nil)
     }
 
     // MARK: - Internal Methods
@@ -324,14 +316,8 @@ import BraintreeCore
     }
 
     func performAppSwitch(with appSwitchURL: URL, shouldVault vault: Bool, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        if let _ = application as? UIApplication {
-            UIApplication.shared.open(appSwitchURL) { success in
-                self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
-            }
-        } else {
-            application.open(appSwitchURL) { success in
-                self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
-            }
+        application.open(appSwitchURL, options: [:]) { success in
+            self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
         }
     }
 

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -9,10 +9,10 @@ public class FakeApplication: URLOpener {
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
 
-    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
+    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler: ((Bool) -> Void)?) {
         lastOpenURL = url
         openURLWasCalled = true
-        completion?(cannedOpenURLSuccess)
+        completionHandler?(cannedOpenURLSuccess)
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -1,20 +1,18 @@
 import UIKit
+import BraintreeCore
 
-public class FakeApplication: NSExtensionContext {
+public class FakeApplication: URLOpener {
+    
     public var lastOpenURL: URL? = nil
     public var openURLWasCalled: Bool = false
     var cannedOpenURLSuccess: Bool = true
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
 
-    public override init() {
-        // no-op
-    }
-
-    @objc public override func open(_ URL: URL, completionHandler: (@Sendable (Bool) -> Void)? = nil) {
-        lastOpenURL = URL
+    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
+        lastOpenURL = url
         openURLWasCalled = true
-        completionHandler?(cannedOpenURLSuccess)
+        completion?(cannedOpenURLSuccess)
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {


### PR DESCRIPTION
### Summary of changes

- Move to protocol & extension to mock `UIApplication.shared`
    - This let's us remove the logic that lived in `BTVenmoClient` source code which only existed for mocking
- Update `FakeApplication` to conform to new protocol

### References

http://swiftyjimmy.com/mock-uiapplication-swift/

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 