### PR TITLE
Allow email OR phone to init `BTShopperInsightsRequest`

### DIFF
--- a/Sources/BraintreeCore/BTShopperInsightsRequest.swift
+++ b/Sources/BraintreeCore/BTShopperInsightsRequest.swift
@@ -4,25 +4,52 @@ import Foundation
 /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTShopperInsightsRequest {
     
+    // MARK: - Private Properties
+    
     /// The buyer's email address.
-    private let email: String
+    private var email: String?
     
-    /// The buyer's country code prefix to the national telephone number. An identifier for a specific country.
-    /// Must not contain special characters.
-    private let phoneCountryCode: String
+    /// The buyer's phone number details.
+    private var phone: Phone?
     
-    /// The buyer's national phone number. Must not contain special characters.
-    private let phoneNationalNumber: String
+    // MARK: - Initializers
+
+    /// Initialize a `BTShopperInsightsRequest`
+    /// - Parameters:
+    ///   - email: The buyer's email address.
+    ///   - phone: The buyer's phone number details.
+    /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
+    public init(email: String, phone: Phone) {
+        self.email = email
+        self.phone = phone
+    }
     
     /// Initialize a `BTShopperInsightsRequest`
     /// - Parameters:
     ///   - email: The buyer's email address.
-    ///   - phoneCountryCode: The buyer's country code prefix to the national telephone number. An identifier for a specific country. Must not contain special characters.
-    ///   - phoneNationalNumber: The buyer's national phone number. Must not contain special characters.
     /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
-    public init(email: String, phoneCountryCode: String, phoneNationalNumber: String) {
+    public init(email: String) {
         self.email = email
-        self.phoneCountryCode = phoneCountryCode
-        self.phoneNationalNumber = phoneNationalNumber
+    }
+    
+    /// Initialize a `BTShopperInsightsRequest`
+    /// - Parameters:
+    ///   - phone: The buyer's phone number details.
+    /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
+    public init(phone: Phone) {
+        self.phone = phone
+    }
+    
+    // MARK: - Data Types
+    
+    /// Buyer's phone number details for use fetching Shopper Insights.
+    public struct Phone {
+        
+        /// The buyer's country code prefix to the national telephone number. An identifier for a specific country.
+        /// Must not contain special characters.
+        private let phoneCountryCode: String
+        
+        /// The buyer's national phone number. Must not contain special characters.
+        private let phoneNationalNumber: String
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add multiple inits to `BTShopperInsightsRequest` to allow for merchants to pass the following combinations:
   1. email only
   2. phone only
   3. email & phone
- Cleanup docstrings & remove redundancies

Note: Tests for this will come once we start constructing the POST json body.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 