### PR TITLE
Add SPM workspace dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ SampleApps/CarthageTest/Cartfile.resolved
 .swiftpm
 .build
 SampleApps/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+Braintree.xcworkspace/xcshareddata/swiftpm/
 
 *.pid


### PR DESCRIPTION

![Screenshot 2023-12-08 at 12 07 37 PM](https://github.com/braintree/braintree_ios/assets/35243507/b860f40a-8770-445d-812d-859b61b45b79)

### Summary of changes

- We don't check in this file and it's always a pain when switching b/w branches. 
- Added it to the gitignore

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 