### PR TITLE
Remove missed Venmo app store analytics event

### DIFF
--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -229,7 +229,6 @@ import BraintreeCore
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
-        apiClient.sendAnalyticsEvent("ios.pay-with-venmo.app-store.invoked")
         application.open(appStoreURL, options: [:], completionHandler: nil)
     }
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -771,7 +771,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
     // MARK: - openVenmoAppPageInAppStore
 
-    func testGotoVenmoInAppStore_opensVenmoAppStoreURL_andSendsAnalyticsEvent() {
+    func testGotoVenmoInAppStore_opensVenmoAppStoreURL() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
         let fakeApplication = FakeApplication()
@@ -782,6 +782,5 @@ class BTVenmoClient_Tests: XCTestCase {
 
         XCTAssertTrue(fakeApplication.openURLWasCalled)
         XCTAssertEqual(fakeApplication.lastOpenURL!.absoluteString, "https://itunes.apple.com/us/app/venmo-send-receive-money/id351727428")
-        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "ios.pay-with-venmo.app-store.invoked")
     }
 }


### PR DESCRIPTION
### Summary of changes

- We just realized that we missed removing this analytic event in iOS V6 (see [GH convo in braintree_android](https://github.com/braintree/braintree_android/pull/846#discussion_r1422907840))

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
