### PR TITLE
Fix unresolved callback in `BTThreeDSecureClient.initializeChallenge()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeThreeDSecure
+  * Fix bug where `BTThreeDSecureClient.initializeChallenge()` callback wasn't properly invoked (fixes #1154)
+
 ## 6.10.0 (2023-11-17)
 * BraintreePayPalNativeCheckout
   * Update PayPalCheckout from 1.1.0 to 1.2.0.

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -169,14 +169,17 @@ import BraintreeCore
     ///   - lookupResponse: The JSON string returned by the server side lookup.
     ///   - request: The BTThreeDSecureRequest object where prepareLookup was called.
     ///   - completion: This completion will be invoked exactly once when the payment flow is complete or an error occurs.
+    /// - Note: Majority of 3DS integrations do not need to use this method. Only for server-side 3DS integrations.
     @objc(initializeChallengeWithLookupResponse:request:completion:)
     public func initializeChallenge(
         lookupResponse: String,
         request: BTThreeDSecureRequest,
         completion: @escaping (BTThreeDSecureResult?, Error?) -> Void
     ) {
+        self.merchantCompletion = completion
+        
         guard let dataResponse = lookupResponse.data(using: .utf8) else {
-            completion(nil, BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "Lookup response cannot be converted to Data type."]))
+            merchantCompletion(nil, BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "Lookup response cannot be converted to Data type."]))
             return
         }
 


### PR DESCRIPTION
### Summary of changes

- Address GH Issue https://github.com/braintree/braintree_ios/issues/1154
- Set completion for `initializeChallenge()` func
    - I tested & verified, this was indeed a bug and the callback wasn't firing prior
- 🏈 Punting on adding unit tests to this method (DTBTSDK-3286)

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
