### PR TITLE
Make SDK Errors Public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Update all SDK errors to be public and Equatable (fixes #1152 and #1080)
+
 ## 6.10.0 (2023-11-17)
 * BraintreePayPalNativeCheckout
   * Update PayPalCheckout from 1.1.0 to 1.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Update all SDK errors to be public and Equatable (fixes #1152 and #1080)
+* Update all SDK errors to be public and [Equatable](https://developer.apple.com/documentation/swift/equatable) (fixes #1152 and #1080)
 * BraintreeThreeDSecure
   * Fix bug where `BTThreeDSecureClient.initializeChallenge()` callback wasn't properly invoked (fixes #1154)
 

--- a/Demo/Application/Features/IdealViewController.swift
+++ b/Demo/Application/Features/IdealViewController.swift
@@ -71,7 +71,7 @@ class IdealViewController: PaymentButtonBaseViewController {
 
         localPaymentClient.startPaymentFlow(request) { result, error in
             guard let result else {
-                if (error as? NSError)?.code == 5 {
+                if error as? BTLocalPaymentError == .canceled("") {
                     self.progressBlock("Canceled 🎲")
                 } else {
                     self.progressBlock("Error: \(error?.localizedDescription ?? "")")

--- a/Demo/Application/Features/SEPADirectDebitViewController.swift
+++ b/Demo/Application/Features/SEPADirectDebitViewController.swift
@@ -39,12 +39,14 @@ class SEPADirectDebitViewController: PaymentButtonBaseViewController {
         sepaDirectDebitRequest.merchantAccountID = "EUR-sepa-direct-debit"
 
         sepaDirectDebitClient.tokenize(sepaDirectDebitRequest) { sepaDirectDebitNonce, error in
-            if let sepaDirectDebitNonce = sepaDirectDebitNonce {
+            if let sepaDirectDebitNonce {
                 self.completionBlock(sepaDirectDebitNonce)
-            } else if let error = error {
-                self.progressBlock(error.localizedDescription)
-            } else {
-                self.progressBlock("Canceled")
+            } else if let error {
+                if error as? BTSEPADirectDebitError == .webFlowCanceled {
+                    self.progressBlock("Canceled")
+                } else {
+                    self.progressBlock(error.localizedDescription)
+                }
             }
         }
     }

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -60,7 +60,7 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
                 self.updateCallbackCount()
 
                 guard let threeDSecureResult else {
-                    if (error as? NSError)?.code == 5 {
+                    if error as? BTThreeDSecureError == .canceled {
                         self.progressBlock("Canceled 🎲")
                     } else {
                         self.progressBlock(error?.localizedDescription)

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -66,7 +66,7 @@ class VenmoViewController: PaymentButtonBaseViewController {
                 progressBlock("Got a nonce 💎!")
                 completionBlock(venmoAccount)
             } catch {
-                if (error as NSError).code == 10 {
+                if error as? BTVenmoError == .canceled {
                     progressBlock("Canceled 🔰")
                 } else {
                     progressBlock(error.localizedDescription)

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressError.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error details associated with American Express.
-enum BTAmericanExpressError: Int, Error, CustomNSError, LocalizedError {
+public enum BTAmericanExpressError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -12,15 +12,15 @@ enum BTAmericanExpressError: Int, Error, CustomNSError, LocalizedError {
     /// 2. Deallocated BTAmericanExpressClient
     case deallocated
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTAmericanExpressErrorDomain"
     }
     
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .unknown:
             return "An unknown error occurred. Please contact support."

--- a/Sources/BraintreeApplePay/BTApplePayError.swift
+++ b/Sources/BraintreeApplePay/BTApplePayError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Error codes associated with Apple Pay.
-enum BTApplePayError: Int, Error, CustomNSError, LocalizedError {
+public enum BTApplePayError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -15,15 +15,15 @@ enum BTApplePayError: Int, Error, CustomNSError, LocalizedError {
     /// 3. Unable to create BTApplePayCardNonce
     case failedToCreateNonce
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTApplePayErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .unknown:
             return ""

--- a/Sources/BraintreeCard/BTCardError.swift
+++ b/Sources/BraintreeCard/BTCardError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // Error codes associated with cards
-enum BTCardError: Error, CustomNSError, LocalizedError {
+public enum BTCardError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -18,11 +18,11 @@ enum BTCardError: Error, CustomNSError, LocalizedError {
     /// 4. Failed to fetch Braintree configuration
     case fetchConfigurationFailed
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTCardClientErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .unknown:
             return 0
@@ -37,7 +37,7 @@ enum BTCardError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorUserInfo: [String: Any] {
+    public var errorUserInfo: [String: Any] {
         switch self {
         case .unknown:
             return [NSLocalizedDescriptionKey: "An unknown error occurred. Please contact support."]
@@ -50,5 +50,11 @@ enum BTCardError: Error, CustomNSError, LocalizedError {
         case .fetchConfigurationFailed:
             return [NSLocalizedDescriptionKey: "Failed to fetch Braintree configuration."]
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTCardError, rhs: BTCardError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsServiceError.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsServiceError.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 ///  Error codes associated with a API Client.
-enum BTAnalyticsServiceError: Int, Error, CustomNSError, LocalizedError {
+public enum BTAnalyticsServiceError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Invalid API client
     case invalidAPIClient
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTAnalyticsServiceErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidAPIClient:
             return "API client must have client token or tokenization key"

--- a/Sources/BraintreeCore/BTAPIClientError.swift
+++ b/Sources/BraintreeCore/BTAPIClientError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error codes associated with a API Client.
-enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError {
+public enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Configuration fetch failed
     case configurationUnavailable
@@ -12,15 +12,15 @@ enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError {
     /// 2. Deallocated BTAPIClient
     case deallocated
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTAPIClientErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .configurationUnavailable:
             return "The operation couldn’t be completed. Unable to fetch remote configuration from Braintree API at this time."

--- a/Sources/BraintreeCore/BTClientTokenError.swift
+++ b/Sources/BraintreeCore/BTClientTokenError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error codes associated with a client token.
-enum BTClientTokenError: Error, CustomNSError, LocalizedError {
+public enum BTClientTokenError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Authorization fingerprint was not present or invalid
     case invalidAuthorizationFingerprint
@@ -18,11 +18,11 @@ enum BTClientTokenError: Error, CustomNSError, LocalizedError {
     /// 4. Failed decoding from Base64 or UTF8
     case failedDecoding(String)
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTClientTokenErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .invalidAuthorizationFingerprint:
             return 0
@@ -37,7 +37,7 @@ enum BTClientTokenError: Error, CustomNSError, LocalizedError {
         }
     }
     
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidAuthorizationFingerprint:
             return "Invalid client token. Please ensure your server is generating a valid Braintree ClientToken. Authorization fingerprint was not present or invalid."

--- a/Sources/BraintreeCore/BTHTTPError.swift
+++ b/Sources/BraintreeCore/BTHTTPError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Error codes associated with BTHTTP
-enum BTHTTPError: Error, CustomNSError, LocalizedError {
+public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error (reserved)
     case unknown
@@ -42,11 +42,11 @@ enum BTHTTPError: Error, CustomNSError, LocalizedError {
     /// 12. Deallocated HTTPClient
     case deallocated(String)
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         BTCoreConstants.httpErrorDomain
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .unknown:
             return 0
@@ -77,7 +77,7 @@ enum BTHTTPError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorUserInfo: [String : Any] {
+    public var errorUserInfo: [String: Any] {
         switch self {
         case .unknown:
             return [NSLocalizedDescriptionKey: "An unexpected error occurred with the HTTP request."]
@@ -106,5 +106,11 @@ enum BTHTTPError: Error, CustomNSError, LocalizedError {
         case .deallocated(let httpType):
             return [NSLocalizedDescriptionKey: "\(httpType) has been deallocated."]
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTHTTPError, rhs: BTHTTPError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreeCore/BTJSONError.swift
+++ b/Sources/BraintreeCore/BTJSONError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BTJSONError: Error, CustomNSError, LocalizedError {
+public enum BTJSONError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. JSONSerialization failure
     case jsonSerializationFailure
@@ -11,11 +11,11 @@ enum BTJSONError: Error, CustomNSError, LocalizedError {
     /// 2. Invalid key
     case keyInvalid(String)
     
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTJSONErrorDomain"
     }
     
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .jsonSerializationFailure:
             return 0
@@ -26,7 +26,7 @@ enum BTJSONError: Error, CustomNSError, LocalizedError {
         }
     }
     
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .jsonSerializationFailure:
             return "Failed to serialize JSON data in initilizer"

--- a/Sources/BraintreeDataCollector/BTDataCollectorError.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollectorError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error details associated with Braintree Data Collector.
-enum BTDataCollectorError: Int, Error, CustomNSError, LocalizedError {
+public enum BTDataCollectorError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -12,15 +12,15 @@ enum BTDataCollectorError: Int, Error, CustomNSError, LocalizedError {
     /// 2. The device data could not be encoded.
     case encodingFailure
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTDataCollectorErrorDomain"
     }
     
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .unknown:
             return "An unknown error occurred. Please contact support."

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentError.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentError.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Error codes associated with Payment Flow
-enum BTLocalPaymentError: Error, CustomNSError, LocalizedError {
-    
+public enum BTLocalPaymentError: Error, CustomNSError, LocalizedError, Equatable {
+
     /// 0. Unknown error
     case unknown
 
@@ -36,9 +36,9 @@ enum BTLocalPaymentError: Error, CustomNSError, LocalizedError {
     /// 10. ASWebAuthentication error
     case webSessionError(Error)
 
-    static var errorDomain = "com.braintreepayments.BTLocalPaymentErrorDomain"
+    public static var errorDomain = "com.braintreepayments.BTLocalPaymentErrorDomain"
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .unknown:
             return 0
@@ -65,7 +65,7 @@ enum BTLocalPaymentError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorDescription: String {
+    public var errorDescription: String {
         switch self {
         case .unknown:
             return ""
@@ -90,5 +90,11 @@ enum BTLocalPaymentError: Error, CustomNSError, LocalizedError {
         case .webSessionError(let error):
             return "ASWebAuthenticationSession failed with \(error.localizedDescription)"
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTLocalPaymentError, rhs: BTLocalPaymentError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Error codes associated with PayPal.
-enum BTPayPalError: Error, CustomNSError, LocalizedError {
+public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. PayPal is disabled in configuration
     case disabled
@@ -33,11 +33,11 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
     /// 9. Deallocated BTPayPalClient
     case deallocated
     
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .disabled:
             return 0
@@ -62,7 +62,7 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .disabled:
             return "PayPal is not enabled for this merchant. Enable PayPal for this merchant in the Braintree Control Panel."
@@ -85,5 +85,11 @@ enum BTPayPalError: Error, CustomNSError, LocalizedError {
         case .deallocated:
             return "BTPayPalClient has been deallocated."
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTPayPalError, rhs: BTPayPalError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
@@ -2,10 +2,7 @@ import Foundation
 import PayPalCheckout
 
 /// Error returned from the native PayPal flow
-enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatable  {
-    static func == (lhs: BTPayPalNativeCheckoutError, rhs: BTPayPalNativeCheckoutError) -> Bool {
-        lhs.errorCode == rhs.errorCode
-    }
+public enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Request is not of type BTPayPalNativeCheckoutRequest or BTPayPalNativeVaultRequest
     case invalidRequest
@@ -46,11 +43,11 @@ enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatabl
     /// 12. Missing return url in approval data
     case missingReturnURL
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTPaypalNativeCheckoutErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .invalidRequest:
             return 0
@@ -81,7 +78,7 @@ enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatabl
         }
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidRequest:
             return "Request is not of type BTPayPalNativeCheckoutRequest or BTPayPalNativeVaultRequest."
@@ -110,5 +107,11 @@ enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatabl
         case .missingReturnURL:
             return "Return URL is missing from the approval data."
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTPayPalNativeCheckoutError, rhs: BTPayPalNativeCheckoutError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitError.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error details associated with SEPA Direct Debit.
-enum BTSEPADirectDebitError: Int, Error, CustomNSError, LocalizedError {
+public enum BTSEPADirectDebitError: Int, Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -30,15 +30,15 @@ enum BTSEPADirectDebitError: Int, Error, CustomNSError, LocalizedError {
     /// 8. Deallocated BTSEPADirectDebitClient
     case deallocated
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.SEPADirectDebitErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         rawValue
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .unknown:
             return "An unknown error occurred. Please contact support."

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -299,8 +299,8 @@ import BraintreeCore
     
     private func performV2Authentication(with lookupResult: BTThreeDSecureResult) {
         threeDSecureV2Provider?.process(lookupResult: lookupResult) { result, error in
-            if let error = error as NSError? {
-                if error.code == BTThreeDSecureError.canceled.errorCode {
+            if let error {
+                if error as? BTThreeDSecureError == .canceled {
                     self.apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.verifyCanceled)
                 }
 
@@ -385,7 +385,7 @@ import BraintreeCore
                 if let error = error as NSError? {
                     // Provide more context for card validation error when status code 422
                     if error.domain == BTCoreConstants.httpErrorDomain,
-                        error.code == 2, // BTHTTPError.errorCode.clientError
+                       error as? BTHTTPError == .clientError([:]),
                        let urlResponseError = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse,
                        urlResponseError.statusCode == 422 {
                         var userInfo: [String: Any] = error.userInfo

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureError.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BTThreeDSecureError: Error, CustomNSError, LocalizedError {
+public enum BTThreeDSecureError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -29,11 +29,11 @@ enum BTThreeDSecureError: Error, CustomNSError, LocalizedError {
     /// 8. Deallocated BTThreeDSecureClient
     case deallocated
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTThreeDSecureFlowErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .unknown:
             return 0
@@ -56,7 +56,7 @@ enum BTThreeDSecureError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorUserInfo: [String : Any] {
+    public var errorUserInfo: [String: Any] {
         switch self {
         case .unknown:
             return [NSLocalizedDescriptionKey: "An unknown error occurred. Please contact support."]
@@ -77,5 +77,11 @@ enum BTThreeDSecureError: Error, CustomNSError, LocalizedError {
         case .deallocated:
             return [NSLocalizedDescriptionKey: "BTThreeDSecureClient has been deallocated."]
         }
+    }
+
+    // MARK: - Equatable Conformance
+
+    public static func == (lhs: BTThreeDSecureError, rhs: BTThreeDSecureError) -> Bool {
+        lhs.errorCode == rhs.errorCode
     }
 }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
@@ -78,18 +78,6 @@ class BTThreeDSecureV2Provider {
         )
     }
 
-    // MARK: - Private Methods
-
-    private func notifyError(
-        withDomain errorDomain: String,
-        errorCode: Int,
-        errorUserInfo: [String: Any]? = nil,
-        completion: @escaping (BTThreeDSecureResult?, Error?) -> Void
-    ) {
-        let error = NSError(domain: errorDomain, code: errorCode, userInfo: errorUserInfo)
-        completion(nil, error)
-    }
-
     private func analyticsString(for actionCode: CardinalResponseActionCode) -> String {
         switch actionCode {
         case .success:
@@ -141,18 +129,9 @@ extension BTThreeDSecureV2Provider: CardinalValidationDelegate {
                 errorCode = BTThreeDSecureError.failedAuthentication("").errorCode
             }
             apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.challengeFailed)
-            notifyError(
-                withDomain: BTThreeDSecureError.errorDomain,
-                errorCode: errorCode,
-                errorUserInfo: userInfo,
-                completion: completionHandler
-            )
+            completionHandler(nil, NSError(domain: BTThreeDSecureError.errorDomain, code: errorCode, userInfo: userInfo))
         case .cancel:
-            notifyError(
-                withDomain: BTThreeDSecureError.errorDomain,
-                errorCode: BTThreeDSecureError.canceled.errorCode,
-                completion: completionHandler
-            )
+            completionHandler(nil, BTThreeDSecureError.canceled)
         default:
             break
         }

--- a/Sources/BraintreeVenmo/BTVenmoError.swift
+++ b/Sources/BraintreeVenmo/BTVenmoError.swift
@@ -1,23 +1,23 @@
 import Foundation
 
 /// Error codes associated with Venmo App Switch
-enum BTVenmoAppSwitchError: Error, CustomNSError, LocalizedError {
+public enum BTVenmoAppSwitchError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. The error returned from the Venmo return URL
     case returnURLError(Int, String?)
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTVenmoAppSwitchReturnURLErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .returnURLError(let errorCode, _):
             return errorCode
         }
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .returnURLError(_, let errorMessage):
             return errorMessage
@@ -26,7 +26,7 @@ enum BTVenmoAppSwitchError: Error, CustomNSError, LocalizedError {
 }
 
 /// Error codes associated with Venmo
-enum BTVenmoError: Error, CustomNSError, LocalizedError {
+public enum BTVenmoError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Unknown error
     case unknown
@@ -61,11 +61,11 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
     /// 10.  The Venmo flow was canceled by the user
     case canceled
 
-    static var errorDomain: String {
+    public static var errorDomain: String {
         "com.braintreepayments.BTVenmoErrorDomain"
     }
 
-    var errorCode: Int {
+    public var errorCode: Int {
         switch self {
         case .unknown:
             return 0
@@ -92,7 +92,7 @@ enum BTVenmoError: Error, CustomNSError, LocalizedError {
         }
     }
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .unknown:
             return "An unknown error occurred. Please contact support."


### PR DESCRIPTION
### Summary of changes

- Update all SDK errors to be public (fixes #1152 and #1080)
- Update all errors to conform to Equatable
    - This allows for a better merchant experience as they won't need to cast to `NSError` and can do error comparison in a more Swift-y way (see Demo app ViewController updates as an example)

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 