### PR TITLE
Paypal Messaging Analytics

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		BE642DA227D0137000694A5B /* BraintreeSEPADirectDebit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEF3F17C27CE9EC600072467 /* BraintreeSEPADirectDebit.framework */; platformFilter = ios; };
 		BE642DA927D013A400694A5B /* BTSEPADirectDebitClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE642D8C27D0130300694A5B /* BTSEPADirectDebitClient_Tests.swift */; };
 		BE642DAB27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */; };
+		BE67CDBE2B29FC3D00BA4904 /* BTPayPalMessagingAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE67CDBD2B29FC3D00BA4904 /* BTPayPalMessagingAnalytics.swift */; };
 		BE698EA028AA8DCB001D9B10 /* BTHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE698E9F28AA8DCB001D9B10 /* BTHTTP.swift */; };
 		BE698EA228AA8EEA001D9B10 /* BTCacheDateValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE698EA128AA8EEA001D9B10 /* BTCacheDateValidator.swift */; };
 		BE698EA428AD2C10001D9B10 /* BTCoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE698EA328AD2C10001D9B10 /* BTCoreConstants.swift */; };
@@ -858,6 +859,7 @@
 		BE642D8C27D0130300694A5B /* BTSEPADirectDebitClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitClient_Tests.swift; sourceTree = "<group>"; };
 		BE642DA027D0132A00694A5B /* BraintreeSEPADirectDebitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeSEPADirectDebitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE642DAA27D01BCA00694A5B /* BTSEPADirectDebitNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitNonce_Tests.swift; sourceTree = "<group>"; };
+		BE67CDBD2B29FC3D00BA4904 /* BTPayPalMessagingAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalMessagingAnalytics.swift; sourceTree = "<group>"; };
 		BE698E9F28AA8DCB001D9B10 /* BTHTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTHTTP.swift; sourceTree = "<group>"; };
 		BE698EA128AA8EEA001D9B10 /* BTCacheDateValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCacheDateValidator.swift; sourceTree = "<group>"; };
 		BE698EA328AD2C10001D9B10 /* BTCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCoreConstants.swift; sourceTree = "<group>"; };
@@ -1777,6 +1779,7 @@
 				BEA0F9232B2373A600C21EFA /* BTPayPalMessagingPlacement.swift */,
 				BEA0F9272B23741900C21EFA /* BTPayPalMessagingRequest.swift */,
 				BEA0F9252B2373E400C21EFA /* BTPayPalMessagingTextAlignment.swift */,
+				BE67CDBD2B29FC3D00BA4904 /* BTPayPalMessagingAnalytics.swift */,
 			);
 			path = BraintreePayPalMessaging;
 			sourceTree = "<group>";
@@ -3246,6 +3249,7 @@
 			files = (
 				BEA0F9242B2373A600C21EFA /* BTPayPalMessagingPlacement.swift in Sources */,
 				BEA0F9222B23736500C21EFA /* BTPayPalMessagingOfferType.swift in Sources */,
+				BE67CDBE2B29FC3D00BA4904 /* BTPayPalMessagingAnalytics.swift in Sources */,
 				BEA0F9202B23731700C21EFA /* BTPayPalMessagingLogoType.swift in Sources */,
 				BEA0F9262B2373E400C21EFA /* BTPayPalMessagingTextAlignment.swift in Sources */,
 				BEA0F91E2B23728000C21EFA /* BTPayPalMessagingDelegate.swift in Sources */,

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingAnalytics.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingAnalytics.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum BTPayPalMessagingAnalytics {
+
+    static let started = "paypal-messaging:create-view:started"
+    static let failed = "paypal-messaging:create-view:failed"
+    static let succeeded = "paypal-messaging:create-view:succeeded"
+}

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingClient.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingClient.swift
@@ -38,17 +38,17 @@ public class BTPayPalMessagingClient: UIView {
         apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.started)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
-                delegate?.onError(self, error: error)
+                self.delegate?.onError(self, error: error)
                 return
             }
 
             guard let configuration else {
-                delegate?.onError(self, error: BTPayPalMessagingError.fetchConfigurationFailed)
+                self.delegate?.onError(self, error: BTPayPalMessagingError.fetchConfigurationFailed)
                 return
             }
 
             guard let clientID = configuration.json?["paypal"]["clientId"].asString() else {
-                delegate?.onError(self, error: BTPayPalMessagingError.payPalClientIDNotFound)
+                self.delegate?.onError(self, error: BTPayPalMessagingError.payPalClientIDNotFound)
                 return
             }
 

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingClient.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingClient.swift
@@ -38,17 +38,17 @@ public class BTPayPalMessagingClient: UIView {
         apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.started)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
-                self.notifyFailure(with: error)
+                delegate?.onError(self, error: error)
                 return
             }
 
             guard let configuration else {
-                self.notifyFailure(with: BTPayPalMessagingError.fetchConfigurationFailed)
+                delegate?.onError(self, error: BTPayPalMessagingError.fetchConfigurationFailed)
                 return
             }
 
             guard let clientID = configuration.json?["paypal"]["clientId"].asString() else {
-                self.notifyFailure(with: BTPayPalMessagingError.payPalClientIDNotFound)
+                delegate?.onError(self, error: BTPayPalMessagingError.payPalClientIDNotFound)
                 return
             }
 
@@ -84,17 +84,6 @@ public class BTPayPalMessagingClient: UIView {
 
             return
         }
-    }
-
-    // MARK: - Analytics Helper Methods
-
-    private func notifySuccess() {
-        apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.succeeded)
-    }
-
-    private func notifyFailure(with error: Error) {
-        apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.failed, errorDescription: error.localizedDescription)
-        self.delegate?.onError(self, error: error)
     }
 }
 
@@ -153,12 +142,12 @@ extension BTPayPalMessagingClient: PayPalMessageViewEventDelegate, PayPalMessage
     }
 
     public func onSuccess(_ paypalMessageView: PayPalMessages.PayPalMessageView) {
-        notifySuccess()
+        apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.succeeded)
         delegate?.didAppear(self)
     }
 
     public func onError(_ paypalMessageView: PayPalMessages.PayPalMessageView, error: PayPalMessages.PayPalMessageError) {
-        notifyFailure(with: error)
-        delegate?.onError(self, error: error)
+        apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.failed, errorDescription: error.localizedDescription)
+        self.delegate?.onError(self, error: error)
     }
 }


### PR DESCRIPTION
This work is going into the `paypal-messaging-feature` branch

### Summary of changes

- Add `started`, `failed`, and `succeeded` events for PayPal Messaging feature

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais