### PR TITLE
ShopperInsights - Merchant Analytics

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		57D94372296CCA2F0079EAB1 /* String+NonceValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D94371296CCA2F0079EAB1 /* String+NonceValidation.swift */; };
 		800E78C429E0DD5300D1B0FC /* FPTIBatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */; };
 		800FC544257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */; };
+		8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */; };
 		804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */; };
 		804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */; };
 		804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */; };
@@ -730,6 +731,7 @@
 		800E23DC22206A8300C5D22E /* BTThreeDSecureAuthenticateJWT_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAuthenticateJWT_Tests.swift; sourceTree = "<group>"; };
 		800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FPTIBatchData.swift; sourceTree = "<group>"; };
 		800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayCardNonce_Tests.swift; sourceTree = "<group>"; };
+		8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsAnalytics.swift; sourceTree = "<group>"; };
 		804698302B27C5340090878E /* BraintreeShopperInsights.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreeShopperInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8046983E2B27C5530090878E /* BraintreeShopperInsightsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeShopperInsightsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		804698482B27C71C0090878E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1296,6 +1298,7 @@
 		804698292B27C4D70090878E /* BraintreeShopperInsights */ = {
 			isa = PBXGroup;
 			children = (
+				8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */,
 				8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */,
 				8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */,
 				8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */,
@@ -2928,6 +2931,7 @@
 			files = (
 				804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */,
 				804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */,
+				8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */,
 				804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -149,6 +149,16 @@
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8046983D2B27C5530090878E"
+               BuildableName = "BraintreeShopperInsightsTests.xctest"
+               BlueprintName = "BraintreeShopperInsightsTests"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum BTShopperInsightsAnalytics {
+    
+    // MARK: - Merchant Triggered Events
+      
+    static let paypalPresented = "payment-insights:paypal-presented"
+    static let paypalSelected = "payment-insights:paypal-selected"
+    static let venmoPresented = "payment-insights:venmo-presented"
+    static let venmoSelected = "payment-insights:venmo-selected"
+}

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
@@ -4,8 +4,8 @@ enum BTShopperInsightsAnalytics {
     
     // MARK: - Merchant Triggered Events
       
-    static let paypalPresented = "payment-insights:paypal-presented"
-    static let paypalSelected = "payment-insights:paypal-selected"
-    static let venmoPresented = "payment-insights:venmo-presented"
-    static let venmoSelected = "payment-insights:venmo-selected"
+    static let paypalPresented = "shopper-insights:paypal-presented"
+    static let paypalSelected = "shopper-insights:paypal-selected"
+    static let venmoPresented = "shopper-insights:venmo-presented"
+    static let venmoSelected = "shopper-insights:venmo-selected"
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -28,4 +28,28 @@ public class BTShopperInsightsClient {
         // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
         return BTShopperInsightsResult()
     }
+    
+    /// Call this method when the PayPal button has been successfully displayed to the buyer.
+    /// This method sends analytics to help improve the Shopper Insights feature experience.
+    public func sendPayPalPresentedEvent() {
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.paypalPresented)
+    }
+    
+    /// Call this method when the PayPal button has been selected/tapped by the buyer..
+    /// This method sends analytics to help improve the Shopper Insights feature experience
+    public func sendPayPalSelectedEvent() {
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.paypalSelected)
+    }
+    
+    /// Call this method when the Venmo button has been successfully displayed to the buyer.
+    /// This method sends analytics to help improve the Shopper Insights feature experience
+    public func sendVenmoPresentedEvent() {
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.venmoPresented)
+    }
+    
+    /// Call this method when the Venmo button has been selected/tapped by the buyer.
+    /// This method sends analytics to help improve the Shopper Insights feature experience
+    public func sendVenmoSelectedEvent() {
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.venmoSelected)
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -26,4 +26,26 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertNotNil(result!.isPayPalRecommended)
         XCTAssertNotNil(result!.isVenmoRecommended)
     }
+    
+    // MARK: - Analytics
+    
+    func testSendPayPalPresentedEvent_sendsAnalytic() {
+        sut.sendPayPalPresentedEvent()
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
+    }
+    
+    func testSendPayPalSelectedEvent_sendsAnalytic() {
+        sut.sendPayPalSelectedEvent()
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-selected")
+    }
+    
+    func testSendVenmoPresentedEvent_sendsAnalytic() {
+        sut.sendVenmoPresentedEvent()
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-presented")
+    }
+    
+    func testSendVenmoSelectedEvent_sendsAnalytic() {
+        sut.sendVenmoSelectedEvent()
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-selected")
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Add 4 methods that allow merchants to fire analytics for the following cases:
    1. PayPal button was displayed
    2. PayPal button was tapped
    3. Venmo button was displayed
    4. Venmo button was tapped
- Add missing ShopperInsightsTests scheme to UnitTests scheme

See braintree.js PR 1339 on internal GHE for reference.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
