### PR TITLE
Bump PayPal Messages to v1.0.0 prerelease.6

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -75,7 +75,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalMessaging" do |s|
     s.source_files = "Sources/BraintreePayPalMessaging/*.swift"
     s.dependency "Braintree/Core"
-    s.dependency "PayPalMessages", '1.0.0-prerelease.3'
+    s.dependency "PayPalMessages", '1.0.0-prerelease.6'
   end
 
   s.subspec "ThreeDSecure" do |s|

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -6624,7 +6624,7 @@
 			repositoryURL = "https://github.com/paypal/paypal-messages-ios";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.0-prerelease.3";
+				version = "1.0.0-prerelease.6";
 			};
 		};
 		BEE2E4B52900436600C03FDD /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */ = {

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" == 2.2.5-6
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" == 5.4.1-stage-removed-xcode14-3
 binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json"  == 1.2.0
+binary "https://github.com/paypal/paypal-messages-ios/raw/prerelease/Carthage/PayPalMessages.json" == 1.0.0-prerelease.6

--- a/Demo/Application/Features/PayPalMessagingViewController.swift
+++ b/Demo/Application/Features/PayPalMessagingViewController.swift
@@ -44,7 +44,7 @@ extension PayPalMessagingViewController: BTPayPalMessagingDelegate {
     }
 
     func willAppear(_ payPalMessagingView: BTPayPalMessagingView) {
-        progressBlock("Loading BTPayPalMessagingClient")
+        progressBlock("Loading BTPayPalMessagingView")
     }
 
     func didAppear(_ payPalMessagingView: BTPayPalMessagingView) {

--- a/Package.swift
+++ b/Package.swift
@@ -93,8 +93,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PayPalMessages",
-            url: "https://github.com/paypal/paypal-messages-ios/releases/download/1.0.0-prerelease.3/PayPalMessages.xcframework.zip",
-            checksum: "a70eecc03aad9cb295298a2699ac7c09ea86b4e9c5b1e6ed227a60546033f4c6"
+            url: "https://github.com/paypal/paypal-messages-ios/releases/download/1.0.0-prerelease.6/PayPalMessages.xcframework.zip",
+            checksum: "d9629801acbe39e1a2bf0404331d5417cf64f1b00c4aac78cdf66178a43791c7"
         ),
         .target(
             name: "BraintreePayPalNativeCheckout",


### PR DESCRIPTION
### Summary of changes

- Add Carthage support for PayPal Messaging module
- Bump `Braintree.podspec`, `Package.swift`, and package dependency to `1.0.0 prerelease.6`
    - This version resolves all warnings we were previously seeing in Xcode

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
