### PR TITLE
Add app installed checks to ShopperInsightsClient

### DIFF
--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 #if canImport(BraintreeCore)
 import BraintreeCore
@@ -8,6 +8,13 @@ import BraintreeCore
 ///  By customizing each customer’s checkout experience, you can improve conversion, increase sales/repeat buys and boost user retention/loyalty.
 /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
 public class BTShopperInsightsClient {
+    
+    // MARK: - Internal Properties
+    
+    /// Defaults to `UIApplication.shared`, but exposed for unit tests to mock calls to `canOpenURL`.
+    var application: URLOpener = UIApplication.shared
+    
+    // MARK: - Private Properties
     
     private let apiClient: BTAPIClient
     
@@ -24,7 +31,10 @@ public class BTShopperInsightsClient {
     /// - Returns: A `BTShopperInsightsResult` instance
     /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
     public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest) async throws -> BTShopperInsightsResult {
-        // TODO: - Add isAppInstalled checks for PP & Venmo. DTBTSDK-3176
+        if isVenmoAppInstalled() && isPayPalAppInstalled() {
+            return BTShopperInsightsResult(isPayPalRecommended: true, isVenmoRecommended: true)
+        }
+        
         // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
         return BTShopperInsightsResult()
     }
@@ -51,5 +61,17 @@ public class BTShopperInsightsClient {
     /// This method sends analytics to help improve the Shopper Insights feature experience
     public func sendVenmoSelectedEvent() {
         apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.venmoSelected)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func isVenmoAppInstalled() -> Bool {
+        let venmoURL = URL(string: "com.venmo.touch.v2://")!
+        return application.canOpenURL(venmoURL)
+    }
+    
+    private func isPayPalAppInstalled() -> Bool {
+        let paypalURL = URL(string: "paypal://")!
+        return application.canOpenURL(paypalURL)
     }
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -33,10 +33,10 @@ public class BTShopperInsightsClient {
     public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest) async throws -> BTShopperInsightsResult {
         if isVenmoAppInstalled() && isPayPalAppInstalled() {
             return BTShopperInsightsResult(isPayPalRecommended: true, isVenmoRecommended: true)
+        } else {
+            // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
+            return BTShopperInsightsResult()
         }
-        
-        // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
-        return BTShopperInsightsResult()
     }
     
     /// Call this method when the PayPal button has been successfully displayed to the buyer.

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -8,23 +8,37 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     var mockAPIClient = MockAPIClient(authorization: "development_client_key")!
     var sut: BTShopperInsightsClient!
     
+    let request = BTShopperInsightsRequest(
+        email: "my-email",
+        phone: Phone(
+            countryCode: "1",
+            nationalNumber: "1234567"
+        )
+    )
+    
     override func setUp() {
         super.setUp()
         sut = BTShopperInsightsClient(apiClient: mockAPIClient)
     }
     
     func testGetRecommendedPaymentMethods_returnsDefaultRecommendations() async {
-        let request = BTShopperInsightsRequest(
-            email: "my-email",
-            phone: Phone(
-                countryCode: "1",
-                nationalNumber: "1234567"
-            )
-        )
         let result = try? await sut.getRecommendedPaymentMethods(request: request)
         
         XCTAssertNotNil(result!.isPayPalRecommended)
         XCTAssertNotNil(result!.isVenmoRecommended)
+    }
+    
+    func testGetRecommendedPaymentMethods_whenBothAppsInstalled_returnsTrue() async {
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedCanOpenURL = false
+        fakeApplication.canOpenURLWhitelist.append(URL(string: "com.venmo.touch.v2://")!)
+        fakeApplication.canOpenURLWhitelist.append(URL(string: "paypal://")!)
+        sut.application = fakeApplication
+        
+        let result = try? await sut.getRecommendedPaymentMethods(request: request)
+        
+        XCTAssertTrue(result!.isPayPalRecommended)
+        XCTAssertTrue(result!.isVenmoRecommended)
     }
     
     // MARK: - Analytics


### PR DESCRIPTION
### Summary of changes

- Equivalent Android PR - https://github.com/braintree/braintree_android/pull/872
- Add checks if Venmo & PayPal apps are installed to `BTShopperInsightsClient.getRecommendedPaymentMethods()` call

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 