### PR TITLE
[ShopperInsights] Add EligiblePayments API Call

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -73,13 +73,14 @@
 		57D94370296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D9436F296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift */; };
 		57D94372296CCA2F0079EAB1 /* String+NonceValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D94371296CCA2F0079EAB1 /* String+NonceValidation.swift */; };
 		800E78C429E0DD5300D1B0FC /* FPTIBatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */; };
+		800ED77F2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */; };
 		800FC544257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */; };
 		8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */; };
+		804326BF2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */; };
 		804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */; };
 		804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */; };
 		804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */; };
 		804698422B27C5530090878E /* BraintreeShopperInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 804698302B27C5340090878E /* BraintreeShopperInsights.framework */; platformFilter = ios; };
-		804326BF2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */; };
 		80482F8029D39A1D007E5F50 /* BTThreeDSecureRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80482F7F29D39A1D007E5F50 /* BTThreeDSecureRequest.swift */; };
 		80482F8229D39BF5007E5F50 /* BTThreeDSecureRequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80482F8129D39BF5007E5F50 /* BTThreeDSecureRequestDelegate.swift */; };
 		80482F8429D3A1D9007E5F50 /* BTThreeDSecureAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80482F8329D3A1D9007E5F50 /* BTThreeDSecureAccountType.swift */; };
@@ -93,12 +94,12 @@
 		8053F05929FB2F700076F988 /* URL+IsPayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8053F05829FB2F700076F988 /* URL+IsPayPal.swift */; };
 		80581A8C25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581A8B25531D0A00006F53 /* BTConfiguration+ThreeDSecure_Tests.swift */; };
 		80581B1D2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80581B1C2553319C00006F53 /* BTGraphQLHTTP_SSLPinning_IntegrationTests.swift */; };
+		8075CBEE2B1B735200CA6265 /* BTAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8075CBED2B1B735200CA6265 /* BTAPIRequest.swift */; };
+		80A6C6192B21205900416D50 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A6C6182B21205900416D50 /* UIApplication+URLOpener.swift */; };
 		80AB424F2B27CAC200249218 /* BraintreeTestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A903E1A624F9D34000C314E1 /* BraintreeTestShared.framework */; platformFilter = ios; };
 		80AB42542B27DF5B00249218 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; platformFilter = ios; };
 		80AB42552B27DF5B00249218 /* BraintreeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		80B59A132B27C7FC004C2FA3 /* BTShopperInsightsClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8064F3942B1E4FEB0059C4CB /* BTShopperInsightsClient_Tests.swift */; };
-		8075CBEE2B1B735200CA6265 /* BTAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8075CBED2B1B735200CA6265 /* BTAPIRequest.swift */; };
-		80A6C6192B21205900416D50 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A6C6182B21205900416D50 /* UIApplication+URLOpener.swift */; };
 		80BA3C292B23892700900BBB /* FakeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA3C282B23892700900BBB /* FakeRequest.swift */; };
 		80BA64AC29D788E000E15264 /* BTLocalPaymentResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA64AB29D788E000E15264 /* BTLocalPaymentResult.swift */; };
 		80BA64B229D7937E00E15264 /* BTLocalPaymentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BA64B129D7937E00E15264 /* BTLocalPaymentRequest.swift */; };
@@ -736,12 +737,13 @@
 		59A4135427B90CD7AE94D5CC /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		800E23DC22206A8300C5D22E /* BTThreeDSecureAuthenticateJWT_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAuthenticateJWT_Tests.swift; sourceTree = "<group>"; };
 		800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FPTIBatchData.swift; sourceTree = "<group>"; };
+		800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTEligiblePaymentsRequest.swift; sourceTree = "<group>"; };
 		800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayCardNonce_Tests.swift; sourceTree = "<group>"; };
 		8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsAnalytics.swift; sourceTree = "<group>"; };
+		804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePaymentTokensRequest.swift; sourceTree = "<group>"; };
 		804698302B27C5340090878E /* BraintreeShopperInsights.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraintreeShopperInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8046983E2B27C5530090878E /* BraintreeShopperInsightsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BraintreeShopperInsightsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		804698482B27C71C0090878E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePaymentTokensRequest.swift; sourceTree = "<group>"; };
 		80482F7F29D39A1D007E5F50 /* BTThreeDSecureRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureRequest.swift; sourceTree = "<group>"; };
 		80482F8129D39BF5007E5F50 /* BTThreeDSecureRequestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureRequestDelegate.swift; sourceTree = "<group>"; };
 		80482F8329D3A1D9007E5F50 /* BTThreeDSecureAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAccountType.swift; sourceTree = "<group>"; };
@@ -1318,6 +1320,7 @@
 				8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */,
 				8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */,
 				8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */,
+				800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */,
 			);
 			path = BraintreeShopperInsights;
 			sourceTree = "<group>";
@@ -2953,6 +2956,7 @@
 			files = (
 				804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */,
 				804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */,
+				800ED77F2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */,
 				8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */,
 				804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */,
 			);

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 		57D94370296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D9436F296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift */; };
 		57D94372296CCA2F0079EAB1 /* String+NonceValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D94371296CCA2F0079EAB1 /* String+NonceValidation.swift */; };
 		800E78C429E0DD5300D1B0FC /* FPTIBatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */; };
-		800ED77F2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */; };
+		800ED7832B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800ED7822B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift */; };
 		800FC544257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */; };
 		8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */; };
 		804326BF2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */; };
@@ -737,7 +737,7 @@
 		59A4135427B90CD7AE94D5CC /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		800E23DC22206A8300C5D22E /* BTThreeDSecureAuthenticateJWT_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAuthenticateJWT_Tests.swift; sourceTree = "<group>"; };
 		800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FPTIBatchData.swift; sourceTree = "<group>"; };
-		800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTEligiblePaymentsRequest.swift; sourceTree = "<group>"; };
+		800ED7822B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTEligiblePaymentsRequest.swift; sourceTree = "<group>"; };
 		800FC543257FDC5100DEE132 /* BTApplePayCardNonce_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayCardNonce_Tests.swift; sourceTree = "<group>"; };
 		8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsAnalytics.swift; sourceTree = "<group>"; };
 		804326BE2B1A5C5B0044E90B /* BTApplePaymentTokensRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePaymentTokensRequest.swift; sourceTree = "<group>"; };
@@ -1316,11 +1316,11 @@
 		804698292B27C4D70090878E /* BraintreeShopperInsights */ = {
 			isa = PBXGroup;
 			children = (
-				800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */,
 				8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */,
 				8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */,
 				8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */,
 				8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */,
+				800ED7822B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift */,
 			);
 			path = BraintreeShopperInsights;
 			sourceTree = "<group>";
@@ -2956,7 +2956,7 @@
 			files = (
 				804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */,
 				804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */,
-				800ED77F2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */,
+				800ED7832B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */,
 				8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */,
 				804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */,
 			);

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -1316,11 +1316,11 @@
 		804698292B27C4D70090878E /* BraintreeShopperInsights */ = {
 			isa = PBXGroup;
 			children = (
+				800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */,
 				8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */,
 				8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */,
 				8064F3962B1E63800059C4CB /* BTShopperInsightsRequest.swift */,
 				8064F3902B1E49E10059C4CB /* BTShopperInsightsResult.swift */,
-				800ED77E2B4DFE9E007D8A30 /* BTEligiblePaymentsRequest.swift */,
 			);
 			path = BraintreeShopperInsights;
 			sourceTree = "<group>";

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8046983D2B27C5530090878E"
-               BuildableName = "BraintreeShopperInsightsTests.xctest"
-               BlueprintName = "BraintreeShopperInsightsTests"
-               ReferencedContainer = "container:Braintree.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -146,16 +130,6 @@
                BlueprintIdentifier = "BE642D8E27D0132A00694A5B"
                BuildableName = "BraintreeSEPADirectDebitTests.xctest"
                BlueprintName = "BraintreeSEPADirectDebitTests"
-               ReferencedContainer = "container:Braintree.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8046983D2B27C5530090878E"
-               BuildableName = "BraintreeShopperInsightsTests.xctest"
-               BlueprintName = "BraintreeShopperInsightsTests"
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8046983D2B27C5530090878E"
+               BuildableName = "BraintreeShopperInsightsTests.xctest"
+               BlueprintName = "BraintreeShopperInsightsTests"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -130,6 +146,16 @@
                BlueprintIdentifier = "BE642D8E27D0132A00694A5B"
                BuildableName = "BraintreeSEPADirectDebitTests.xctest"
                BlueprintName = "BraintreeSEPADirectDebitTests"
+               ReferencedContainer = "container:Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8046983D2B27C5530090878E"
+               BuildableName = "BraintreeShopperInsightsTests.xctest"
+               BlueprintName = "BraintreeShopperInsightsTests"
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -181,7 +181,7 @@ import Foundation
                 }
                 
                 if payPalHTTP == nil {
-                    let paypalBaseURL: URL? = paypalAPIURL(forEnvironment: configuration?.environment ?? "")
+                    let paypalBaseURL: URL? = payPalAPIURL(forEnvironment: configuration?.environment ?? "")
                     
                     if let clientToken, let paypalBaseURL {
                         payPalHTTP = BTHTTP(url: paypalBaseURL, authorizationFingerprint: clientToken.authorizationFingerprint)
@@ -481,7 +481,7 @@ import Foundation
         return components.url
     }
     
-    func paypalAPIURL(forEnvironment environment: String) -> URL? {
+    func payPalAPIURL(forEnvironment environment: String) -> URL? {
         if environment.caseInsensitiveCompare("sandbox") == .orderedSame ||
             environment.caseInsensitiveCompare("development") == .orderedSame {
             return URL(string: "https://api-m.sandbox.paypal.com")

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -26,7 +26,7 @@ import Foundation
 
     var http: BTHTTP?
     var graphQLHTTP: BTGraphQLHTTP?
-    var paypalHTTP: BTHTTP?
+    var payPalHTTP: BTHTTP?
     
     var session: URLSession {
         let configurationQueue: OperationQueue = OperationQueue()
@@ -180,11 +180,11 @@ import Foundation
                     }
                 }
                 
-                if paypalHTTP == nil {
+                if payPalHTTP == nil {
                     let paypalBaseURL: URL? = paypalAPIURL(forEnvironment: configuration?.environment ?? "")
                     
                     if let clientToken, let paypalBaseURL {
-                        paypalHTTP = BTHTTP(url: paypalBaseURL, authorizationFingerprint: clientToken.authorizationFingerprint)
+                        payPalHTTP = BTHTTP(url: paypalBaseURL, authorizationFingerprint: clientToken.authorizationFingerprint)
                     }
                 }
             }
@@ -366,7 +366,7 @@ import Foundation
             return parameters?.merging(["_meta": metadata.parameters]) { $1 }
         case .graphQLAPI:
             return parameters?.merging(["clientSdkMetadata": metadata.parameters]) { $1 }
-        case .paypalAPI:
+        case .payPalAPI:
             return parameters
         }
     }
@@ -496,8 +496,8 @@ import Foundation
             return http
         case .graphQLAPI:
             return graphQLHTTP
-        case .paypalAPI:
-            return paypalHTTP
+        case .payPalAPI:
+            return payPalHTTP
         }
     }
 }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -26,7 +26,8 @@ import Foundation
 
     var http: BTHTTP?
     var graphQLHTTP: BTGraphQLHTTP?
-
+    var paypalHTTP: BTHTTP?
+    
     var session: URLSession {
         let configurationQueue: OperationQueue = OperationQueue()
         configurationQueue.name = "com.braintreepayments.BTAPIClient"
@@ -176,6 +177,14 @@ import Foundation
                         graphQLHTTP = BTGraphQLHTTP(url: graphQLBaseURL, authorizationFingerprint: clientToken.authorizationFingerprint)
                     } else if let tokenizationKey, let graphQLBaseURL {
                         graphQLHTTP = BTGraphQLHTTP(url: graphQLBaseURL, tokenizationKey: tokenizationKey)
+                    }
+                }
+                
+                if paypalHTTP == nil {
+                    let paypalBaseURL: URL? = paypalAPIURL(forEnvironment: configuration?.environment ?? "")
+                    
+                    if let clientToken, let paypalBaseURL {
+                        paypalHTTP = BTHTTP(url: paypalBaseURL, authorizationFingerprint: clientToken.authorizationFingerprint)
                     }
                 }
             }
@@ -357,6 +366,8 @@ import Foundation
             return parameters?.merging(["_meta": metadata.parameters]) { $1 }
         case .graphQLAPI:
             return parameters?.merging(["clientSdkMetadata": metadata.parameters]) { $1 }
+        case .paypalAPI:
+            return parameters
         }
     }
 
@@ -469,6 +480,15 @@ import Foundation
         components.path = "/graphql"
         return components.url
     }
+    
+    func paypalAPIURL(forEnvironment environment: String) -> URL? {
+        if environment.caseInsensitiveCompare("sandbox") == .orderedSame ||
+            environment.caseInsensitiveCompare("development") == .orderedSame {
+            return URL(string: "https://api-m.sandbox.paypal.com")
+        } else {
+            return URL(string: "https://api-m.paypal.com")
+        }
+    }
 
     func http(for httpType: BTAPIClientHTTPService) -> BTHTTP? {
         switch httpType {
@@ -476,6 +496,8 @@ import Foundation
             return http
         case .graphQLAPI:
             return graphQLHTTP
+        case .paypalAPI:
+            return paypalHTTP
         }
     }
 }

--- a/Sources/BraintreeCore/BTAPIClientHTTPType.swift
+++ b/Sources/BraintreeCore/BTAPIClientHTTPType.swift
@@ -10,5 +10,5 @@ import Foundation
     case graphQLAPI
     
     /// Use the PayPal API
-    case paypalAPI
+    case payPalAPI
 }

--- a/Sources/BraintreeCore/BTAPIClientHTTPType.swift
+++ b/Sources/BraintreeCore/BTAPIClientHTTPType.swift
@@ -8,4 +8,7 @@ import Foundation
 
     /// Use the GraphQL API
     case graphQLAPI
+    
+    /// Use the PayPal API
+    case paypalAPI
 }

--- a/Sources/BraintreeCore/BTAPIRequest.swift
+++ b/Sources/BraintreeCore/BTAPIRequest.swift
@@ -34,7 +34,7 @@ struct BTAPIRequest: Encodable {
         case .graphQLAPI:
             let metadataEncoder = metadataContainer.superEncoder(forKey: .graphQLMetadataKey)
             try self.metadata.encode(to: metadataEncoder)
-        case .paypalAPI:
+        case .payPalAPI:
             break
         }
     }

--- a/Sources/BraintreeCore/BTAPIRequest.swift
+++ b/Sources/BraintreeCore/BTAPIRequest.swift
@@ -34,6 +34,8 @@ struct BTAPIRequest: Encodable {
         case .graphQLAPI:
             let metadataEncoder = metadataContainer.superEncoder(forKey: .graphQLMetadataKey)
             try self.metadata.encode(to: metadataEncoder)
+        case .paypalAPI:
+            break
         }
     }
 }

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -269,8 +269,20 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
             return
         }
 
-        var headers: [String: String] = defaultHeaders
+        var headers: [String: String]
         var request: URLRequest
+        
+        if url.isPayPalURL {
+            headers = [:]
+            if case .authorizationFingerprint(let key) = clientAuthorization {
+                headers["Authorization"] = "Bearer \(key)"
+            }
+        } else {
+            headers = defaultHeaders
+            if case .tokenizationKey(let key) = clientAuthorization {
+                headers["Client-Key"] = key
+            }
+        }
 
         if method == "GET" || method == "DELETE" {
             if !isDataURL {
@@ -301,10 +313,6 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
 
             request.httpBody = bodyData
             headers["Content-Type"] = "application/json; charset=utf-8"
-        }
-        
-        if case .tokenizationKey(let key) = clientAuthorization {
-            headers["Client-Key"] = key
         }
 
         request.allHTTPHeaderFields = headers

--- a/Sources/BraintreeCore/URL+IsPayPal.swift
+++ b/Sources/BraintreeCore/URL+IsPayPal.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension URL {
     
-    /// Used to determine if a the URL is a paypal.com domain in order to format API requests accordingly
+    /// Used to determine if the URL is a paypal.com domain in order to format API requests accordingly
     var isPayPalURL: Bool {
         absoluteString.contains("api-m.paypal.com") || absoluteString.contains("api-m.sandbox.paypal.com")
     }

--- a/Sources/BraintreeCore/URL+IsPayPal.swift
+++ b/Sources/BraintreeCore/URL+IsPayPal.swift
@@ -4,6 +4,6 @@ extension URL {
     
     /// Used to determine if a the URL is a paypal.com domain in order to format API requests accordingly
     var isPayPalURL: Bool {
-        absoluteString.contains("api-m.paypal.com")
+        absoluteString.contains("api-m.paypal.com") || absoluteString.contains("api-m.sandbox.paypal.com")
     }
 }

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -49,12 +49,10 @@ struct BTEligiblePaymentsRequest: Encodable {
     
     struct Preferences: Encodable {
         let includeAccountDetails = true
-        let includeVaultTokens = true
         let paymentSourceConstraint = PaymentSourceConstraint()
         
         enum CodingKeys: String, CodingKey {
             case includeAccountDetails = "include_account_details"
-            case includeVaultTokens = "include_vault_tokens"
             case paymentSourceConstraint = "payment_source_constraint"
         }
         

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -4,8 +4,42 @@ import PassKit
 /// The POST body for `v2/payments/find-eligible-methods`
 struct BTEligiblePaymentsRequest: Encodable {
     
-    init() {
-  
+    private let customer: Customer
+    private let purchaseUnits: [PurchaseUnit]
+    private let preferences = Preferences()
+    
+    struct Customer: Encodable {
+        let countryCode: String = "US"
+        let email: String?
+        let phone: Phone?
     }
 
+    struct PurchaseUnit: Encodable {
+        let payee: Payee
+        let amount = Amount()
+        
+        struct Amount: Encodable {
+            let currencyCode = "USD"
+        }
+
+        struct Payee: Encodable {
+            let merchantID: String
+        }
+    }
+    
+    struct Preferences: Encodable {
+        let includeAccountDetails = true
+        let includeVaultTokens = true
+        let paymentSourceConstraint = PaymentSourceConstraint()
+        
+        struct PaymentSourceConstraint: Encodable {
+            let constraintType = "INCLUDE"
+            let paymentSources = ["PAYPAL", "VENMO"]
+        }
+    }
+    
+    init(email: String?, phone: Phone?, merchantID: String) {
+        self.customer = Customer(email: email, phone: phone)
+        self.purchaseUnits = [PurchaseUnit(payee: PurchaseUnit.Payee(merchantID: merchantID))]
+    }
 }

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -1,0 +1,11 @@
+import Foundation
+import PassKit
+
+/// The POST body for `v2/payments/find-eligible-methods`
+struct BTEligiblePaymentsRequest: Encodable {
+    
+    init() {
+  
+    }
+
+}

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -12,6 +12,12 @@ struct BTEligiblePaymentsRequest: Encodable {
         let countryCode: String = "US"
         let email: String?
         let phone: Phone?
+        
+        enum CodingKeys: String, CodingKey {
+            case countryCode = "country_code"
+            case email = "email"
+            case phone = "phone"
+        }
     }
 
     struct PurchaseUnit: Encodable {
@@ -20,10 +26,18 @@ struct BTEligiblePaymentsRequest: Encodable {
         
         struct Amount: Encodable {
             let currencyCode = "USD"
+            
+            enum CodingKeys: String, CodingKey {
+                case currencyCode = "currency_code"
+            }
         }
 
         struct Payee: Encodable {
             let merchantID: String
+            
+            enum CodingKeys: String, CodingKey {
+                case merchantID = "merchant_id"
+            }
         }
     }
     
@@ -32,9 +46,20 @@ struct BTEligiblePaymentsRequest: Encodable {
         let includeVaultTokens = true
         let paymentSourceConstraint = PaymentSourceConstraint()
         
+        enum CodingKeys: String, CodingKey {
+            case includeAccountDetails = "include_account_details"
+            case includeVaultTokens = "include_vault_tokens"
+            case paymentSourceConstraint = "payment_source_constraint"
+        }
+        
         struct PaymentSourceConstraint: Encodable {
             let constraintType = "INCLUDE"
             let paymentSources = ["PAYPAL", "VENMO"]
+            
+            enum CodingKeys: String, CodingKey {
+                case constraintType = "constraint_type"
+                case paymentSources = "payment_sources"
+            }
         }
     }
     

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -8,6 +8,12 @@ struct BTEligiblePaymentsRequest: Encodable {
     private let purchaseUnits: [PurchaseUnit]
     private let preferences = Preferences()
     
+    enum CodingKeys: String, CodingKey {
+        case customer = "customer"
+        case purchaseUnits = "purchase_units"
+        case preferences = "preferences"
+    }
+    
     struct Customer: Encodable {
         let countryCode: String = "US"
         let email: String?

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -35,6 +35,10 @@ public class BTShopperInsightsClient {
             return BTShopperInsightsResult(isPayPalRecommended: true, isVenmoRecommended: true)
         } else {
             // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
+            apiClient.post("/v2/payments/find-eligible-methods", parameters: BTEligiblePaymentsRequest(), httpType: .paypalAPI) { json, response, error in
+                print("HELLO")
+            }
+            
             return BTShopperInsightsResult()
         }
     }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -46,7 +46,7 @@ public class BTShopperInsightsClient {
                 parameters: postParameters,
                 httpType: .payPalAPI
             ) { json, response, error in
-                // TODO: - Handle API Response. DTBTSDK-3176
+                // TODO: - Handle API Response. DTBTSDK-3388
             }
             
             return BTShopperInsightsResult()

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -44,7 +44,7 @@ public class BTShopperInsightsClient {
             apiClient.post(
                 "/v2/payments/find-eligible-methods",
                 parameters: postParameters,
-                httpType: .paypalAPI
+                httpType: .payPalAPI
             ) { json, response, error in
                 // TODO: - Handle API Response. DTBTSDK-3176
             }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -34,9 +34,19 @@ public class BTShopperInsightsClient {
         if isVenmoAppInstalled() && isPayPalAppInstalled() {
             return BTShopperInsightsResult(isPayPalRecommended: true, isVenmoRecommended: true)
         } else {
-            // TODO: - Make API call to PaymentReadyAPI. DTBTSDK-3176
-            apiClient.post("/v2/payments/find-eligible-methods", parameters: BTEligiblePaymentsRequest(), httpType: .paypalAPI) { json, response, error in
-                print("HELLO")
+            // TODO: - Fill in appropriate merchantID (or ppClientID) from config once API team decides what we need to send
+            let postParameters = BTEligiblePaymentsRequest(
+                email: request.email,
+                phone: request.phone,
+                merchantID: "TODO-merchant-id-type"
+            )
+            
+            apiClient.post(
+                "/v2/payments/find-eligible-methods",
+                parameters: postParameters,
+                httpType: .paypalAPI
+            ) { json, response, error in
+                // TODO: - Handle API Response. DTBTSDK-3176
             }
             
             return BTShopperInsightsResult()

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsRequest.swift
@@ -42,8 +42,13 @@ public struct BTShopperInsightsRequest {
 /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
 public struct Phone: Encodable {
     
-    let countryCode: String
-    let nationalNumber: String
+    private let countryCode: String
+    private let nationalNumber: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case countryCode = "country_code"
+        case nationalNumber = "national_number"
+    }
     
     /// Initialize a `BTShopperInsightsRequest.Phone`.
     /// - Parameters:

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsRequest.swift
@@ -4,10 +4,10 @@ import Foundation
 /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTShopperInsightsRequest {
     
-    // MARK: - Private Properties
+    // MARK: - Internal Properties
     
-    private var email: String?
-    private var phone: Phone?
+    var email: String?
+    var phone: Phone?
     
     // MARK: - Initializers
 
@@ -40,10 +40,10 @@ public struct BTShopperInsightsRequest {
 
 /// Buyer's phone number details for use with the Shopper Insights feature.
 /// - Note: This feature is in beta. It's public API may change or be removed in future releases.
-public struct Phone {
+public struct Phone: Encodable {
     
-    private let countryCode: String
-    private let nationalNumber: String
+    let countryCode: String
+    let nationalNumber: String
     
     /// Initialize a `BTShopperInsightsRequest.Phone`.
     /// - Parameters:

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -585,4 +585,20 @@ class BTAPIClient_Tests: XCTestCase {
         let sandboxURL: URL? = apiClient?.graphQLURL(forEnvironment: "unknown")
         XCTAssertEqual(sandboxURL?.absoluteString, "https://payments.braintree-api.com/graphql")
     }
+    
+    func testPayPalBaseURLForEnvironment_returnsSandbox() {
+        let apiClientSand = BTAPIClient(authorization: "development_tokenization_key")
+        let baseURLSand: URL? = apiClientSand?.paypalAPIURL(forEnvironment: "sandbox")
+        XCTAssertEqual(baseURLSand?.absoluteString, "https://api-m.sandbox.paypal.com")
+        
+        let apiClientDev = BTAPIClient(authorization: "development_tokenization_key")
+        let baseURLDev: URL? = apiClientDev?.paypalAPIURL(forEnvironment: "development")
+        XCTAssertEqual(baseURLDev?.absoluteString, "https://api-m.sandbox.paypal.com")
+    }
+    
+    func testPayPalBaseURLForEnvironment_returnsProductionURL_asDefault() {
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
+        let baseURL: URL? = apiClient?.paypalAPIURL(forEnvironment: "unknown")
+        XCTAssertEqual(baseURL?.absoluteString, "https://api-m.paypal.com")
+    }
 }

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -586,19 +586,25 @@ class BTAPIClient_Tests: XCTestCase {
         XCTAssertEqual(sandboxURL?.absoluteString, "https://payments.braintree-api.com/graphql")
     }
     
-    func testPayPalBaseURLForEnvironment_returnsSandbox() {
+    func testPayPalBaseURLForEnvironment_returnsSandboxURL() {
         let apiClientSand = BTAPIClient(authorization: "development_tokenization_key")
-        let baseURLSand: URL? = apiClientSand?.paypalAPIURL(forEnvironment: "sandbox")
+        let baseURLSand: URL? = apiClientSand?.payPalAPIURL(forEnvironment: "sandbox")
         XCTAssertEqual(baseURLSand?.absoluteString, "https://api-m.sandbox.paypal.com")
         
         let apiClientDev = BTAPIClient(authorization: "development_tokenization_key")
-        let baseURLDev: URL? = apiClientDev?.paypalAPIURL(forEnvironment: "development")
+        let baseURLDev: URL? = apiClientDev?.payPalAPIURL(forEnvironment: "development")
         XCTAssertEqual(baseURLDev?.absoluteString, "https://api-m.sandbox.paypal.com")
+    }
+    
+    func testPayPalBaseURLForEnvironment_returnsProductionURL() {
+        let apiClientSand = BTAPIClient(authorization: "development_tokenization_key")
+        let baseURLSand: URL? = apiClientSand?.payPalAPIURL(forEnvironment: "production")
+        XCTAssertEqual(baseURLSand?.absoluteString, "https://api-m.paypal.com")
     }
     
     func testPayPalBaseURLForEnvironment_returnsProductionURL_asDefault() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let baseURL: URL? = apiClient?.paypalAPIURL(forEnvironment: "unknown")
+        let baseURL: URL? = apiClient?.payPalAPIURL(forEnvironment: "unknown")
         XCTAssertEqual(baseURL?.absoluteString, "https://api-m.paypal.com")
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -503,6 +503,25 @@ final class BTHTTP_Tests: XCTestCase {
 
         waitForExpectations(timeout: 2)
     }
+    
+    func testPOSTRequests_whenBTHTTPInitializedWithPayPalAPIURL_sendsAuthorizationInHeader() {
+        let expectation = expectation(description: "POST callback")
+
+        let http = BTHTTP(url: URL(string: "https://api-m.paypal.com")!, authorizationFingerprint: "some-fingerprint")
+        http.session = testURLSession
+        
+        http.post("200.json") { body, response, error in
+            XCTAssertNotNil(body)
+            XCTAssertNotNil(response)
+            XCTAssertNil(error)
+
+            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
+            XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Authorization"], "Bearer some-fingerprint")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
 
     func testPOSTRequests_whenBTHTTPInitializedWithTokenizationKey_sendAuthorization() {
         http = BTHTTP(url: BTHTTPTestProtocol.testBaseURL(), tokenizationKey: "development_tokenization_key")

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -66,6 +66,12 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         let paymentSourceConstraint = preferences["payment_source_constraint"] as! [String: Any]
         XCTAssertEqual(paymentSourceConstraint["constraint_type"] as! String, "INCLUDE")
         XCTAssertEqual(paymentSourceConstraint["payment_sources"] as! [String], ["PAYPAL", "VENMO"])
+        
+        let purchaseUnits = lastPostParameters["purchase_units"] as! [String: Any]
+        let payee = purchaseUnits["payee"] as! [String: String]
+        XCTAssertEqual(payee["merchant_id"], "TODO-merchant-id-type")
+        let amount = purchaseUnits["payee"] as! [String: String]
+        XCTAssertEqual(amount["currency_code"], "USD")
     }
     
     // MARK: - Analytics

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -62,7 +62,6 @@ class BTShopperInsightsClient_Tests: XCTestCase {
 
         let preferences = lastPostParameters["preferences"] as! [String: Any]
         XCTAssertTrue(preferences["include_account_details"] as! Bool)
-        XCTAssertTrue(preferences["include_vault_tokens"] as! Bool)
         let paymentSourceConstraint = preferences["payment_source_constraint"] as! [String: Any]
         XCTAssertEqual(paymentSourceConstraint["constraint_type"] as! String, "INCLUDE")
         XCTAssertEqual(paymentSourceConstraint["payment_sources"] as! [String], ["PAYPAL", "VENMO"])

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -67,10 +67,10 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(paymentSourceConstraint["constraint_type"] as! String, "INCLUDE")
         XCTAssertEqual(paymentSourceConstraint["payment_sources"] as! [String], ["PAYPAL", "VENMO"])
         
-        let purchaseUnits = lastPostParameters["purchase_units"] as! [String: Any]
-        let payee = purchaseUnits["payee"] as! [String: String]
+        let purchaseUnits = lastPostParameters["purchase_units"] as! [[String: Any]]
+        let payee = purchaseUnits.first?["payee"] as! [String: String]
         XCTAssertEqual(payee["merchant_id"], "TODO-merchant-id-type")
-        let amount = purchaseUnits["payee"] as! [String: String]
+        let amount = purchaseUnits.first?["amount"] as! [String: String]
         XCTAssertEqual(amount["currency_code"], "USD")
     }
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -47,7 +47,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         _ = try? await sut.getRecommendedPaymentMethods(request: request)
         
         XCTAssertEqual(mockAPIClient.lastPOSTPath, "/v2/payments/find-eligible-methods")
-        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .paypalAPI)
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .payPalAPI)
         
         guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
             XCTFail()


### PR DESCRIPTION
### Summary of changes

- Update `BTAPIClient` & `BTHTTP` to support API calls to paypal.com APIs
- Add `BTEligiblePaymentsRequest` struct to house POST body for `v2/payments/find-eligible-methods` API call
- Add relevant unit tests
- Leave TODO for parsing result of API call

### Notes
- API call still expected to 403 right now ⚠️ 
- Adding support for hitting a PayPal API reveals how tightly coupled our networking implementation is to BT API specifics
    - A few highlights:
       - `BTHTTP` & `BTGraphQLHTTP` have a lot of overlap & duplication (3 different `URLSession` configurations, 2 different `URLRequest` creation sites)
       - No service-agnostic networking interface
    - When time permits, I think there's room to rework things similar to how we did in a [series of PPCP PRs](https://github.com/paypal/paypal-ios/pulls?q=is%3Apr+networking+label%3Anetworking-refactor)
    - Especially if we want to make BraintreeCore the potential unified dependency for networking & analytics b/w PPCP & BT 👀 

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 