### PR TITLE
Remove ObjC headers instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,32 +19,6 @@ To run the tests:
 
 _Note:_ Running the `UI` and `IntegrationTests` schemes follows the same steps as above, just replacing the `UnitTests` scheme name in step 3.
 
-## Importing Header Files
-
-### Importing a Swift module into Obj-C
-
-To import a Braintree framework written in **Swift** into an Objective-C file, use the following syntax:
-```objc
-#if __has_include(<Braintree/Braintree-Swift.h>) // CocoaPods
-#import <Braintree/Braintree-Swift.h>
-
-#elif __has_include("Braintree-Swift.h")         // CocoaPods for ReactNative
-/* Use quoted style when importing Swift headers for ReactNative support
- * See https://github.com/braintree/braintree_ios/issues/671
- */
-#import "Braintree-Swift.h"
-
-#elif SWIFT_PACKAGE                              // SPM
-/* Use @import for SPM support
- * See https://forums.swift.org/t/using-a-swift-package-in-a-mixed-swift-and-objective-c-project/27348
- */
-@import BraintreeCore;
-
-#else                                            // Carthage
-#import <BraintreeCore/BraintreeCore-Swift.h>
-#endif
-```
-
 ## Releasing
 
 Refer to the `ios/releases` section in the internal SDK Knowledge Repo.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Here are a few ways to get in touch:
 
 ## Help
 
-* Read the headers
 * [Read the Braintree docs](https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ios/v5)
 * [Check out the reference docs](https://braintree.github.io/braintree_ios/)
 * Find a bug? [Open an issue](https://github.com/braintree/braintree_ios/issues)


### PR DESCRIPTION
### Summary of changes

- Importing headers is no-longer part of our development process in this SDK 🥲

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
