### PR TITLE
[Important] Fix UPC Tests

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		BEC251EA2B1E49C600E4B47C /* MockBTPayPalNativeCheckoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC251E92B1E49C600E4B47C /* MockBTPayPalNativeCheckoutProvider.swift */; };
 		BEC3F11328A4401E0074DF0F /* BTHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */; };
 		BEC66DBE2901CC9E0030B6B2 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
+		BECB10C62B5999EE008D398E /* BTPayPalLineItem_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB10C52B5999EE008D398E /* BTPayPalLineItem_Tests.swift */; };
 		BECBA0E62AEABC99002518AC /* BTCardClient_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */; };
 		BED00CAC28A4504E00D74AEC /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; };
 		BED00CAE28A5419900D74AEC /* BTBinData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAD28A5419900D74AEC /* BTBinData.swift */; };
@@ -886,6 +887,7 @@
 		BEC251E92B1E49C600E4B47C /* MockBTPayPalNativeCheckoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBTPayPalNativeCheckoutProvider.swift; sourceTree = "<group>"; };
 		BEC3F11228A4401E0074DF0F /* BTHTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTHTTPError.swift; sourceTree = "<group>"; };
 		BECA56C929C3F0A80098EC3C /* BTThreeDSecureV2UICustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2UICustomization.swift; sourceTree = "<group>"; };
+		BECB10C52B5999EE008D398E /* BTPayPalLineItem_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTPayPalLineItem_Tests.swift; sourceTree = "<group>"; };
 		BECBA0E52AEABC99002518AC /* BTCardClient_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient_IntegrationTests.swift; sourceTree = "<group>"; };
 		BED00CAD28A5419900D74AEC /* BTBinData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBinData.swift; sourceTree = "<group>"; };
 		BED00CAF28A579D700D74AEC /* BTClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientToken.swift; sourceTree = "<group>"; };
@@ -1670,6 +1672,7 @@
 				3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */,
 				42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */,
 				427F32DF25D1D62D00435294 /* BTPayPalClient_Tests.swift */,
+				BECB10C52B5999EE008D398E /* BTPayPalLineItem_Tests.swift */,
 				42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */,
 				427F328F25D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift */,
 				A9E5C1E424FD665D00EE691F /* Info.plist */,
@@ -3053,6 +3056,7 @@
 				42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */,
 				BEDEAF112AC1D049004EA970 /* BTPayPalAccountNonce_Tests.swift in Sources */,
 				427F329025D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift in Sources */,
+				BECB10C62B5999EE008D398E /* BTPayPalLineItem_Tests.swift in Sources */,
 				3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */,
 				A95229C724FD949D006F7D25 /* BTConfiguration+PayPal_Tests.swift in Sources */,
 			);

--- a/UnitTests/BraintreePayPalTests/BTPayPalLineItem_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalLineItem_Tests.swift
@@ -8,41 +8,41 @@ class BTPayPalLineItem_Tests: XCTestCase {
         let lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
        
         lineItem.upcType = .UPC_A 
-        let requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-A");
-       
+        var requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-A");
+
         lineItem.upcType = .UPC_B 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-B");
-       
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-B")
+
         lineItem.upcType = .UPC_C 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-C");
-       
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-C")
+
         lineItem.upcType = .UPC_D 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-D");
-       
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-D")
+
         lineItem.upcType = .UPC_E 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-E");
-       
-        lineItem.upcType = .UPC_1 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-1");
-       
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-E")
+
         lineItem.upcType = .UPC_2 
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["upc_type"] as! String, "UPC-2");
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"]!, "UPC-2")
+
+        lineItem.upcType = .UPC_5
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["upc_type"], "UPC-5")
     }
 
     func testKindStringReturnsCorrectValue() {
-        let lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
-        let requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["kind"] as! String, "debit");
-        
+        var lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
+        var requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["kind"], "debit");
+
         lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .credit)
-        requestParams = lineItem.requestParameters();
-        XCTAssertEqual(requestParams["kind"] as! String, "credit");
+        requestParams = lineItem.requestParameters()
+        XCTAssertEqual(requestParams["kind"], "credit");
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalLineItem_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalLineItem_Tests.swift
@@ -5,11 +5,11 @@ import XCTest
 class BTPayPalLineItem_Tests: XCTestCase {
     
     func testUPCTypeStringReturnsCorrectValue() {
-        let lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
-       
+        var lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
+
         lineItem.upcType = .UPC_A 
         var requestParams = lineItem.requestParameters()
-        XCTAssertEqual(requestParams["upc_type"], "UPC-A");
+        XCTAssertEqual(requestParams["upc_type"], "UPC-A")
 
         lineItem.upcType = .UPC_B 
         requestParams = lineItem.requestParameters()
@@ -39,10 +39,10 @@ class BTPayPalLineItem_Tests: XCTestCase {
     func testKindStringReturnsCorrectValue() {
         var lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .debit)
         var requestParams = lineItem.requestParameters()
-        XCTAssertEqual(requestParams["kind"], "debit");
+        XCTAssertEqual(requestParams["kind"], "debit")
 
         lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "10", name: "item-name", kind: .credit)
         requestParams = lineItem.requestParameters()
-        XCTAssertEqual(requestParams["kind"], "credit");
+        XCTAssertEqual(requestParams["kind"], "credit")
     }
 }


### PR DESCRIPTION
### Summary of changes

- The new file `BTPayPalLineItem_Tests` was not correctly added to Xcode and therefore the tests never ran as part of CI - one of the tests was wrong and should have failed, this file has now been added to Xcode and will run on CI
- Cleanup the test file based on compiler warnings

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
