### PR TITLE
Update Docstrings for PayPal Messaging `Init`

### DIFF
--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -18,7 +18,7 @@ public class BTPayPalMessagingView: UIView {
 
     // MARK: - Initializers
 
-    ///  Initializes a PayPal Messaging client.
+    ///  Initializes a `PayPalMessagingView`.
     /// - Parameter apiClient: The Braintree API client
     public init(apiClient: BTAPIClient) {
         self.apiClient = apiClient
@@ -103,7 +103,7 @@ public extension BTPayPalMessagingView {
 
         private var request: BTPayPalMessagingRequest = BTPayPalMessagingRequest()
         
-        ///  Initializes a PayPal Messaging client.
+        ///  Initializes a `PayPalMessagingView`.
         /// - Parameters:
         ///   - apiClient: The Braintree API client
         ///   - request: an optional `BTPayPalMessagingRequest`

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -18,7 +18,7 @@ public class BTPayPalMessagingView: UIView {
 
     // MARK: - Initializers
 
-    ///  Initializes a `PayPalMessagingView`.
+    ///  Initializes a `BTPayPalMessagingView`.
     /// - Parameter apiClient: The Braintree API client
     public init(apiClient: BTAPIClient) {
         self.apiClient = apiClient
@@ -103,7 +103,7 @@ public extension BTPayPalMessagingView {
 
         private var request: BTPayPalMessagingRequest = BTPayPalMessagingRequest()
         
-        ///  Initializes a `PayPalMessagingView`.
+        ///  Initializes a `BTPayPalMessagingView`.
         /// - Parameters:
         ///   - apiClient: The Braintree API client
         ///   - request: an optional `BTPayPalMessagingRequest`


### PR DESCRIPTION
### Summary of changes

- A couple of docstring incorrectly mentioned the initial name for this class as `Client`, updated the docstrings to be correct and ensured there were no other references to the old name

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
