### PR TITLE
[Shopper Insights] Fix return flow bug

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -347,6 +347,31 @@ import Foundation
     }
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    ///
+    /// Perfom an HTTP POST on a URL composed of the configured from environment and the given path.
+    /// - Parameters:
+    ///   - path: The endpoint URI path.
+    ///   - parameters: Optional set of query parameters to be encoded with the request.
+    ///   - httpType: The underlying `BTAPIClientHTTPService` of the HTTP request. Defaults to `.gateway`.
+    /// - Returns: On success, `(BTJSON?, HTTPURLResponse?)` will contain the JSON body response and the HTTP response.
+    @_documentation(visibility: private)
+    public func post(
+        _ path: String,
+        parameters: Encodable,
+        httpType: BTAPIClientHTTPService = .gateway
+    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+        try await withCheckedThrowingContinuation { continuation in
+            post(path, parameters: parameters, httpType: httpType) { json, httpResonse, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: (json, httpResonse))
+                }
+            }
+        }
+    }
+
+    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
         analyticsService?.sendAnalyticsEvent(

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -45,7 +45,7 @@ public class BTShopperInsightsClient {
             )
             
             do {
-                let (body, _) = try await apiClient.post("/v2/payments/find-eligible-methods", parameters: postParameters, httpType: .payPalAPI)
+                let (_, _) = try await apiClient.post("/v2/payments/find-eligible-methods", parameters: postParameters, httpType: .payPalAPI)
                 
                 // TODO: - Handle API Response. DTBTSDK-3388
                 let result = BTShopperInsightsResult()

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -44,22 +44,15 @@ public class BTShopperInsightsClient {
                 merchantID: "TODO-merchant-id-type"
             )
             
-            apiClient.post(
-                "/v2/payments/find-eligible-methods",
-                parameters: postParameters,
-                httpType: .payPalAPI
-            ) { json, _, error in
-                Task {
-                    if let error {
-                        try self.notifyFailure(with: error)
-                    }
-                    let result = BTShopperInsightsResult()
-                    return self.notifySuccess(with: result)
-                }
+            do {
+                let (body, _) = try await apiClient.post("/v2/payments/find-eligible-methods", parameters: postParameters, httpType: .payPalAPI)
+                
                 // TODO: - Handle API Response. DTBTSDK-3388
+                let result = BTShopperInsightsResult()
+                return self.notifySuccess(with: result)
+            } catch {
+                throw self.notifyFailure(with: error)
             }
-            
-            return BTShopperInsightsResult()
         }
     }
     
@@ -106,8 +99,8 @@ public class BTShopperInsightsClient {
         return result
     }
     
-    private func notifyFailure(with error: Error) throws {
+    private func notifyFailure(with error: Error) -> Error {
         apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.recommendedPaymentsFailed, errorDescription: error.localizedDescription)
-        throw error
+        return error
     }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -77,6 +77,21 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(amount["currency_code"], "USD")
     }
     
+    func testGetRecommendedPaymentMethods_whenAPIError_throws() async {
+        mockAPIClient.cannedResponseError = NSError(domain: "fake-error-domain", code: 123, userInfo: [NSLocalizedDescriptionKey:"fake-error-description"])
+        
+        do {
+            _ = try await sut.getRecommendedPaymentMethods(request: request)
+            XCTFail("Expected error to be thrown.")
+        } catch let error as NSError {
+            XCTAssertEqual(error.code, 123)
+            XCTAssertEqual(error.localizedDescription, "fake-error-description")
+            XCTAssertEqual(error.domain, "fake-error-domain")
+            
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:failed")
+        }
+    }
+    
     // MARK: - Analytics
     
     func testSendPayPalPresentedEvent_sendsAnalytic() {

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -92,6 +92,16 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         }
     }
     
+    func testGetRecommendedPaymentMethods_whenAPISuccess_returnsResult() async {
+        // TODO: - Elaborate test once parsing logic added
+        do {
+            let result = try await sut.getRecommendedPaymentMethods(request: request)
+            XCTAssertNotNil(result)
+        } catch let error as NSError {
+            XCTFail("An error was not expected.")
+        }
+    }
+    
     // MARK: - Analytics
     
     func testSendPayPalPresentedEvent_sendsAnalytic() {

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -97,6 +97,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         do {
             let result = try await sut.getRecommendedPaymentMethods(request: request)
             XCTAssertNotNil(result)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
         } catch let error as NSError {
             XCTFail("An error was not expected.")
         }


### PR DESCRIPTION
### Summary 

- When I ran our demo app, I realized there was an issue with [this logic](https://github.com/braintree/braintree_ios/blob/2d931f498e795d3b5f843a3182c6e73614a035c9/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift#L52-L62) where line 62 would always execute before the `Task` had a chance to complete & even if you properly returned in all conditions within the `Task` the compiler still requires an exit out of the function outside of the `Task`
- The cleanest approach (from the `BTShopperInsightsClient` perspective) is to stick with all async-await syntax

### Changes
- Add an `async` version of `BTAPIClient.post()`
- Update `BTShopperInsightsClient` to use new `post()` async method
- Add unit tests
    - Added failing tests first to confirm (TDD for _life_)

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 