### PR TITLE
Add `paypal_context_id` FPTI Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
+
 ## 6.12.0 (2024-01-18)
 * BraintreePayPal
   * Add `imageURL`, `upcCode`, and `upcType` to `BTPayPalLineItem`

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -34,6 +34,8 @@ class BTAnalyticsService: Equatable {
 
     private let apiClient: BTAPIClient
 
+    private var payPalContextID: String?
+
     // MARK: - Initializer
 
     init(apiClient: BTAPIClient, flushThreshold: Int = 1) {
@@ -48,8 +50,14 @@ class BTAnalyticsService: Equatable {
     ///  Events are queued and sent in batches to the analytics service, based on the status of the app and
     ///  the number of queued events. After exiting this method, there is no guarantee that the event has been sent.
     /// - Parameter eventName: String representing the event name
-    func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
+    func sendAnalyticsEvent(
+        _ eventName: String,
+        errorDescription: String? = nil,
+        correlationID: String? = nil,
+        payPalContextID: String? = nil
+    ) {
         DispatchQueue.main.async {
+            self.payPalContextID = payPalContextID
             self.enqueueEvent(eventName, errorDescription: errorDescription, correlationID: correlationID)
             self.flushIfAtThreshold()
         }
@@ -60,9 +68,11 @@ class BTAnalyticsService: Equatable {
         _ eventName: String,
         errorDescription: String? = nil,
         correlationID: String? = nil,
+        payPalContextID: String? = nil,
         completion: @escaping (Error?) -> Void = { _ in }
     ) {
         DispatchQueue.main.async {
+            self.payPalContextID = payPalContextID
             self.enqueueEvent(eventName, errorDescription: errorDescription, correlationID: correlationID)
             self.flush(completion)
         }
@@ -159,6 +169,7 @@ class BTAnalyticsService: Equatable {
             environment: config.fptiEnvironment,
             integrationType: apiClient.metadata.integration.stringValue,
             merchantID: config.merchantID,
+            payPalContextID: payPalContextID,
             sessionID: sessionID,
             tokenizationKey: apiClient.tokenizationKey
         )

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -97,7 +97,9 @@ struct FPTIBatchData: Codable {
         let merchantAppVersion: String = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? "N/A"
 
         let merchantID: String?
-        
+
+        let payPalContextID: String?
+
         let platform = "iOS"
 
         let sessionID: String
@@ -120,6 +122,7 @@ struct FPTIBatchData: Codable {
             case isSimulator = "is_simulator"
             case merchantAppVersion = "mapv"
             case merchantID = "merchant_id"
+            case payPalContextID = "paypal_context_id"
             case platform = "platform"
             case sessionID = "session_id"
             case tokenizationKey = "tokenization_key"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -98,6 +98,8 @@ struct FPTIBatchData: Codable {
 
         let merchantID: String?
 
+        /// Used for linking events from the client to server side request
+        /// This value will be PayPal Order ID, Payment Token, EC token or Billing Agreement depending on the flow
         let payPalContextID: String?
 
         let platform = "iOS"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -339,11 +339,17 @@ import Foundation
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     @_documentation(visibility: private)
-    public func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
+    public func sendAnalyticsEvent(
+        _ eventName: String,
+        errorDescription: String? = nil,
+        correlationID: String? = nil,
+        payPalContextID: String? = nil
+    ) {
         analyticsService?.sendAnalyticsEvent(
             eventName,
             errorDescription: errorDescription,
             correlationID: correlationID,
+            payPalContextID: payPalContextID,
             completion: { _ in }
         )
     }

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -27,6 +27,8 @@ import BraintreeDataCollector
     private let apiClient: BTAPIClient
     private var request: BTLocalPaymentRequest?
 
+    private var payPalContextID: String? = nil
+
     // MARK: - Initializer
 
     /// Initialize a new `BTLocalPaymentClient` instance.
@@ -240,6 +242,7 @@ import BraintreeDataCollector
                let approvalURLString = body?["paymentResource"]["redirectUrl"].asString(),
                let url = URL(string: approvalURLString) {
 
+                self.payPalContextID = paymentID
                 self.request?.localPaymentFlowDelegate?.localPaymentStarted(request, paymentID: paymentID) {
                     self.onPayment(with: url, error: error)
                 }
@@ -308,14 +311,15 @@ import BraintreeDataCollector
         with result: BTLocalPaymentResult,
         completion: @escaping (BTLocalPaymentResult?, Error?) -> Void
     ) {
-        apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.paymentSucceeded)
+        apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.paymentSucceeded, payPalContextID: payPalContextID)
         completion(result, nil)
     }
 
     private func notifyFailure(with error: Error, completion: @escaping (BTLocalPaymentResult?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTLocalPaymentAnalytics.paymentFailed,
-            errorDescription: error.localizedDescription
+            errorDescription: error.localizedDescription,
+            payPalContextID: payPalContextID
         )
         completion(nil, error)
     }

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -27,6 +27,8 @@ import BraintreeDataCollector
     private let apiClient: BTAPIClient
     private var request: BTLocalPaymentRequest?
 
+    /// Used for linking events from the client to server side request
+    /// In the Local Payment flow this will be a Payment Token/Order ID
     private var payPalContextID: String? = nil
 
     // MARK: - Initializer

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -242,7 +242,10 @@ import BraintreeDataCollector
                let approvalURLString = body?["paymentResource"]["redirectUrl"].asString(),
                let url = URL(string: approvalURLString) {
 
-                self.payPalContextID = paymentID
+                if !paymentID.isEmpty {
+                    self.payPalContextID = paymentID
+                }
+
                 self.request?.localPaymentFlowDelegate?.localPaymentStarted(request, paymentID: paymentID) {
                     self.onPayment(with: url, error: error)
                 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -35,7 +35,7 @@ import BraintreeDataCollector
     /// Will only be `true` if the user proceed through the `UIAlertController`
     private var webSessionReturned: Bool = false
 
-    private var payPalContextID: String?
+    private var payPalContextID: String? = nil
 
     // MARK: - Initializer
 

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -35,6 +35,8 @@ import BraintreeDataCollector
     /// Will only be `true` if the user proceed through the `UIAlertController`
     private var webSessionReturned: Bool = false
 
+    private var payPalContextID: String?
+
     // MARK: - Initializer
 
     /// Initialize a new PayPal client instance.
@@ -263,6 +265,8 @@ import BraintreeDataCollector
                 }
 
                 let pairingID = self.token(from: approvalURL)
+                self.payPalContextID = pairingID
+
                 let dataCollector = BTDataCollector(apiClient: self.apiClient)
                 self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(pairingID)
                 self.handlePayPalRequest(with: approvalURL, paymentType: request.paymentType, completion: completion)
@@ -399,7 +403,7 @@ import BraintreeDataCollector
         with result: BTPayPalAccountNonce,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeSucceeded, correlationID: clientMetadataID)
+        apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeSucceeded, correlationID: clientMetadataID, payPalContextID: payPalContextID)
         completion(result, nil)
     }
 
@@ -407,13 +411,18 @@ import BraintreeDataCollector
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.tokenizeFailed,
             errorDescription: error.localizedDescription,
-            correlationID: clientMetadataID
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
         )
         completion(nil, error)
     }
 
     private func notifyCancel(completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled, correlationID: clientMetadataID)
+        self.apiClient.sendAnalyticsEvent(
+            BTPayPalAnalytics.browserLoginCanceled,
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
+        )
         completion(nil, BTPayPalError.canceled)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -35,6 +35,8 @@ import BraintreeDataCollector
     /// Will only be `true` if the user proceed through the `UIAlertController`
     private var webSessionReturned: Bool = false
 
+    /// Used for linking events from the client to server side request
+    /// In the PayPal flow this will be either an EC token or a Billing Agreement token
     private var payPalContextID: String? = nil
 
     // MARK: - Initializer

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -265,7 +265,10 @@ import BraintreeDataCollector
                 }
 
                 let pairingID = self.token(from: approvalURL)
-                self.payPalContextID = pairingID
+
+                if !pairingID.isEmpty {
+                    self.payPalContextID = pairingID
+                }
 
                 let dataCollector = BTDataCollector(apiClient: self.apiClient)
                 self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(pairingID)
@@ -296,19 +299,19 @@ import BraintreeDataCollector
             handleBrowserSwitchReturn(url, paymentType: paymentType, completion: completion)
         } sessionDidAppear: { [self] didAppear in
             if didAppear {
-                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserPresentationSucceeded)
+                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserPresentationSucceeded, payPalContextID: payPalContextID)
             } else {
-                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserPresentationFailed)
+                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserPresentationFailed, payPalContextID: payPalContextID)
             }
         } sessionDidCancel: { [self] in
             if !webSessionReturned {
                 // User tapped system cancel button on permission alert
-                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginAlertCanceled)
+                apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginAlertCanceled, payPalContextID: payPalContextID)
             }
 
             // User canceled by breaking out of the PayPal browser switch flow
             // (e.g. System "Cancel" button on permission alert or browser during ASWebAuthenticationSession)
-            apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled)
+            apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled, payPalContextID: payPalContextID)
             notifyCancel(completion: completion)
             return
         }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -17,6 +17,7 @@ import PayPalCheckout
     
     /// Used in POST body for FPTI analytics.
     private var clientMetadataID: String? = nil
+    private var payPalContextID: String? = nil
     private let nativeCheckoutProvider: BTPayPalNativeCheckoutStartable
 
 
@@ -121,6 +122,8 @@ import PayPalCheckout
         self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeStarted)
         
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
+        payPalContextID = orderCreationClient.payPalContextID
+        
         orderCreationClient.createOrder(with: request) { [weak self] result in
             guard let self else {
                 completion(nil, BTPayPalNativeCheckoutError.deallocated)
@@ -169,7 +172,11 @@ import PayPalCheckout
         with result: BTPayPalNativeCheckoutAccountNonce,
         completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void
     ) {
-        apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded, correlationID: clientMetadataID)
+        apiClient.sendAnalyticsEvent(
+            BTPayPalNativeCheckoutAnalytics.tokenizeSucceeded,
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
+        )
         completion(result, nil)
     }
 
@@ -177,13 +184,18 @@ import PayPalCheckout
         apiClient.sendAnalyticsEvent(
             BTPayPalNativeCheckoutAnalytics.tokenizeFailed,
             errorDescription: error.localizedDescription,
-            correlationID: clientMetadataID
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
         )
         completion(nil, error)
     }
 
     private func notifyCancel(completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void) {
-        self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeCanceled, correlationID: clientMetadataID)
+        self.apiClient.sendAnalyticsEvent(
+            BTPayPalNativeCheckoutAnalytics.tokenizeCanceled,
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
+        )
         completion(nil, BTPayPalNativeCheckoutError.canceled)
     }
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -122,8 +122,11 @@ import PayPalCheckout
         self.apiClient.sendAnalyticsEvent(BTPayPalNativeCheckoutAnalytics.tokenizeStarted)
         
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
-        payPalContextID = orderCreationClient.payPalContextID
-        
+
+        if let payPalContextID = orderCreationClient.payPalContextID, !payPalContextID.isEmpty {
+            self.payPalContextID = payPalContextID
+        }
+
         orderCreationClient.createOrder(with: request) { [weak self] result in
             guard let self else {
                 completion(nil, BTPayPalNativeCheckoutError.deallocated)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -123,14 +123,14 @@ import PayPalCheckout
         
         let orderCreationClient = BTPayPalNativeOrderCreationClient(with: apiClient)
 
-        if let payPalContextID = orderCreationClient.payPalContextID, !payPalContextID.isEmpty {
-            self.payPalContextID = payPalContextID
-        }
-
         orderCreationClient.createOrder(with: request) { [weak self] result in
             guard let self else {
                 completion(nil, BTPayPalNativeCheckoutError.deallocated)
                 return
+            }
+
+            if let payPalContextID = orderCreationClient.payPalContextID, !payPalContextID.isEmpty {
+                self.payPalContextID = payPalContextID
             }
 
             switch result {

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -17,7 +17,11 @@ import PayPalCheckout
     
     /// Used in POST body for FPTI analytics.
     private var clientMetadataID: String? = nil
+
+    /// Used for linking events from the client to server side request
+    /// In the PayPal Native Checkout flow this will be an Order ID
     private var payPalContextID: String? = nil
+
     private let nativeCheckoutProvider: BTPayPalNativeCheckoutStartable
 
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -16,6 +16,8 @@ struct BTPayPalNativeOrder: Equatable {
 
 class BTPayPalNativeOrderCreationClient {
 
+    var payPalContextID: String? = nil
+
     private let apiClient: BTAPIClient
 
     init(with apiClient: BTAPIClient) {
@@ -72,6 +74,7 @@ class BTPayPalNativeOrderCreationClient {
                     orderID: hermesResponse.orderID
                 )
 
+                self.payPalContextID = order.orderID
                 completion(.success(order))
             }
         }

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -11,6 +11,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         environment: "fake-env",
         integrationType: "fake-integration-type",
         merchantID: "fake-merchant-id",
+        payPalContextID: "fake-order-id",
         sessionID: "fake-session",
         tokenizationKey: "fake-auth"
     )
@@ -70,6 +71,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertNotNil(batchParams["mapv"] as? String) // Unable to specify bundle version number within test targets
         XCTAssertTrue((batchParams["mobile_device_model"] as! String).matches("iPhone\\d,\\d|x86_64|arm64"))
         XCTAssertEqual(batchParams["merchant_id"] as! String, "fake-merchant-id")
+        XCTAssertEqual(batchParams["paypal_context_id"] as! String, "fake-order-id")
         XCTAssertEqual(batchParams["platform"] as? String, "iOS")
         XCTAssertEqual(batchParams["session_id"] as? String, "fake-session")
         XCTAssertEqual(batchParams["tokenization_key"] as! String, "fake-auth")

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -5,7 +5,12 @@ class FakeAnalyticsService: BTAnalyticsService {
     var lastEvent: String = ""
     var didLastFlush: Bool = false
 
-    override func sendAnalyticsEvent(_ eventName: String, errorDescription: String? = nil, correlationID: String? = nil) {
+    override func sendAnalyticsEvent(
+        _ eventName: String,
+        errorDescription: String? = nil,
+        correlationID: String? = nil,
+        payPalContextID: String? = nil
+    ) {
         self.lastEvent = eventName
         self.didLastFlush = false
     }
@@ -14,6 +19,7 @@ class FakeAnalyticsService: BTAnalyticsService {
         _ eventName: String,
         errorDescription: String? = nil,
         correlationID: String? = nil,
+        payPalContextID: String? = nil,
         completion: @escaping (Error?) -> Void = { _ in }
     ) {
         self.lastEvent = eventName

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -210,6 +210,35 @@ class BTPayPalClient_Tests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
 
+    func testTokenize_whenApprovalURLContainsPayPalContextID_sendsPayPalContextIDInAnalytics() {
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paymentResource": [
+                "redirectUrl": "https://www.paypal.com/checkout?token=EC-Random-Value"
+            ]
+        ])
+
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
+
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        payPalClient.tokenize(request) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.postedPayPalContextID, "EC-Random-Value")
+    }
+
+    func testTokenize_whenApprovalURLDoesNotContainPayPalContextID_doesNotSendPayPalContextIDInAnalytics() {
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paymentResource": [
+                "redirectUrl": "https://www.paypal.com/checkout?token="
+            ]
+        ])
+
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
+
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        payPalClient.tokenize(request) { _, _ in }
+
+        XCTAssertNil(mockAPIClient.postedPayPalContextID)
+    }
 
     // MARK: - Browser switch
 

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -11,6 +11,7 @@ public class MockAPIClient: BTAPIClient {
     public var lastGETAPIClientHTTPType: BTAPIClientHTTPService?
 
     public var postedAnalyticsEvents : [String] = []
+    public var postedPayPalContextID: String? = nil
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -80,7 +81,8 @@ public class MockAPIClient: BTAPIClient {
         completion([], nil)
     }
 
-    public override func sendAnalyticsEvent(_ name: String, errorDescription: String? = nil, correlationID: String? = nil) {
+    public override func sendAnalyticsEvent(_ name: String, errorDescription: String? = nil, correlationID: String? = nil, payPalContextID: String? = nil) {
+        postedPayPalContextID = payPalContextID
         postedAnalyticsEvents.append(name)
     }
 


### PR DESCRIPTION
### Summary of changes

- Pass `paypal_context_id` to FPTI when available:
    - PayPal Web: passing either the `token` (checkout) or `ba_token` (vault) as the `paypal_context_id`
    - PayPal Native: passing the `orderID` as the `paypal_context_id`
    - Local Payments: passing the `paymentToken` (which is an order ID) as the `paypal_context_id`
    - If we get an empty string back we will not pass an empty string to FPTI
- I have verified that we are passing this value as expected in the above flows to FPTI
- Add Unit Tests

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais  
