### PR TITLE
[DRAFT] Remove Response from HTTP Requests

### DIFF
--- a/IntegrationTests/Braintree-API-Integration-Specs/BTGraphQLHTTP_SSLPinning_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTGraphQLHTTP_SSLPinning_IntegrationTests.swift
@@ -9,7 +9,7 @@ class BTGraphQLHTTP_SSLPinning_IntegrationTests : XCTestCase {
 
         let expectation = self.expectation(description: "Callback invoked")
 
-        graphqlHttp.post("/ping") { body, response, error in
+        graphqlHttp.post("/ping") { body, error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -22,7 +22,7 @@ class BTGraphQLHTTP_SSLPinning_IntegrationTests : XCTestCase {
 
         let expectation = self.expectation(description: "Callback invoked")
 
-        graphqlHttp.post("/ping") { body, response, error in
+        graphqlHttp.post("/ping") { body, error in
             XCTAssertNil(error)
             expectation.fulfill()
         }

--- a/IntegrationTests/Braintree-API-Integration-Specs/BTHTTP_SSLPinning_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTHTTP_SSLPinning_IntegrationTests.swift
@@ -8,7 +8,7 @@ final class BTHTTP_SSLPinning_IntegrationTests: XCTestCase {
         let http = BTHTTP(url: url, tokenizationKey: "development_testing_integration_merchant_id")
         let expectation = expectation(description: "Callback invoked")
 
-        http.get("/heartbeat.json") { body, _, error in
+        http.get("/heartbeat.json") { body, error in
             XCTAssertNil(error)
             XCTAssertEqual(body?["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-production")
             expectation.fulfill()
@@ -22,7 +22,7 @@ final class BTHTTP_SSLPinning_IntegrationTests: XCTestCase {
         let http = BTHTTP(url: url, tokenizationKey: "development_testing_integration_merchant_id")
         let expectation = expectation(description: "Callback invoked")
 
-        http.get("/heartbeat.json") { body, _, error in
+        http.get("/heartbeat.json") { body, error in
             XCTAssertNil(error)
             XCTAssertEqual(body?["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-sandbox")
             expectation.fulfill()
@@ -36,9 +36,8 @@ final class BTHTTP_SSLPinning_IntegrationTests: XCTestCase {
         let http = BTHTTP(url: url, tokenizationKey: "development_testing_integration_merchant_id")
         let expectation = expectation(description: "Callback invoked")
 
-        http.get("/heartbeat.json") { body, response, error in
+        http.get("/heartbeat.json") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
 
             let error = error as NSError?
             XCTAssertEqual(error?.domain, URLError.errorDomain)

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -29,7 +29,7 @@ import BraintreeCore
         let parameters = BTAmexRewardsBalanceRequest(currencyIsoCode: currencyISOCode, paymentMethodNonce: nonce)
         apiClient.sendAnalyticsEvent(BTAmericanExpressAnalytics.started)
 
-        apiClient.get("v1/payment_methods/amex_rewards_balance", parameters: parameters) { [weak self] body, response, error in
+        apiClient.get("v1/payment_methods/amex_rewards_balance", parameters: parameters) { [weak self] body, error in
             guard let self else {
                 completion(nil, BTAmericanExpressError.deallocated)
                 return

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -91,7 +91,7 @@ import BraintreeCore
             
             let parameters = BTApplePaymentTokensRequest(token: payment.token)
 
-            self.apiClient.post("v1/payment_methods/apple_payment_tokens", parameters: parameters) { body, _, error in
+            self.apiClient.post("v1/payment_methods/apple_payment_tokens", parameters: parameters) { body, error in
                 if let error {
                     self.notifyFailure(with: error, completion: completion)
                     return

--- a/Sources/BraintreeCard/BTCardClient.swift
+++ b/Sources/BraintreeCard/BTCardClient.swift
@@ -53,7 +53,7 @@ import BraintreeCore
 
                 let parameters = card.graphQLParameters()
 
-                self.apiClient.post("", parameters: parameters, httpType: .graphQLAPI) { body, _, error in
+                self.apiClient.post("", parameters: parameters, httpType: .graphQLAPI) { body, error in
                     if let error = error as NSError? {
                         let response: HTTPURLResponse? = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse
                         var callbackError: Error? = error
@@ -81,7 +81,7 @@ import BraintreeCore
             } else {
                 let parameters = self.clientAPIParameters(for: card)
 
-                self.apiClient.post("v1/payment_methods/credit_cards", parameters: parameters) {body, _, error in
+                self.apiClient.post("v1/payment_methods/credit_cards", parameters: parameters) {body, error in
                     if let error = error as NSError? {
                         let response: HTTPURLResponse? = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse
                         var callbackError: Error? = error

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -104,7 +104,7 @@ class BTAnalyticsService: Equatable {
 
                 self.analyticsSessions.keys.forEach { sessionID in
                     let postParameters = self.createAnalyticsEvent(config: configuration, sessionID: sessionID)
-                    self.http?.post("v1/tracking/batch/events", parameters: postParameters) { body, response, error in
+                    self.http?.post("v1/tracking/batch/events", parameters: postParameters) { body, error in
                         if let error {
                             completion(error)
                         }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -155,6 +155,11 @@ import Foundation
                 return
             }
 
+            guard let body else {
+                completion(nil, BTAPIClientError.configurationUnavailable)
+                return
+            }
+
             configuration = BTConfiguration(json: body)
 
             if http == nil {
@@ -175,11 +180,6 @@ import Foundation
                 } else if let tokenizationKey, let graphQLBaseURL {
                     graphQLHTTP = BTGraphQLHTTP(url: graphQLBaseURL, tokenizationKey: tokenizationKey)
                 }
-            }
-
-            guard let configuration else {
-                completion(nil, BTAPIClientError.configurationUnavailable)
-                return
             }
 
             completion(configuration, nil)

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class BTGraphQLHTTP: BTHTTP {
 
-    typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
+    typealias RequestCompletion = (BTJSON?, Error?) -> Void
 
     // MARK: - Properties
 
@@ -38,7 +38,7 @@ class BTGraphQLHTTP: BTHTTP {
         if baseURL.absoluteString.isEmpty || baseURL.absoluteString == "" {
             errorUserInfo["method"] = method
             errorUserInfo["parameters"] = parameters
-            completion(nil, nil, BTHTTPError.missingBaseURL(errorUserInfo))
+            completion(nil, BTHTTPError.missingBaseURL(errorUserInfo))
             return
         }
         
@@ -53,12 +53,12 @@ class BTGraphQLHTTP: BTHTTP {
         }
         
         guard let components = URLComponents(string: baseURL.absoluteString) else {
-            completion(nil, nil, BTHTTPError.urlStringInvalid)
+            completion(nil, BTHTTPError.urlStringInvalid)
             return
         }
 
         guard let urlFromComponents = components.url else {
-            completion(nil, nil, BTHTTPError.urlStringInvalid)
+            completion(nil, BTHTTPError.urlStringInvalid)
             return
         }
 
@@ -81,14 +81,14 @@ class BTGraphQLHTTP: BTHTTP {
             // Perform the actual request
             session.dataTask(with: request) { [weak self] data, response, error in
                 guard let self else {
-                    completion(nil, nil, BTHTTPError.deallocated("BTGraphQLHTTP"))
+                    completion(nil, BTHTTPError.deallocated("BTGraphQLHTTP"))
                     return
                 }
 
                 handleRequestCompletion(data: data, response: response, error: error, completion: completion)
             }.resume()
         } catch {
-            completion(nil, nil, error)
+            completion(nil, error)
         }
     }
 

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -4,7 +4,7 @@ import Security
 /// Performs HTTP methods on the Braintree Client API
 class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
 
-    typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
+    typealias RequestCompletion = (BTJSON?, Error?) -> Void
 
     enum ClientAuthorization: Equatable {
         case authorizationFingerprint(String), tokenizationKey(String)
@@ -108,8 +108,8 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
             } else {
                 httpRequest(method: "GET", path: path, parameters: dict, completion: completion)
             }
-        } catch let error {
-            completion(nil, nil, error)
+        } catch {
+            completion(nil, error)
         }
     }
 
@@ -122,8 +122,8 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         do {
             let dict = try parameters.toDictionary()
             post(path, parameters: dict, completion: completion)
-        } catch let error {
-            completion(nil, nil, error)
+        } catch {
+            completion(nil, error)
         }
     }
 
@@ -164,7 +164,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
                 } else {
                     self.session.dataTask(with: request) { [weak self] data, response, error in
                         guard let self else {
-                            completion?(nil, nil, BTHTTPError.deallocated("BTHTTP"))
+                            completion?(nil, BTHTTPError.deallocated("BTHTTP"))
                             return
                         }
 
@@ -189,7 +189,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
 
             self.session.dataTask(with: request) { [weak self] data, response, error in
                 guard let self else {
-                    completion?(nil, nil, BTHTTPError.deallocated("BTHTTP"))
+                    completion?(nil, BTHTTPError.deallocated("BTHTTP"))
                     return
                 }
 
@@ -342,7 +342,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         if httpResponse.statusCode >= 400 {
             handleHTTPResponseError(response: httpResponse, data: data) { [weak self] json, error in
                 guard let self else {
-                    completion(nil, nil, BTHTTPError.deallocated("BTHTTP"))
+                    completion(nil, BTHTTPError.deallocated("BTHTTP"))
                     return
                 }
 
@@ -356,7 +356,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         if json.isError {
             handleJSONResponseError(json: json, response: response) { [weak self] error in
                 guard let self else {
-                    completion(nil, nil, BTHTTPError.deallocated("BTHTTP"))
+                    completion(nil, BTHTTPError.deallocated("BTHTTP"))
                     return
                 }
 
@@ -379,7 +379,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
     
     func callCompletionAsync(with completion: @escaping RequestCompletion, body: BTJSON?, response: HTTPURLResponse?, error: Error?) {
         self.dispatchQueue.async {
-            completion(body, response, error)
+            completion(body, error)
         }
     }
 

--- a/Sources/BraintreeCore/Encodable+Dictionary.swift
+++ b/Sources/BraintreeCore/Encodable+Dictionary.swift
@@ -16,7 +16,7 @@ extension Encodable {
             } else {
                 throw BTHTTPError.serializationError("Serialization to dictionary failed.")
             }
-        } catch let error {
+        } catch {
             throw BTHTTPError.serializationError(error.localizedDescription)
         }
     }

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -145,7 +145,7 @@ import BraintreeDataCollector
 
         requestParameters["_meta"] = metadataParameters
 
-        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: requestParameters) { [weak self] body, response, error in
+        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: requestParameters) { [weak self] body, error in
             guard let self else {
                 NSLog("%@ BTLocalPaymentClient has been deallocated.", BTLogLevelDescription.string(for: .critical))
                 return
@@ -230,7 +230,7 @@ import BraintreeDataCollector
 
         requestParameters["experience_profile"] = experienceProfile
 
-        apiClient.post("v1/local_payments/create", parameters: requestParameters) { body, response, error in
+        apiClient.post("v1/local_payments/create", parameters: requestParameters) { body, error in
             if let error {
                 self.notifyFailure(with: error, completion: self.merchantCompletion)
                 return

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -184,7 +184,7 @@ import BraintreeDataCollector
             "sessionId": metadata.sessionID
         ]
         
-        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: parameters) { body, response, error in
+        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: parameters) { body, error in
             if let error {
                 self.notifyFailure(with: error, completion: completion)
                 return
@@ -241,7 +241,7 @@ import BraintreeDataCollector
             }
 
             self.payPalRequest = request
-            self.apiClient.post(request.hermesPath, parameters: request.parameters(with: configuration)) { body, response, error in
+            self.apiClient.post(request.hermesPath, parameters: request.parameters(with: configuration)) { body, error in
                 if let error = error as? NSError {
                     guard let jsonResponseBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON else {
                         self.notifyFailure(with: error, completion: completion)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -59,7 +59,7 @@ class BTPayPalNativeOrderCreationClient {
             self.apiClient.post(
                 request.hermesPath,
                 parameters: request.parameters(with: config)
-            ) { json, response, error in
+            ) { json, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeCheckoutError.invalidJSONResponse
                     completion(.failure(.orderCreationFailed(underlyingError)))

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -36,7 +36,7 @@ class BTPayPalNativeTokenizationClient {
         apiClient.post(
             "v1/payment_methods/paypal_accounts",
             parameters: tokenizationRequest.parameters(returnURL: returnURL)
-        ) { body, _, error in
+        ) { body, error in
             guard let json = body, error == nil else {
                 let underlyingError = error ?? BTPayPalNativeCheckoutError.invalidJSONResponse
                 completion(.failure(.tokenizationFailed(underlyingError)))

--- a/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
@@ -18,13 +18,13 @@ class SEPADirectDebitAPI {
         completion: @escaping (CreateMandateResult?, Error?) -> Void
     ) {
         let sepaDebitRequest = SEPADebitRequest(sepaDirectDebitRequest: sepaDirectDebitRequest)
-        apiClient.post("v1/sepa_debit", parameters: sepaDebitRequest) { body, response, error in
-            if let error = error {
+        apiClient.post("v1/sepa_debit", parameters: sepaDebitRequest) { body, error in
+            if let error {
                 completion(nil, error)
                 return
             }
 
-            guard let body = body else {
+            guard let body else {
                 completion(nil, BTSEPADirectDebitError.noBodyReturned)
                 return
             }
@@ -36,13 +36,13 @@ class SEPADirectDebitAPI {
 
     func tokenize(createMandateResult: CreateMandateResult, completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void) {
         let sepaDebitAccountsRequest = SEPADebitAccountsRequest(createMandateResult: createMandateResult)
-        apiClient.post("v1/payment_methods/sepa_debit_accounts", parameters: sepaDebitAccountsRequest) { body, response, error in
-            if let error = error {
+        apiClient.post("v1/payment_methods/sepa_debit_accounts", parameters: sepaDebitAccountsRequest) { body, error in
+            if let error {
                 completion(nil, error)
                 return
             }
 
-            guard let body = body else {
+            guard let body else {
                 completion(nil, BTSEPADirectDebitError.noBodyReturned)
                 return
             }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
@@ -29,7 +29,7 @@ class BTThreeDSecureAuthenticateJWT {
         apiClient.post(
             "v1/payment_methods/\(urlSafeNonce)/three_d_secure/authenticate_from_jwt",
             parameters: requestParameters
-        ) { body, _, error in
+        ) { body, error in
             if let error {
                 apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.jwtAuthFailed)
                 completion(nil, error)

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -384,7 +384,7 @@ import BraintreeCore
             self.apiClient.post(
                 "v1/payment_methods/\(urlSafeNonce)/three_d_secure/lookup",
                 parameters: requestParameters as [String: Any] 
-            ) { body, _, error in
+            ) { body, error in
                 if let error = error as NSError? {
                     // Provide more context for card validation error when status code 422
                     if error.domain == BTCoreConstants.httpErrorDomain,

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -157,7 +157,7 @@ import BraintreeCore
                 "variables": inputDictionary
             ]
 
-            self.apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, _, error in
+            self.apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, error in
                 if let error = error as? NSError {
                     let jsonResponse: BTJSON? = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON
                     let errorMessage = jsonResponse?["error"]["message"].asString()
@@ -250,7 +250,7 @@ import BraintreeCore
                 "variables": variablesDictionary
             ]
 
-            apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, _, error in
+            apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, error in
                 if let error {
                     self.notifyFailure(with: error, completion: self.appSwitchCompletion)
                     return
@@ -338,7 +338,7 @@ import BraintreeCore
         let venmoAccount: [String: String] = ["nonce": nonce]
         let parameters: [String: Any] = ["venmoAccount": venmoAccount]
 
-        apiClient.post("v1/payment_methods/venmo_accounts", parameters: parameters) { body, _, error in
+        apiClient.post("v1/payment_methods/venmo_accounts", parameters: parameters) { body, error in
             if let error {
                 self.notifyFailure(with: error, completion: self.appSwitchCompletion)
                 return

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -168,7 +168,6 @@ class BTApplePay_Tests: XCTestCase {
                 "status" : "production"
             ]
         ])
-        mockClient.cannedHTTPURLResponse = HTTPURLResponse(url: URL(string: "any")!, statusCode: 503, httpVersion: nil, headerFields: nil)
         mockClient.cannedResponseError = NSError(domain: "foo", code: 100, userInfo: nil)
         let client = BTApplePayClient(apiClient: mockClient)
         let payment = MockPKPayment()

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -358,16 +358,16 @@ class BTAPIClient_Tests: XCTestCase {
         }
 
         let expectation2 = expectation(description: "GET request")
-        apiClient?.get("/endpoint", parameters: nil) { _, response, error in
-            XCTAssertNotNil(response)
+        apiClient?.get("/endpoint", parameters: nil) { body, error in
+            XCTAssertNotNil(body)
             XCTAssertNil(error)
             XCTAssert(Thread.isMainThread)
             expectation2.fulfill()
         }
 
         let expectation3 = expectation(description: "POST request")
-        apiClient?.post("/endpoint", parameters: nil) { _, response, error in
-            XCTAssertNotNil(response)
+        apiClient?.post("/endpoint", parameters: nil) { body, error in
+            XCTAssertNotNil(body)
             XCTAssertNil(error)
             XCTAssert(Thread.isMainThread)
             expectation3.fulfill()
@@ -412,7 +412,7 @@ class BTAPIClient_Tests: XCTestCase {
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
 
         let expectation = expectation(description: "POST callback")
-        apiClient?.post("/", parameters: [:], httpType: .gateway) { _, _, _ in
+        apiClient?.post("/", parameters: [:], httpType: .gateway) { _, _ in
             let metaParameters = mockHTTP.lastRequestParameters?["_meta"] as? [String: Any]
             XCTAssertEqual(metaParameters?["integration"] as? String, metadata?.integration.stringValue)
             XCTAssertEqual(metaParameters?["source"] as? String, metadata?.source.stringValue)
@@ -440,7 +440,7 @@ class BTAPIClient_Tests: XCTestCase {
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWith: mockResponse, statusCode: 200)
 
         let expectation = expectation(description: "POST callback")
-        apiClient?.post("/", parameters: [:], httpType: .graphQLAPI) { _, _, _ in
+        apiClient?.post("/", parameters: [:], httpType: .graphQLAPI) { _, _ in
             let clientSdkMetadata = mockGraphQLHTTP.lastRequestParameters?["clientSdkMetadata"] as? [String: String]
             XCTAssertEqual(clientSdkMetadata?["integration"] as? String, metadata?.integration.stringValue)
             XCTAssertEqual(clientSdkMetadata?["source"] as? String, metadata?.source.stringValue)
@@ -463,7 +463,7 @@ class BTAPIClient_Tests: XCTestCase {
         let postParameters = FakeRequest(testValue: "fake-value")
 
         let expectation = expectation(description: "POST callback")
-        apiClient?.post("/", parameters: postParameters, httpType: .gateway) { _, _, _ in
+        apiClient?.post("/", parameters: postParameters, httpType: .gateway) { _, _ in
             XCTAssertEqual(mockHTTP.lastRequestParameters?["testValue"] as? String, "fake-value")
             
             let metaParameters = mockHTTP.lastRequestParameters?["_meta"] as? [String: Any]
@@ -495,7 +495,7 @@ class BTAPIClient_Tests: XCTestCase {
         let postParameters = FakeRequest(testValue: "fake-value")
 
         let expectation = expectation(description: "POST callback")
-        apiClient?.post("/", parameters: postParameters, httpType: .graphQLAPI) { _, _, _ in
+        apiClient?.post("/", parameters: postParameters, httpType: .graphQLAPI) { _, _ in
             XCTAssertEqual(mockGraphQLHTTP.lastRequestParameters?["testValue"] as? String, "fake-value")
             
             let clientSdkMetadata = mockGraphQLHTTP.lastRequestParameters?["clientSdkMetadata"] as? [String: String]
@@ -520,8 +520,8 @@ class BTAPIClient_Tests: XCTestCase {
         fakeConfigurationHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
         let expectation = expectation(description: "GET request")
-        apiClient?.get("/example", parameters: nil) { body, response, error in
-            XCTAssertNil(response)
+        apiClient?.get("/example", parameters: nil) { body, error in
+            XCTAssertNil(body)
             XCTAssertNotNil(error)
             XCTAssertEqual(mockError, error as NSError?)
             expectation.fulfill()
@@ -539,8 +539,8 @@ class BTAPIClient_Tests: XCTestCase {
         fakeConfigurationHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
         let expectation = expectation(description: "GET request")
-        apiClient?.post("/example", parameters: nil) { body, response, error in
-            XCTAssertNil(response)
+        apiClient?.post("/example", parameters: nil) { body, error in
+            XCTAssertNil(body)
             XCTAssertNotNil(error)
             XCTAssertEqual(mockError, error as NSError?)
             expectation.fulfill()

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
@@ -27,7 +27,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "GET callback")
         http?.session = fakeSession
 
-        http?.post("") { body, _, _ in
+        http?.post("") { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
 
             XCTAssertTrue(httpRequest.url!.absoluteString.contains("bt-http-test://base.example.com:1234/base/path"))
@@ -41,7 +41,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "GET callback")
         http?.session = fakeSession
 
-        http?.post("hey/go/here.html") { body, _, _ in
+        http?.post("hey/go/here.html") { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
 
             XCTAssertEqual(httpRequest.url!.absoluteString, "bt-http-test://base.example.com:1234/base/path")
@@ -56,7 +56,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
     func testGETRequests_areUnsupported() {
         do {
             try BTExceptionCatcher.catchException {
-                self.http?.get("") { _, _, _ in
+                self.http?.get("") { _, _ in
                     // no-op
                 }
             }
@@ -68,7 +68,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
     func testPUTRequests_areUnsupported() {
         do {
             try BTExceptionCatcher.catchException {
-                self.http?.put("") { _, _, _ in
+                self.http?.put("") { _, _ in
                     // no-op
                 }
             }
@@ -80,7 +80,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
     func testDELETERequests_areUnsupported() {
         do {
             try BTExceptionCatcher.catchException {
-                self.http?.delete("") { _, _, _ in
+                self.http?.delete("") { _, _ in
                     // no-op
                 }
             }
@@ -95,7 +95,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "POST callback")
         http?.session = fakeSession
 
-        http?.post("", parameters: ["hey": "now"]) { body, _, error in
+        http?.post("", parameters: ["hey": "now"]) { body, error in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let bodyJSONData = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!).data(using: .utf8)
 
@@ -123,7 +123,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("", parameters: ["hey": "now"]) { body, _, _ in
+        http?.post("", parameters: ["hey": "now"]) { body, _ in
             XCTAssertEqual(body?.asDictionary(), stubResponseData as NSDictionary)
             expectation.fulfill()
         }
@@ -137,7 +137,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "POST callback")
         http?.session = fakeSession
 
-        http?.post("", parameters: nil) { body, _, _ in
+        http?.post("", parameters: nil) { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let requestHeaders = httpRequest.allHTTPHeaderFields
             XCTAssertTrue((requestHeaders!["User-Agent"])!.matches("^Braintree/iOS/\\d+\\.\\d+\\.\\d+(-[0-9a-zA-Z-]+)?$"))
@@ -151,7 +151,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "POST callback")
         http?.session = fakeSession
 
-        http?.post("", parameters: nil) { body, _, _ in
+        http?.post("", parameters: nil) { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let requestHeaders = httpRequest.allHTTPHeaderFields
             XCTAssertEqual(requestHeaders!["Braintree-Version"], "2018-03-06")
@@ -166,7 +166,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         http = BTGraphQLHTTP(url: BTHTTPTestProtocol.testBaseURL(), tokenizationKey: "development_testing_key")
         http?.session = fakeSession
 
-        http?.post("", parameters: nil) { body, _, _ in
+        http?.post("", parameters: nil) { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let requestHeaders = httpRequest.allHTTPHeaderFields
             XCTAssertEqual(requestHeaders!["Authorization"], "Bearer development_testing_key")
@@ -180,7 +180,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "POST callback")
         http?.session = fakeSession
 
-        http?.post("", parameters: nil) { body, _, _ in
+        http?.post("", parameters: nil) { body, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let requestHeaders = httpRequest.allHTTPHeaderFields
             XCTAssertEqual(requestHeaders!["Authorization"], "Bearer test-authorization-fingerprint")
@@ -295,7 +295,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -341,7 +341,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -371,7 +371,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -399,7 +399,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -440,7 +440,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             }
 
             let expectation = expectation(description: "POST callback")
-            http?.post("") { body, _, error in
+            http?.post("") { body, error in
                 let error = error as NSError?
                 let errorDictionary = error!.userInfo[BTCoreConstants.urlResponseKey] as! HTTPURLResponse
                 XCTAssertEqual(errorDictionary.statusCode, expectedStatusCode)
@@ -495,7 +495,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -526,7 +526,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.post("") { body, _, error in
+        http?.post("") { body, error in
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
@@ -547,9 +547,8 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: -1002, userInfo: [:]))
         }
 
-        http?.post("") { body, response, error in
+        http?.post("") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
 
             let error = error as NSError?
             XCTAssertEqual(error?.domain, URLError.errorDomain)
@@ -561,7 +560,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
     }
 
     func testHttpError_withEmptyDataAndNoError_returnsError() {
-        http?.handleRequestCompletion(data: nil, response: nil, error: nil) { _, _, error in
+        http?.handleRequestCompletion(data: nil, response: nil, error: nil) { _, error in
             let error = error as NSError?
             XCTAssertEqual(error?.localizedDescription, "Unable to create HTTPURLResponse from response data.")
             XCTAssertEqual(error?.domain, BTHTTPError.errorDomain)

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -45,7 +45,7 @@ final class BTHTTP_Tests: XCTestCase {
     func testRequests_useTheSpecifiedURLScheme() {
         let expectation = expectation(description: "GET callback")
 
-        http?.get("200.json") { body, _, error in
+        http?.get("200.json") { body, error in
             XCTAssertNil(error)
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             XCTAssertEqual(httpRequest.url?.scheme, "bt-http-test")
@@ -58,9 +58,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testRequests_useTheHostAtTheBaseURL() {
         let expectation = expectation(description: "GET callback")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             XCTAssertEqual(httpRequest.url?.absoluteString, "bt-http-test://base.example.com:1234/base/path/200.json?authorization_fingerprint=test-authorization-fingerprint")
@@ -73,9 +72,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testItAppendsThePathToTheBaseURL() {
         let expectation = expectation(description: "GET callback")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
@@ -88,9 +86,8 @@ final class BTHTTP_Tests: XCTestCase {
     func test_whenThePathIsNil_itHitsTheBaseURL() {
         let expectation = expectation(description: "GET callback")
 
-        http?.get("/") { body, response, error in
+        http?.get("/") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             XCTAssertEqual(httpRequest.url?.path, "/base/path")
@@ -106,9 +103,8 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "GET callback")
         http = BTHTTP(url: validDataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/") { body, response, error in
+        http?.get("/") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
             XCTAssertEqual(body?["clientId"].asString(), "a-client-id")
             XCTAssertEqual(body?["nest"]["nested"].asString(), "nested-value")
@@ -122,11 +118,9 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Perform request")
         http = BTHTTP(url: validDataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.post("/", parameters: ["a-post-param": "POST"]) { body, response, error in
+        http?.post("/", parameters: ["a-post-param": "POST"]) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
-            XCTAssertEqual(response?.statusCode, 200)
             expectation.fulfill()
         }
 
@@ -137,11 +131,9 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Perform request")
         http = BTHTTP(url: validDataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/", parameters: ["a-get-param": "GET"]) { body, response, error in
+        http?.get("/", parameters: ["a-get-param": "GET"]) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
-            XCTAssertEqual(response?.statusCode, 200)
             expectation.fulfill()
         }
 
@@ -152,11 +144,9 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Perform request")
         http = BTHTTP(url: validDataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/resource") { body, response, error in
+        http?.get("/resource") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
-            XCTAssertEqual(response?.statusCode, 200)
             expectation.fulfill()
         }
 
@@ -168,9 +158,8 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Perform request")
         http = BTHTTP(url: dataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/") { body, response, error in
+        http?.get("/") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
             XCTAssertEqual(error.code, BTHTTPError.responseContentTypeNotAcceptable([:]).errorCode)
@@ -184,11 +173,9 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Perform request")
         http = BTHTTP(url: validDataURL, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/") { body, response, error in
+        http?.get("/") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
-            XCTAssertNotNil(response?.statusCode)
             expectation.fulfill()
         }
 
@@ -200,9 +187,8 @@ final class BTHTTP_Tests: XCTestCase {
         let dataStringURL = "data:application/json;base64,BAD-BASE-64-STRING"
         http = BTHTTP(url: URL(string: dataStringURL)!, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("/") { body, response, error in
+        http?.get("/") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -215,9 +201,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsGETRequest() {
         let expectation = expectation(description: "GET request")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -233,9 +218,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsGETRequestWithParameters() {
         let expectation = expectation(description: "GET request")
 
-        http?.get("200.json", parameters: ["param": "value"]) { body, response, error in
+        http?.get("200.json", parameters: ["param": "value"]) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -252,9 +236,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsPOSTRequest() {
         let expectation = expectation(description: "POST request")
 
-        http?.post("200.json") { body, response, error in
+        http?.post("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -276,9 +259,8 @@ final class BTHTTP_Tests: XCTestCase {
         
         let expectation = expectation(description: "POST request")
 
-        http?.post("200.json", parameters: parameters) { body, response, error in
+        http?.post("200.json", parameters: parameters) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -298,9 +280,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsPOSTRequestWithDictionaryParameters() {
         let expectation = expectation(description: "POST request")
 
-        http?.post("200.json", parameters: ["param": "value"]) { body, response, error in
+        http?.post("200.json", parameters: ["param": "value"]) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -320,9 +301,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsPUTRequest() {
         let expectation = expectation(description: "PUT request")
 
-        http?.put("200.json") { body, response, error in
+        http?.put("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -339,9 +319,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsPUTRequestWithParameters() {
         let expectation = expectation(description: "PUT request")
 
-        http?.put("200.json", parameters: ["param": "value"]) { body, response, error in
+        http?.put("200.json", parameters: ["param": "value"]) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -361,9 +340,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsADELETERequest() {
         let expectation = expectation(description: "DELETE request")
 
-        http?.delete("200.json") { body, response, error in
+        http?.delete("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -379,9 +357,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testSendsDELETERequestWithParameters() {
         let expectation = expectation(description: "DELETE request")
 
-        http?.delete("200.json") { body, response, error in
+        http?.delete("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -401,9 +378,8 @@ final class BTHTTP_Tests: XCTestCase {
         URLCache.shared.removeAllCachedResponses()
         let expectation = expectation(description: "Fetches configuration")
 
-        http?.get("/configuration", parameters: ["configVersion": "3"], shouldCache: true) { body, response, error in
+        http?.get("/configuration", parameters: ["configVersion": "3"], shouldCache: true) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -419,9 +395,8 @@ final class BTHTTP_Tests: XCTestCase {
         URLCache.shared.removeAllCachedResponses()
         let expectation = expectation(description: "Fetches configuration")
 
-        http?.get("/configuration", parameters: ["configVersion": "3"], shouldCache: false) { body, response, error in
+        http?.get("/configuration", parameters: ["configVersion": "3"], shouldCache: false) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -438,9 +413,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testGETRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInQueryParams() {
         let expectation = expectation(description: "Request with authorization")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -456,9 +430,8 @@ final class BTHTTP_Tests: XCTestCase {
         http?.session = testURLSession
 
         let expectation = expectation(description: "GET callback")
-        http?.get("200.json") {body, response, error in
+        http?.get("200.json") {body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -472,9 +445,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testPOSTRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInBody() {
         let expectation = expectation(description: "POST callback")
 
-        http?.post("200.json") { body, response, error in
+        http?.post("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
@@ -491,9 +463,8 @@ final class BTHTTP_Tests: XCTestCase {
         let http = BTHTTP(url: URL(string: "https://api-m.paypal.com")!, authorizationFingerprint: "test-authorization-fingerprint")
         http.session = testURLSession
         
-        http.post("200.json") { body, response, error in
+        http.post("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
@@ -509,9 +480,8 @@ final class BTHTTP_Tests: XCTestCase {
         http?.session = testURLSession
 
         let expectation = expectation(description: "POST callback")
-        http?.post("200.json") { body, response, error in
+        http?.post("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -525,9 +495,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testPUTRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInBody() {
         let expectation = expectation(description: "PUT callback")
 
-        http?.put("200.json") { body, response, error in
+        http?.put("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
@@ -543,9 +512,8 @@ final class BTHTTP_Tests: XCTestCase {
         http?.session = testURLSession
 
         let expectation = expectation(description: "POST callback")
-        http?.put("200.json") { body, response, error in
+        http?.put("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -559,9 +527,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testDELETERequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInQueryParams() {
         let expectation = expectation(description: "DELETE callback")
 
-        http?.delete("200.json") { body, response, error in
+        http?.delete("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -577,9 +544,8 @@ final class BTHTTP_Tests: XCTestCase {
         http?.session = testURLSession
 
         let expectation = expectation(description: "DELETE callback")
-        http?.delete("200.json") { body, response, error in
+        http?.delete("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -594,9 +560,8 @@ final class BTHTTP_Tests: XCTestCase {
 
     func testIncludeAccept() {
         withStub() {
-            http?.get("stub://200/resource") { body, response, error in
+            http?.get("stub://200/resource") { body, error in
                 XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
                 XCTAssertNil(error)
 
                 let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -608,9 +573,8 @@ final class BTHTTP_Tests: XCTestCase {
 
     func testIncludeUserAgent() {
         withStub {
-            http?.get("stub://200/resource") { body, response, error in
+            http?.get("stub://200/resource") { body, error in
                 XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
                 XCTAssertNil(error)
 
                 let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -622,9 +586,8 @@ final class BTHTTP_Tests: XCTestCase {
 
     func testIncludeAcceptLanguage() {
         withStub {
-            http?.get("stub://200/resource") { body, response, error in
+            http?.get("stub://200/resource") { body, error in
                 XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
                 XCTAssertNil(error)
 
                 let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -672,9 +635,8 @@ final class BTHTTP_Tests: XCTestCase {
             "arrayParameter%5B%5D=arrayItem2"
         ]
 
-        http?.get("200.json", parameters: SampleRequest()) { body, response, error in
+        http?.get("200.json", parameters: SampleRequest()) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -703,9 +665,8 @@ final class BTHTTP_Tests: XCTestCase {
             "authorization_fingerprint": "test-authorization-fingerprint"
         ]
 
-        http?.post("200.json", parameters: SampleRequest()) { body, response, error in
+        http?.post("200.json", parameters: SampleRequest()) { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
@@ -725,9 +686,8 @@ final class BTHTTP_Tests: XCTestCase {
     func testCallsBackOnMainQueue() {
         let expectation = expectation(description: "Receive callback")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let name = __dispatch_queue_get_label(nil)
@@ -743,9 +703,8 @@ final class BTHTTP_Tests: XCTestCase {
         let expectation = expectation(description: "Receive callback")
         http?.dispatchQueue = DispatchQueue(label: "com.braintreepayments.BTHTTPSpec.callbackQueueTest")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
 
             let name = __dispatch_queue_get_label(nil)
@@ -773,11 +732,9 @@ final class BTHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
-            XCTAssertEqual(response?.statusCode, 200)
             HTTPStubs.removeStub(stub)
             expectation.fulfill()
         }
@@ -800,9 +757,8 @@ final class BTHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.get("403.json") { body, response, error in
+        http?.get("403.json") { body, error in
             XCTAssertEqual(body?.asDictionary(), errorBody as NSDictionary)
-            XCTAssertNotNil(response)
 
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
@@ -830,9 +786,8 @@ final class BTHTTP_Tests: XCTestCase {
                 )
         }
 
-        http?.get("429.json") { body, response, error in
+        http?.get("429.json") { body, error in
             XCTAssertEqual(body?.asDictionary(), [:])
-            XCTAssertNotNil(response)
 
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
@@ -862,9 +817,8 @@ final class BTHTTP_Tests: XCTestCase {
             )
         }
 
-        http?.get("503.json") { body, response, error in
+        http?.get("503.json") { body, error in
             XCTAssertEqual(body?.asDictionary(), errorBody as NSDictionary)
-            XCTAssertNotNil(response)
 
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
@@ -890,9 +844,8 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.notConnectedToInternet.rawValue))
         }
 
-        http?.get("network-down") { body, response, error in
+        http?.get("network-down") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
 
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, URLError.errorDomain)
@@ -914,9 +867,8 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.cannotConnectToHost.rawValue))
         }
 
-        http?.get("gateway-down") { body, response, error in
+        http?.get("gateway-down") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
 
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, URLError.errorDomain)
@@ -940,9 +892,8 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(data: "{\"status\": \"OK\"}".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
             XCTAssertNil(error)
             XCTAssertEqual(body?["status"].asString(), "OK")
             HTTPStubs.removeStub(stub)
@@ -962,8 +913,7 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(data: Data(), statusCode: 200, headers: ["Content-Type": "application/json"])
         }
 
-        http?.get("empty.json") { body, response, error in
-            XCTAssertEqual(response?.statusCode, 200)
+        http?.get("empty.json") { body, error in
             XCTAssertNotNil(body)
             XCTAssertEqual(body?.asDictionary()?.count, 0)
             XCTAssertNil(error)
@@ -984,9 +934,8 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(data: "{ really invalid json ]".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
 
-        http?.get("invalid.json") { body, response, error in
+        http?.get("invalid.json") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
             XCTAssertNotNil(error)
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, NSCocoaErrorDomain)
@@ -1007,9 +956,8 @@ final class BTHTTP_Tests: XCTestCase {
             return HTTPStubsResponse(data: "<html>response</html>".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "text/html"])
         }
 
-        http?.get("200.html") { body, response, error in
+        http?.get("200.html") { body, error in
             XCTAssertNil(body)
-            XCTAssertNil(response)
             XCTAssertNotNil(error)
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
@@ -1024,7 +972,7 @@ final class BTHTTP_Tests: XCTestCase {
     func testNoopsForANilCompletionBlock() {
         http = BTHTTP(url: URL(string: "stub://stub")!, authorizationFingerprint: "test-authorization-fingerprint")
 
-        http?.get("200.json") { body, response, error in
+        http?.get("200.json") { body, error in
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
                 // no-op
             }

--- a/UnitTests/BraintreeTestShared/FakeHTTP.swift
+++ b/UnitTests/BraintreeTestShared/FakeHTTP.swift
@@ -43,33 +43,32 @@ import Foundation
 
         if cannedError != nil {
             dispatchQueue.async {
-                completion?(nil, nil, self.cannedError)
+                completion?(nil, self.cannedError)
             }
         } else {
             let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
             dispatchQueue.async {
                 if path.contains("v1/configuration") {
-                    completion?(self.cannedConfiguration, httpResponse, nil)
+                    completion?(self.cannedConfiguration, nil)
                 } else {
-                    completion?(self.cannedResponse, httpResponse, nil)
+                    completion?(self.cannedResponse, nil)
                 }
             }
         }
     }
 
-    public override func post(_ path: String, parameters: [String: Any]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]? = nil, completion: ((BTJSON?, Error?) -> Void)? = nil) {
         POSTRequestCount += 1
         lastRequestEndpoint = path
         lastRequestParameters = parameters
         lastRequestMethod = "POST"
-        if cannedError != nil {
+        if let cannedError {
             dispatchQueue.async {
-                completion?(nil, nil, self.cannedError)
+                completion?(nil, self.cannedError)
             }
         } else {
-            let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
             dispatchQueue.async {
-                completion?(self.cannedResponse, httpResponse, nil)
+                completion?(self.cannedResponse, nil)
             }
         }
     }
@@ -88,9 +87,9 @@ import Foundation
         self.init(url: URL(string: "http://fake.com")!)
     }
 
-    public override func post(_ path: String, parameters: [String: Any]?, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]?, completion: ((BTJSON?, Error?) -> Void)? = nil) {
         POSTRequestCount += 1
         lastRequestParameters = parameters
-        completion?(self.cannedConfiguration, nil, nil)
+        completion?(self.cannedConfiguration, nil)
     }
 }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -16,7 +16,6 @@ public class MockAPIClient: BTAPIClient {
     @objc public var cannedConfigurationResponseError : NSError? = nil
 
     public var cannedResponseError : NSError? = nil
-    public var cannedHTTPURLResponse : HTTPURLResponse? = nil
     public var cannedResponseBody : BTJSON? = nil
     var cannedMetadata : BTClientMetadata? = nil
 
@@ -27,7 +26,7 @@ public class MockAPIClient: BTAPIClient {
         super.init(authorization: authorization, sendAnalyticsEvent: sendAnalyticsEvent)
     }
 
-    public override func get(_ path: String, parameters: Encodable?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func get(_ path: String, parameters: Encodable?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, Error?) -> Void)? = nil) {
         lastGETPath = path
         lastGETParameters = try? parameters?.toDictionary()
         lastGETAPIClientHTTPType = httpType
@@ -35,21 +34,21 @@ public class MockAPIClient: BTAPIClient {
         guard let completionBlock = completionBlock else {
             return
         }
-        completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
+        completionBlock(cannedResponseBody, cannedResponseError)
     }
     
-    public override func post(_ path: String, parameters: [String: Any]?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, Error?) -> Void)? = nil) {
         lastPOSTPath = path
         lastPOSTParameters = parameters
         lastPOSTAPIClientHTTPType = httpType
         
-        guard let completionBlock = completionBlock else {
+        guard let completionBlock else {
             return
         }
-        completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
+        completionBlock(cannedResponseBody, cannedResponseError)
     }
     
-    public override func post(_ path: String, parameters: Encodable, httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: Encodable, httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, Error?) -> Void)? = nil) {
         lastPOSTPath = path
         lastPOSTParameters = try? parameters.toDictionary()
         lastPOSTAPIClientHTTPType = httpType
@@ -57,7 +56,7 @@ public class MockAPIClient: BTAPIClient {
         guard let completionBlock = completionBlock else {
             return
         }
-        completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
+        completionBlock(cannedResponseBody, cannedResponseError)
     }
     
     public override func fetchOrReturnRemoteConfiguration(_ completionBlock: @escaping (BTConfiguration?, Error?) -> Void) {


### PR DESCRIPTION
### Summary of changes

- Remove `HTTPURLResponse` from all HTTP requests
- Update Tests

#### Additional Details:
This was only used in 1 place in the entire codebase when checking the `statusCode` of a `configuration` object. This code was added ~9 years ago and has just always existed as a check in the SDK despite this being the only place it's used. 

Instead, we can check that both body and error are not nil. This is in line with what Android does as well ([code here](https://github.com/braintree/braintree_android/blob/13140a52d349533d1285d7c0a0257852c3f1cd57/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.kt#L35-L48)). 

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
