### PR TITLE
[DTBTSDK-3403] Send PayPal-Client-Metadata-Id to PaymentReady API Call

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -343,7 +343,7 @@ import Foundation
             }
 
             let postParameters = BTAPIRequest(requestBody: parameters, metadata: metadata, httpType: httpType)
-            http(for: httpType)?.post(path, parameters: postParameters, completion: completion)
+            http(for: httpType)?.post(path, parameters: postParameters, headers: headers, completion: completion)
         }
     }
 

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -327,6 +327,7 @@ import Foundation
     public func post(
         _ path: String,
         parameters: Encodable,
+        headers: [String: String]? = nil,
         httpType: BTAPIClientHTTPService = .gateway,
         completion: @escaping RequestCompletion
     ) {
@@ -358,10 +359,11 @@ import Foundation
     public func post(
         _ path: String,
         parameters: Encodable,
+        headers: [String: String]? = nil,
         httpType: BTAPIClientHTTPService = .gateway
     ) async throws -> (BTJSON?, HTTPURLResponse?) {
         try await withCheckedThrowingContinuation { continuation in
-            post(path, parameters: parameters, httpType: httpType) { json, httpResonse, error in
+            post(path, parameters: parameters, headers: headers, httpType: httpType) { json, httpResonse, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -14,7 +14,7 @@ class BTGraphQLHTTP: BTHTTP {
         NSException(name: exceptionName, reason: "GET is unsupported").raise()
     }
 
-    override func post(_ path: String, parameters: [String: Any]? = nil, completion: @escaping RequestCompletion) {
+    override func post(_ path: String, parameters: [String: Any]? = nil, headers: [String: String]? = nil, completion: @escaping RequestCompletion) {
         httpRequest(method: "POST", parameters: parameters, completion: completion)
     }
 

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -115,7 +115,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
 
     // TODO: - Remove when all POST bodies use Codable, instead of BTJSON/raw dictionaries
     func post(_ path: String, parameters: [String: Any]? = nil, headers: [String: String]? = nil, completion: @escaping RequestCompletion) {
-        httpRequest(method: "POST", path: path, parameters: parameters, completion: completion)
+        httpRequest(method: "POST", path: path, parameters: parameters, headers: headers, completion: completion)
     }
     
     func post(_ path: String, parameters: Encodable, headers: [String: String]? = nil, completion: @escaping RequestCompletion) {
@@ -179,10 +179,10 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         method: String,
         path: String,
         parameters: [String: Any]? = [:],
-        headers: [String: String]? = [:],
+        headers: [String: String]? = nil,
         completion: RequestCompletion?
     ) {
-        createRequest(method: method, path: path, parameters: parameters) { request, error in
+        createRequest(method: method, path: path, parameters: parameters, headers: headers) { request, error in
             guard let request = request else {
                 self.handleRequestCompletion(data: nil, request: nil, shouldCache: false, response: nil, error: error, completion: completion)
                 return
@@ -289,7 +289,7 @@ class BTHTTP: NSObject, NSCopying, URLSessionDelegate {
         }
         
         if let additionalHeaders {
-            headers = headers.merging(additionalHeaders) { (_, newHeader) in newHeader}
+            headers = headers.merging(additionalHeaders) { $1 }
         }
 
         if method == "GET" || method == "DELETE" {

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -41,7 +41,12 @@ public class BTShopperInsightsClient {
         )
         
         do {
-            let (json, _) = try await apiClient.post("/v2/payments/find-eligible-methods", parameters: postParameters, httpType: .payPalAPI)
+            let (json, _) = try await apiClient.post(
+                "/v2/payments/find-eligible-methods",
+                parameters: postParameters,
+                headers: ["PayPal-Client-Metadata-Id": apiClient.metadata.sessionID],
+                httpType: .payPalAPI
+            )
             guard let eligibleMethodsJSON = json?["eligible_methods"].asDictionary(),
                   eligibleMethodsJSON.count != 0 else {
                 throw self.notifyFailure(with: BTShopperInsightsError.emptyBodyReturned)

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -29,6 +29,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         
         XCTAssertEqual(mockAPIClient.lastPOSTPath, "/v2/payments/find-eligible-methods")
         XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .payPalAPI)
+        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], mockAPIClient.metadata.sessionID)
         
         guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
             XCTFail()
@@ -52,8 +53,6 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(payee["merchant_id"], "MXSJ4F5BADVNS")
         let amount = purchaseUnits.first?["amount"] as! [String: String]
         XCTAssertEqual(amount["currency_code"], "USD")
-        
-        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], mockAPIClient.metadata.sessionID)
     }
     
     func testGetRecommendedPaymentMethods_whenAPIError_throws() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -53,10 +53,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         let amount = purchaseUnits.first?["amount"] as! [String: String]
         XCTAssertEqual(amount["currency_code"], "USD")
         
-        let fakeClientMetadata = BTClientMetadata()
-        fakeClientMetadata.sessionID = "fake-session-id"
-        mockAPIClient.cannedMetadata = fakeClientMetadata
-        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], "fake-session-id")
+        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], mockAPIClient.metadata.sessionID)
     }
     
     func testGetRecommendedPaymentMethods_whenAPIError_throws() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -52,6 +52,11 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(payee["merchant_id"], "MXSJ4F5BADVNS")
         let amount = purchaseUnits.first?["amount"] as! [String: String]
         XCTAssertEqual(amount["currency_code"], "USD")
+        
+        let fakeClientMetadata = BTClientMetadata()
+        fakeClientMetadata.sessionID = "fake-session-id"
+        mockAPIClient.cannedMetadata = fakeClientMetadata
+        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], "fake-session-id")
     }
     
     func testGetRecommendedPaymentMethods_whenAPIError_throws() async {

--- a/UnitTests/BraintreeTestShared/FakeHTTP.swift
+++ b/UnitTests/BraintreeTestShared/FakeHTTP.swift
@@ -57,7 +57,7 @@ import Foundation
         }
     }
 
-    public override func post(_ path: String, parameters: [String: Any]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]? = nil, headers:[String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         POSTRequestCount += 1
         lastRequestEndpoint = path
         lastRequestParameters = parameters
@@ -88,7 +88,7 @@ import Foundation
         self.init(url: URL(string: "http://fake.com")!)
     }
 
-    public override func post(_ path: String, parameters: [String: Any]?, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]?, headers: [String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         POSTRequestCount += 1
         lastRequestParameters = parameters
         completion?(self.cannedConfiguration, nil, nil)

--- a/UnitTests/BraintreeTestShared/FakeHTTP.swift
+++ b/UnitTests/BraintreeTestShared/FakeHTTP.swift
@@ -6,6 +6,7 @@ import Foundation
     @objc public var POSTRequestCount: Int = 0
     @objc public var lastRequestEndpoint: String?
     public var lastRequestMethod: String?
+    public var lastPOSTRequestHeaders: [String: String]? = [:]
     @objc public var lastRequestParameters: [String: Any]?
     var stubMethod: String?
     var stubEndpoint: String?
@@ -57,11 +58,12 @@ import Foundation
         }
     }
 
-    public override func post(_ path: String, parameters: [String: Any]? = nil, headers:[String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: [String: Any]? = nil, headers: [String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         POSTRequestCount += 1
         lastRequestEndpoint = path
         lastRequestParameters = parameters
         lastRequestMethod = "POST"
+        lastPOSTRequestHeaders = headers
         if cannedError != nil {
             dispatchQueue.async {
                 completion?(nil, nil, self.cannedError)

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -51,7 +51,7 @@ public class MockAPIClient: BTAPIClient {
         completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
     }
     
-    public override func post(_ path: String, parameters: Encodable, headers: [String: String]? = nil,httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: Encodable, headers: [String: String]? = nil, httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         lastPOSTPath = path
         lastPOSTParameters = try? parameters.toDictionary()
         lastPOSTAPIClientHTTPType = httpType

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -5,6 +5,7 @@ public class MockAPIClient: BTAPIClient {
     public var lastPOSTPath = ""
     public var lastPOSTParameters = [:] as [AnyHashable: Any]?
     public var lastPOSTAPIClientHTTPType: BTAPIClientHTTPService?
+    public var lastPOSTAdditionalHeaders: [String: String]? = [:]
 
     public var lastGETPath = ""
     public var lastGETParameters = [:] as [String: Any]?
@@ -50,10 +51,11 @@ public class MockAPIClient: BTAPIClient {
         completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
     }
     
-    public override func post(_ path: String, parameters: Encodable, httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
+    public override func post(_ path: String, parameters: Encodable, headers: [String: String]? = nil,httpType: BTAPIClientHTTPService = .gateway, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
         lastPOSTPath = path
         lastPOSTParameters = try? parameters.toDictionary()
         lastPOSTAPIClientHTTPType = httpType
+        lastPOSTAdditionalHeaders = headers
         
         guard let completionBlock = completionBlock else {
             return


### PR DESCRIPTION
### Summary of changes

- Adds the `PayPal-Client-Metadata-Id` to the Shopper Insights API Call
- Adds appropriate unit test to ensure `PayPal-Client-Metadata-Id` is properly set to the `sessionID` 
- Adds the optional `headers` parameter to all relevant HTTP POST methods within various files
- Adds `lastPOSTAdditionalHeaders` property to `MockAPIClient` for testing purposes

### Checklist

- ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 
