### PR TITLE
Accept email in `BTPayPalVaultRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
+* Add `BTPayPalRequest.payerEmail` optional property
 
 ## 6.12.0 (2024-01-18)
 * BraintreePayPal

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -51,6 +51,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.isEnabled = false
 
         let request = BTPayPalVaultRequest()
+        request.payerEmail = "jsdk@bt.com"
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -51,7 +51,6 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.isEnabled = false
 
         let request = BTPayPalVaultRequest()
-        request.payerEmail = "jsdk@bt.com"
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -11,6 +11,9 @@ import BraintreeCore
 
     /// Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     public var offerCredit: Bool
+    
+    /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    public var payerEmail: String?
 
     // MARK: - Initializer
 
@@ -30,8 +33,12 @@ import BraintreeCore
         let baseParameters = super.parameters(with: configuration)
         var vaultParameters: [String: Any] = ["offer_paypal_credit": offerCredit]
 
-        if billingAgreementDescription != nil {
+        if let billingAgreementDescription {
             vaultParameters["description"] = billingAgreementDescription
+        }
+        
+        if let payerEmail {
+            vaultParameters["payer_email"] = payerEmail
         }
 
         if let shippingAddressOverride {

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -47,11 +47,13 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         request.shippingAddressOverride = shippingAddress
         request.isShippingAddressEditable = true
         request.offerCredit = true
+        request.payerEmail = "fake@email.com"
 
         let parameters = request.parameters(with: configuration)
 
         XCTAssertEqual(parameters["description"] as? String, "desc")
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)
+        XCTAssertEqual(parameters["payer_email"] as? String, "fake@email.com")
 
         guard let shippingParams = parameters["shipping_address"] as? [String:String] else { XCTFail(); return }
 


### PR DESCRIPTION
### Summary of changes

- Add `payerEmail` property to `BTPayPalRequest`
   - Format request accordingly for POST to `v1/paypal_hermes/setup_billing_agreement`
   - This is supposed to optimize the user's PwPP web checkout experience by pre-populating their email in the flow when possible, though I was unable to see any differences when testing in sand & prod

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 