### PR TITLE
Pass email from text field into PayPalVaultRequest

### DIFF
--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -129,6 +129,8 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         button.isEnabled = false
         
         let paypalRequest = BTPayPalVaultRequest()
+        paypalRequest.userAuthenticationEmail = emailView.textField.text ?? nil
+        
         paypalClient.tokenize(paypalRequest) { (nonce, error) in
             button.isEnabled = true
             self.displayResultDetails(nonce: nonce, error: error)


### PR DESCRIPTION
### Summary of changes

- Pass `email` from text field in ShopperInsights demo feature into `BTPayPalVaultRequest`

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 