### PR TITLE
Venmo Final Amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
+* BraintreeVenmo
+  * Add `isFinalAmount` to `BTVenmoRequest`
 
 ## 6.12.0 (2024-01-18)
 * BraintreePayPal

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -102,7 +102,8 @@ import BraintreeCore
                 "paymentMethodUsage": request.paymentMethodUsage.stringValue,
                 "merchantProfileId": merchantProfileID,
                 "customerClient": "MOBILE_APP",
-                "intent": "CONTINUE"
+                "intent": "CONTINUE",
+                "isFinalAmount": "\(request.isFinalAmount)"
             ]
             
             if let displayName = request.displayName {

--- a/Sources/BraintreeVenmo/BTVenmoRequest.swift
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.swift
@@ -52,7 +52,7 @@ import Foundation
 
     /// Indicates whether the purchase amount is the final amount.
     /// Defaults to `false`
-    public var finalAmount: Bool = false
+    public var isFinalAmount: Bool = false
 
     /// Optional. The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
     ///

--- a/Sources/BraintreeVenmo/BTVenmoRequest.swift
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.swift
@@ -51,6 +51,7 @@ import Foundation
     public var collectCustomerShippingAddress: Bool = false
 
     /// Indicates whether the purchase amount is the final amount.
+    /// Removes "subject to change" notice in Venmo app paysheet UI.
     /// Defaults to `false`
     public var isFinalAmount: Bool = false
 

--- a/Sources/BraintreeVenmo/BTVenmoRequest.swift
+++ b/Sources/BraintreeVenmo/BTVenmoRequest.swift
@@ -49,7 +49,11 @@ import Foundation
     /// Whether the customer's shipping address should be collected and displayed on the Venmo paysheet.
     /// Defaults to `false`
     public var collectCustomerShippingAddress: Bool = false
-    
+
+    /// Indicates whether the purchase amount is the final amount.
+    /// Defaults to `false`
+    public var finalAmount: Bool = false
+
     /// Optional. The subtotal amount of the transaction to be displayed on the paysheet. Excludes taxes, discounts, and shipping amounts.
     ///
     /// If this value is set, `totalAmount` must also be set.

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -667,6 +667,46 @@ class BTVenmoClient_Tests: XCTestCase {
         XCTAssertNotNil(fakeApplication.lastOpenURL!.absoluteString.range(of: "venmo-access-token"));
     }
 
+    func testTokenizeVenmoAccount_whenIsFinalAmountSetAsTrue_createsPaymentContext() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        venmoRequest.displayName = "app-display-name"
+        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+
+        let fakeApplication = FakeApplication()
+        venmoClient.application = fakeApplication
+        venmoClient.bundle = FakeBundle()
+
+        venmoRequest.isFinalAmount = true
+        venmoClient.tokenize(venmoRequest) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("true", input["isFinalAmount"] as? String)
+        }
+    }
+
+    func testTokenizeVenmoAccount_whenIsFinalAmountSetAsFalse_createsPaymentContext() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        venmoRequest.displayName = "app-display-name"
+        BTAppContextSwitcher.sharedInstance.returnURLScheme = "scheme"
+
+        let fakeApplication = FakeApplication()
+        venmoClient.application = fakeApplication
+        venmoClient.bundle = FakeBundle()
+
+        venmoRequest.isFinalAmount = false
+        venmoClient.tokenize(venmoRequest) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .graphQLAPI)
+        let params = mockAPIClient.lastPOSTParameters as? NSDictionary
+        if let inputDict = params?["variables"] as? NSDictionary,
+           let input = inputDict["input"] as? [String:Any] {
+            XCTAssertEqual("false", input["isFinalAmount"] as? String)
+        }
+    }
+
     // MARK: - Analytics
     
     func testAPIClientMetadata_hasIntegrationSetToCustom() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -19,20 +19,6 @@ class BTVenmoRequest_Tests: XCTestCase {
         XCTAssertEqual(request.collectCustomerBillingAddress, false)
     }
 
-    func testIsFinalAmount_whenIsFinalAmountSetAsTrue_returnsTrue() {
-        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
-        request.isFinalAmount = true
-        
-        XCTAssertEqual(request.isFinalAmount, true)
-    }
-
-    func testIsFinalAmount_whenIsFinalAmountSetAsFalse_returnsFalse() {
-        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
-        request.isFinalAmount = false
-
-        XCTAssertEqual(request.isFinalAmount, false)
-    }
-
     func testIsFinalAmount_whenIsFinalAmountNotSet_defaultsToFalse() {
         let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
         XCTAssertEqual(request.isFinalAmount, false)

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -31,7 +31,6 @@ class BTVenmoRequest_Tests: XCTestCase {
         request.isFinalAmount = false
 
         XCTAssertEqual(request.isFinalAmount, false)
-
     }
 
     func testIsFinalAmount_whenIsFinalAmountNotSet_defaultsToFalse() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -24,7 +24,6 @@ class BTVenmoRequest_Tests: XCTestCase {
         request.isFinalAmount = true
         
         XCTAssertEqual(request.isFinalAmount, true)
-
     }
 
     func testIsFinalAmount_whenIsFinalAmountSetAsFalse_returnsFalse() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoRequest_Tests.swift
@@ -18,4 +18,25 @@ class BTVenmoRequest_Tests: XCTestCase {
         XCTAssertEqual(request.collectCustomerShippingAddress, false)
         XCTAssertEqual(request.collectCustomerBillingAddress, false)
     }
+
+    func testIsFinalAmount_whenIsFinalAmountSetAsTrue_returnsTrue() {
+        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
+        request.isFinalAmount = true
+        
+        XCTAssertEqual(request.isFinalAmount, true)
+
+    }
+
+    func testIsFinalAmount_whenIsFinalAmountSetAsFalse_returnsFalse() {
+        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
+        request.isFinalAmount = false
+
+        XCTAssertEqual(request.isFinalAmount, false)
+
+    }
+
+    func testIsFinalAmount_whenIsFinalAmountNotSet_defaultsToFalse() {
+        let request = BTVenmoRequest(paymentMethodUsage: .singleUse)
+        XCTAssertEqual(request.isFinalAmount, false)
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Add `isFinalAmount` to `BTVenmoRequest`
    - This removes the text "Subject to change" as seen below

#### Visuals
| Final Amount = false (default) | Final Amount = true |
|-----|-----|
|![IMG_0015](https://github.com/braintree/braintree_ios/assets/20733831/ceb32df0-0fdd-426c-b5c6-72a9cd089dca)|![IMG_0016](https://github.com/braintree/braintree_ios/assets/20733831/d06103db-64bb-4ff3-95d0-1e251e3115d8)|

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
