### PR TITLE
[DTBTSDK-3544] Remove merchant_id from the Payment Ready API Request

### DIFF
--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -25,7 +25,7 @@ struct BTEligiblePaymentsRequest: Encodable {
             case phone = "phone"
         }
     }
-    
+
     struct PurchaseUnit: Encodable {
         let amount = Amount()
         

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -5,8 +5,8 @@ import PassKit
 struct BTEligiblePaymentsRequest: Encodable {
     
     private let customer: Customer
-    private let purchaseUnits = [PurchaseUnit()]
-    private let preferences = Preferences()
+    private let purchaseUnits: [PurchaseUnit]
+    private let preferences: Preferences
     
     enum CodingKeys: String, CodingKey {
         case customer = "customer"
@@ -60,5 +60,7 @@ struct BTEligiblePaymentsRequest: Encodable {
     
     init(email: String?, phone: Phone?) {
         self.customer = Customer(email: email, phone: phone)
+        self.purchaseUnits = [PurchaseUnit()]
+        self.preferences = Preferences()
     }
 }

--- a/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
+++ b/Sources/BraintreeShopperInsights/BTEligiblePaymentsRequest.swift
@@ -5,7 +5,7 @@ import PassKit
 struct BTEligiblePaymentsRequest: Encodable {
     
     private let customer: Customer
-    private let purchaseUnits: [PurchaseUnit]
+    private let purchaseUnits = [PurchaseUnit()]
     private let preferences = Preferences()
     
     enum CodingKeys: String, CodingKey {
@@ -25,9 +25,8 @@ struct BTEligiblePaymentsRequest: Encodable {
             case phone = "phone"
         }
     }
-
+    
     struct PurchaseUnit: Encodable {
-        let payee: Payee
         let amount = Amount()
         
         struct Amount: Encodable {
@@ -35,14 +34,6 @@ struct BTEligiblePaymentsRequest: Encodable {
             
             enum CodingKeys: String, CodingKey {
                 case currencyCode = "currency_code"
-            }
-        }
-
-        struct Payee: Encodable {
-            let merchantID: String
-            
-            enum CodingKeys: String, CodingKey {
-                case merchantID = "merchant_id"
             }
         }
     }
@@ -67,8 +58,7 @@ struct BTEligiblePaymentsRequest: Encodable {
         }
     }
     
-    init(email: String?, phone: Phone?, merchantID: String) {
+    init(email: String?, phone: Phone?) {
         self.customer = Customer(email: email, phone: phone)
-        self.purchaseUnits = [PurchaseUnit(payee: PurchaseUnit.Payee(merchantID: merchantID))]
     }
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -33,11 +33,9 @@ public class BTShopperInsightsClient {
     public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest) async throws -> BTShopperInsightsResult {
         apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.recommendedPaymentsStarted)
         
-        // TODO: - Fill in appropriate merchantID (or ppClientID) from config once API team decides what we need to send
         let postParameters = BTEligiblePaymentsRequest(
             email: request.email,
-            phone: request.phone,
-            merchantID: "MXSJ4F5BADVNS"
+            phone: request.phone
         )
         
         do {

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -49,8 +49,6 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(paymentSourceConstraint["payment_sources"] as! [String], ["PAYPAL", "VENMO"])
         
         let purchaseUnits = lastPostParameters["purchase_units"] as! [[String: Any]]
-        let payee = purchaseUnits.first?["payee"] as! [String: String]
-        XCTAssertEqual(payee["merchant_id"], "MXSJ4F5BADVNS")
         let amount = purchaseUnits.first?["amount"] as! [String: String]
         XCTAssertEqual(amount["currency_code"], "USD")
     }


### PR DESCRIPTION
### Summary of changes

- This PR removes the `merchantID` parameter from the Payment Ready API Request as this value is now determined by the auth fingerprint.

### Checklist

-~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
