### PR TITLE
Universal Links Demo

### DIFF
--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -18,7 +18,7 @@ import BraintreeCore
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        return true
+        true
     }
 
     func registerDefaultsFromSettings() {

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -17,10 +17,6 @@ import BraintreeCore
         return true
     }
 
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        true
-    }
-
     func registerDefaultsFromSettings() {
         if processInfoArgs.contains("-EnvironmentSandbox") {
             userDefaults.set(BraintreeDemoEnvironment.sandbox.rawValue, forKey: BraintreeDemoSettings.EnvironmentDefaultsKey)

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -16,7 +16,11 @@ import BraintreeCore
         
         return true
     }
-    
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        return true
+    }
+
     func registerDefaultsFromSettings() {
         if processInfoArgs.contains("-EnvironmentSandbox") {
             userDefaults.set(BraintreeDemoEnvironment.sandbox.rawValue, forKey: BraintreeDemoSettings.EnvironmentDefaultsKey)

--- a/Demo/Application/Base/SceneDelegate.swift
+++ b/Demo/Application/Base/SceneDelegate.swift
@@ -27,7 +27,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        // TODO: add implementation
-        print("Returning from the Universal Link to the app")
+        if let returnURL = userActivity.webpageURL {
+            // TODO: implementation - pass full URL to BT SDK
+            print("Returned to Demo app via universal link: \(returnURL)")
+        }
     }
 }

--- a/Demo/Application/Base/SceneDelegate.swift
+++ b/Demo/Application/Base/SceneDelegate.swift
@@ -25,4 +25,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
     }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        // TODO: add implementation
+        print("Returning from the Universal Link to the app")
+    }
 }

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -10,8 +10,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
         let payPalPayLaterButton = createButton(title: "PayPal with Pay Later Offered", action: #selector(tappedPayPalPayLater))
+        let universalLinkButton = createButton(title: "Universal Link Flow", action: #selector(universalLinkFlow))
 
-        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton]
+        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton, universalLinkButton]
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.axis = .vertical
         stackView.alignment = .center
@@ -82,5 +83,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
             self.completionBlock(nonce)
         }
+    }
+
+    @objc func universalLinkFlow(_ sender: UIButton) {
+        UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev")!)
     }
 }

--- a/Demo/Demo.entitlements
+++ b/Demo/Demo.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:braintree-ios-demo.fly.dev</string>
+	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.braintreepayments.apple-pay-demo.Braintree-Demo</string>


### PR DESCRIPTION
### Summary of changes

- Add "Universal Link Flow" button to PayPal Web demo app - this button with open a page that will allow us to return to the app on tapping "open"
- This PR is a proof of concept that our demo app can be set up for universal linking, follow up PRs to this feature branch will build on this work

### Demo
![Simulator Screen Recording - iPhone 15 - 2024-03-05 at 09 05 53](https://github.com/braintree/braintree_ios/assets/20733831/560db372-7dd5-4567-ad4a-a696888cdf0f)

#### Notes
- We are currently using Fly.io for hosting this proof of concept, I have hosted the [server side code here](https://github.com/jaxdesmarais/fly-server-demo) for the time being, as this feature develops we can consider moving this to a shared space or Heroku depending on if the free tier of Fly.io is sufficient for our usecase
- This is part of the `paypal-app-switch-feature` work and will be built upon as this feature develops

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
