### PR TITLE
[5.x] Amend v5.24.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 5.24.0 (2023-10-30)
 * BraintreePayPalDataCollector
   * Update PPRiskMagnes with 5.4.1 - staging removed (fixes #1107)
+  * This version of the PPRiskMagnes framework is static
 
 ## 5.23.0 (2023-08-18)
 * BraintreeVenmo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.24.1 (2023-11-17)
 * BraintreePayPalDataCollector
   * Update previously incorrect version of PPRiskMagnes 5.4.1 with staging removed
+  * This version of the PPRiskMagnes framework is dynamic
 
 ## 5.24.0 (2023-10-30)
 * BraintreePayPalDataCollector


### PR DESCRIPTION
### Summary of changes

- We were investigating our Magnes versions and realized that in v5.24.0 of Braintree iOS we switched to a static version of Magnes
   - Technically switching b/w static & dynamic is a breaking change, but since it's v5 and been out for awhile we'll just leave it :) 
- This PR clarifies the CHANGELOG entry for future readers

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo @agedd 
