### PR TITLE
Fix bug where AnalyticsServices fires same event multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * Add `BTVenmoRequest.fallbackToWeb`
     * If set to `true` customers will fallback to a web based Venmo flow if the Venmo app is not installed
     * This method uses Universal Links instead of URL Schemes
+* BraintreeCore
+  * Fix bug where FPTI analytic events were being sent multiple times
 
 ## 6.12.0 (2024-01-18)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
 * BraintreeVenmo
   * Add `isFinalAmount` to `BTVenmoRequest`
   * Add `BTVenmoRequest.fallbackToWeb`
     * If set to `true` customers will fallback to a web based Venmo flow if the Venmo app is not installed
     * This method uses Universal Links instead of URL Schemes
 * BraintreeCore
+  * Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
   * Fix bug where FPTI analytic events were being sent multiple times
 
 ## 6.12.0 (2024-01-18)

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -84,7 +84,11 @@ class BTAnalyticsService: Equatable {
             }
 
             let postParameters = self.createAnalyticsEvent(config: configuration, sessionID: self.apiClient.metadata.sessionID, event: event)
-            self.http?.post("v1/tracking/batch/events", parameters: postParameters, completion: { _,_,_ in })
+            self.http?.post("v1/tracking/batch/events", parameters: postParameters, completion: { _,_, error in
+                if let error {
+                    NSLog("[Braintree SDK] Failed to send analytics: \(error.localizedDescription)")
+                }
+            })
         }
     }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -63,6 +63,7 @@ class BTAnalyticsService: Equatable {
                 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             guard let configuration, error == nil else {
+                NSLog("[Braintree SDK] Failed to send analytics")
                 return
             }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -63,7 +63,6 @@ class BTAnalyticsService: Equatable {
                 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             guard let configuration, error == nil else {
-                NSLog("[Braintree SDK] Failed to send analytics")
                 return
             }
 
@@ -84,11 +83,7 @@ class BTAnalyticsService: Equatable {
             }
 
             let postParameters = self.createAnalyticsEvent(config: configuration, sessionID: self.apiClient.metadata.sessionID, event: event)
-            self.http?.post("v1/tracking/batch/events", parameters: postParameters, completion: { _,_, error in
-                if let error {
-                    NSLog("[Braintree SDK] Failed to send analytics: \(error.localizedDescription)")
-                }
-            })
+            self.http?.post("v1/tracking/batch/events", parameters: postParameters, completion: { _,_, error in })
         }
     }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -83,7 +83,7 @@ class BTAnalyticsService: Equatable {
             }
 
             let postParameters = self.createAnalyticsEvent(config: configuration, sessionID: self.apiClient.metadata.sessionID, event: event)
-            self.http?.post("v1/tracking/batch/events", parameters: postParameters, completion: { _,_, error in })
+            self.http?.post("v1/tracking/batch/events", parameters: postParameters) { _, _, _ in }
         }
     }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -28,6 +28,7 @@ class BTAnalyticsService: Equatable {
     ///   - errorDescription: Optional. Full error description returned to merchant.
     ///   - correlationID: Optional. CorrelationID associated with the checkout session.
     ///   - payPalContextID: Optional. PayPal Context ID associated with the checkout session.
+    ///   - linkType: Optional. The type of link the SDK will be handling, currently deeplink or universal.
     func sendAnalyticsEvent(
         _ eventName: String,
         errorDescription: String? = nil,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -65,7 +65,7 @@ import Foundation
         self.metadata = BTClientMetadata()
 
         super.init()
-        BTAPIClient._analyticsService = BTAnalyticsService(apiClient: self, flushThreshold: 5)
+        BTAPIClient._analyticsService = BTAnalyticsService(apiClient: self)
         guard let authorizationType: BTAPIClientAuthorization = Self.authorizationType(forAuthorization: authorization) else { return nil }
 
         let errorString = BTLogLevelDescription.string(for: .error) 
@@ -349,8 +349,7 @@ import Foundation
             eventName,
             errorDescription: errorDescription,
             correlationID: correlationID,
-            payPalContextID: payPalContextID,
-            completion: { _ in }
+            payPalContextID: payPalContextID
         )
     }
 

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -3,7 +3,6 @@ import Foundation
 
 class FakeAnalyticsService: BTAnalyticsService {
     var lastEvent: String = ""
-    var didLastFlush: Bool = false
 
     override func sendAnalyticsEvent(
         _ eventName: String,
@@ -12,17 +11,5 @@ class FakeAnalyticsService: BTAnalyticsService {
         payPalContextID: String? = nil
     ) {
         self.lastEvent = eventName
-        self.didLastFlush = false
-    }
-
-    override func sendAnalyticsEvent(
-        _ eventName: String,
-        errorDescription: String? = nil,
-        correlationID: String? = nil,
-        payPalContextID: String? = nil,
-        completion: @escaping (Error?) -> Void = { _ in }
-    ) {
-        self.lastEvent = eventName
-        self.didLastFlush = true
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -389,7 +389,7 @@ class BTAPIClient_Tests: XCTestCase {
         XCTAssertTrue(apiClient?.analyticsService is BTAnalyticsService)
     }
 
-    func testSendAnalyticsEvent_whenCalled_callsAnalyticsService_doesFlush() {
+    func testSendAnalyticsEvent_whenCalled_callsAnalyticsService() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
         let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
 
@@ -397,7 +397,6 @@ class BTAPIClient_Tests: XCTestCase {
         apiClient.sendAnalyticsEvent("blahblah")
 
         XCTAssertEqual(mockAnalyticsService.lastEvent, "blahblah")
-        XCTAssertTrue(mockAnalyticsService.didLastFlush)
     }
 
     // MARK: - Client SDK Metadata


### PR DESCRIPTION
### Summary 

- This PR came out of [this conversation](https://github.com/braintree/braintree_ios/pull/1198#discussion_r1515426571) in a previous PR
- We found a bug where every analytic event was being sent multiple times
    - The reason why was because our [sessionsQueue](https://github.com/braintree/braintree_ios/blob/8e631aac435210357524374fc73632bb97895187/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift#L19) was never being wiped after events were already sent out in an API request
- This PR takes a path-of-least-resistance approach to fixing this duplicate events bug
   - It uses the existing batch POST formatting, but only sends a single event per API request
   - Previously we were still sending an API request every time `sendAnalyticsEvent()` was called, but with this change, the payload won't contain duplicate events
   - Our batching logic needs a dedicated revamp (handling app backgrounding, memory wipe, etc) - JIRA **DTBTSDK-3629** created

### Changes

- Remove unused `flushThreshold` & flush logic (this was never called within the SDK)
- Remove improperly managed `DispatchQueue` for holding events. This was never getting cleared, thus sending every event multiple times. We can re-add this when we have more time to properly implement the queue's maintenance and clearance.
- Move to async-await style for `BTAnalyticsService.sendAnalyticsEvent()` method

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo @jaxdesmarais 
