### PR TITLE
Send `paypal_context_id` at Event Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Send `paypal_context_id` in `batch_params` to PayPal's analytics service (FPTI) when available
+* BraintreeCore
+  * Send `paypal_context_id` in `event_params` to PayPal's analytics service (FPTI) when available
 * BraintreeVenmo
   * Add `isFinalAmount` to `BTVenmoRequest`
   * Add `BTVenmoRequest.fallbackToWeb`

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -32,6 +32,9 @@ struct FPTIBatchData: Codable {
         let eventName: String
         /// The type of link the SDK will be handling, currently deeplink or universal
         let linkType: String?
+        /// Used for linking events from the client to server side request
+        /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow
+        let payPalContextID: String?
         let timestamp: String
         let tenantName: String = "Braintree"
 
@@ -40,6 +43,7 @@ struct FPTIBatchData: Codable {
             case errorDescription = "error_desc"
             case eventName = "event_name"
             case linkType = "link_type"
+            case payPalContextID = "paypal_context_id"
             case timestamp = "t"
             case tenantName = "tenant_name"
         }
@@ -101,10 +105,6 @@ struct FPTIBatchData: Codable {
 
         let merchantID: String?
 
-        /// Used for linking events from the client to server side request
-        /// This value will be PayPal Order ID, Payment Token, EC token or Billing Agreement depending on the flow
-        let payPalContextID: String?
-
         let platform = "iOS"
 
         let sessionID: String
@@ -127,7 +127,6 @@ struct FPTIBatchData: Codable {
             case isSimulator = "is_simulator"
             case merchantAppVersion = "mapv"
             case merchantID = "merchant_id"
-            case payPalContextID = "paypal_context_id"
             case platform = "platform"
             case sessionID = "session_id"
             case tokenizationKey = "tokenization_key"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -341,17 +341,17 @@ import Foundation
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(
         _ eventName: String,
-        errorDescription: String? = nil,
         correlationID: String? = nil,
-        payPalContextID: String? = nil,
-        linkType: String? = nil
+        errorDescription: String? = nil,
+        linkType: String? = nil,
+        payPalContextID: String? = nil
     ) {
         analyticsService?.sendAnalyticsEvent(
             eventName,
-            errorDescription: errorDescription,
             correlationID: correlationID,
-            payPalContextID: payPalContextID,
+            errorDescription: errorDescription,
             linkType: linkType,
+            payPalContextID: payPalContextID,
             completion: { _ in }
         )
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -415,8 +415,8 @@ import BraintreeDataCollector
     private func notifyFailure(with error: Error, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.tokenizeFailed,
-            errorDescription: error.localizedDescription,
             correlationID: clientMetadataID,
+            errorDescription: error.localizedDescription,
             payPalContextID: payPalContextID
         )
         completion(nil, error)

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -190,8 +190,8 @@ import PayPalCheckout
     private func notifyFailure(with error: Error, completion: @escaping (BTPayPalNativeCheckoutAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalNativeCheckoutAnalytics.tokenizeFailed,
-            errorDescription: error.localizedDescription,
             correlationID: clientMetadataID,
+            errorDescription: error.localizedDescription,
             payPalContextID: payPalContextID
         )
         completion(nil, error)

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -352,11 +352,11 @@ import BraintreeCore
         shouldVault = success && vault
 
         if success {
-            apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchSucceeded, linkType: linkType)
+            apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchSucceeded, linkType: linkType, payPalContextID: payPalContextID)
             BTVenmoClient.venmoClient = self
             self.appSwitchCompletion = completion
         } else {            
-            apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchFailed, linkType: linkType)
+            apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchFailed, linkType: linkType, payPalContextID: payPalContextID)
             notifyFailure(with: BTVenmoError.appSwitchFailed, completion: completion)
         }
     }
@@ -416,7 +416,7 @@ import BraintreeCore
         with result: BTVenmoAccountNonce,
         completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void
     ) {
-        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeSucceeded, payPalContextID: payPalContextID, linkType: linkType)
+        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeSucceeded, linkType: linkType, payPalContextID: payPalContextID)
         completion(result, nil)
     }
 
@@ -424,14 +424,14 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent(
             BTVenmoAnalytics.tokenizeFailed,
             errorDescription: error.localizedDescription,
-            payPalContextID: payPalContextID,
-            linkType: linkType
+            linkType: linkType, 
+            payPalContextID: payPalContextID
         )
         completion(nil, error)
     }
 
     private func notifyCancel(completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchCanceled, payPalContextID: payPalContextID, linkType: linkType)
+        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchCanceled, linkType: linkType, payPalContextID: payPalContextID)
         completion(nil, BTVenmoError.canceled)
     }
 }

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -11,7 +11,6 @@ final class FPTIBatchData_Tests: XCTestCase {
         environment: "fake-env",
         integrationType: "fake-integration-type",
         merchantID: "fake-merchant-id",
-        payPalContextID: "fake-order-id",
         sessionID: "fake-session",
         tokenizationKey: "fake-auth"
     )
@@ -22,6 +21,7 @@ final class FPTIBatchData_Tests: XCTestCase {
             errorDescription: "fake-error-description-1",
             eventName: "fake-event-1",
             linkType: "universal",
+            payPalContextID: "fake-order-id",
             timestamp: "fake-time-1"
         ),
         FPTIBatchData.Event(
@@ -29,6 +29,7 @@ final class FPTIBatchData_Tests: XCTestCase {
             errorDescription: nil,
             eventName: "fake-event-2",
             linkType: nil,
+            payPalContextID: "fake-order-id-2",
             timestamp: "fake-time-2"
         )
     ]
@@ -73,7 +74,6 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertNotNil(batchParams["mapv"] as? String) // Unable to specify bundle version number within test targets
         XCTAssertTrue((batchParams["mobile_device_model"] as! String).matches("iPhone\\d,\\d|x86_64|arm64"))
         XCTAssertEqual(batchParams["merchant_id"] as! String, "fake-merchant-id")
-        XCTAssertEqual(batchParams["paypal_context_id"] as! String, "fake-order-id")
         XCTAssertEqual(batchParams["platform"] as? String, "iOS")
         XCTAssertEqual(batchParams["session_id"] as? String, "fake-session")
         XCTAssertEqual(batchParams["tokenization_key"] as! String, "fake-auth")
@@ -87,6 +87,8 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(eventParams[1]["tenant_name"] as? String, "Braintree")
         XCTAssertEqual(eventParams[0]["link_type"] as? String, "universal")
         XCTAssertNil(eventParams[1]["link_type"])
+        XCTAssertEqual(eventParams[0]["paypal_context_id"] as! String, "fake-order-id")
+        XCTAssertEqual(eventParams[1]["paypal_context_id"] as! String, "fake-order-id-2")
         XCTAssertEqual(eventParams[0]["error_desc"] as? String, "fake-error-description-1")
         XCTAssertNil(eventParams[1]["error_desc"])
         XCTAssertEqual(eventParams[0]["correlation_id"] as? String, "fake-correlation-id-1")

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -7,8 +7,8 @@ class FakeAnalyticsService: BTAnalyticsService {
 
     override func sendAnalyticsEvent(
         _ eventName: String,
-        errorDescription: String? = nil,
         correlationID: String? = nil,
+        errorDescription: String? = nil,
         payPalContextID: String? = nil,
         linkType: String? = nil
     ) {
@@ -18,10 +18,10 @@ class FakeAnalyticsService: BTAnalyticsService {
 
     override func sendAnalyticsEvent(
         _ eventName: String,
-        errorDescription: String? = nil,
         correlationID: String? = nil,
-        payPalContextID: String? = nil,
+        errorDescription: String? = nil,
         linkType: String? = nil,
+        payPalContextID: String? = nil,
         completion: @escaping (Error?) -> Void = { _ in }
     ) {
         self.lastEvent = eventName

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -8,8 +8,8 @@ class FakeAnalyticsService: BTAnalyticsService {
         _ eventName: String,
         correlationID: String? = nil,
         errorDescription: String? = nil,
-        payPalContextID: String? = nil,
-        linkType: String? = nil
+        linkType: String? = nil,
+        payPalContextID: String? = nil
     ) {
         self.lastEvent = eventName
     }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -84,10 +84,10 @@ public class MockAPIClient: BTAPIClient {
 
     public override func sendAnalyticsEvent(
         _ name: String,
-        errorDescription: String? = nil,
         correlationID: String? = nil,
-        payPalContextID: String? = nil,
-        linkType: String? = nil
+        errorDescription: String? = nil,
+        linkType: String? = nil,
+        payPalContextID: String? = nil
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType


### PR DESCRIPTION
### Summary of changes

- Move `paypal_context_id` from `batch_params` to `event_params`
    - Cleaned up implementation
- Alphabetized parameters order in `sendAnalyticsEvent`
- Update tests

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
