### PR TITLE
[Open Dev] Provide Default View Controller

### DIFF
--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -188,7 +188,7 @@ class ContainmentViewController: UIViewController {
 
     private func instantiateViewController(with authorization: String) -> BaseViewController? {
         guard let integrationName = UserDefaults.standard.string(forKey: "BraintreeDemoSettingsIntegration") else {
-            return nil
+            return PayPalWebCheckoutViewController(authorization: authorization)
         }
 
         switch integrationName {
@@ -213,7 +213,7 @@ class ContainmentViewController: UIViewController {
         case "VenmoViewController":
             return VenmoViewController(authorization: authorization)
         default:
-            return nil
+            return PayPalWebCheckoutViewController(authorization: authorization)
         }
     }
 


### PR DESCRIPTION
### Summary of changes

Right now if the `FeatureViewController` cannot be found, a message is displayed "Demo not available", by providing a default as `PayPalWebCheckoutViewController` we can load a View Controller instead of returning `nil` without a super clear message to the user. This is mainly helpful for first time installs, when nothing is stored in `UserDefaults` yet or when switching between feature branches where the demo exists on a branch but not on main.

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
