### PR TITLE
[QL] Add `BTAppContextSwitcher.universalLink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeCore
-  * Added property `BTAppContextSwitcher.sharedInstance.universalLink` for the PayPal app switch flow
+  * Add property `BTAppContextSwitcher.sharedInstance.universalLink` for the PayPal app switch flow
 
 ## 6.13.0 (2024-03-12)
 * BraintreeVenmo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Added property `BTAppContextSwitcher.sharedInstance.universalLink` for the PayPal app switch flow
+
 ## 6.13.0 (2024-03-12)
 * BraintreeVenmo
   * Add `isFinalAmount` to `BTVenmoRequest`

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -4,6 +4,7 @@ import BraintreeCore
 @UIApplicationMain class AppDelegate: UIResponder, UIApplicationDelegate {
         
     private let returnURLScheme = "com.braintreepayments.Demo.payments"
+    private let universalLinkURL = "https://braintree-ios-demo.fly.dev/braintree-payments"
     private let processInfoArgs = ProcessInfo.processInfo.arguments
     private let userDefaults = UserDefaults.standard
     
@@ -11,7 +12,8 @@ import BraintreeCore
         registerDefaultsFromSettings()
         persistDemoSettings()
         BTAppContextSwitcher.sharedInstance.returnURLScheme = returnURLScheme
-        
+        BTAppContextSwitcher.sharedInstance.universalLink = universalLinkURL
+
         userDefaults.setValue(true, forKey: "magnes.debug.mode")
         
         return true

--- a/Demo/Application/Base/SceneDelegate.swift
+++ b/Demo/Application/Base/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         URLContexts.forEach { urlContext in
             let url = urlContext.url
             if url.scheme?.localizedCaseInsensitiveCompare("com.braintreepayments.Demo.payments") == .orderedSame {
-                _ = BTAppContextSwitcher.sharedInstance.handleOpenURL(context: urlContext)
+                BTAppContextSwitcher.sharedInstance.handleOpenURL(context: urlContext)
             }
         }
     }
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         if let returnURL = userActivity.webpageURL, returnURL.path == "/braintree-payments" {
             print("Returned to Demo app via universal link: \(returnURL)")
-            _ = BTAppContextSwitcher.sharedInstance.handleOpen(returnURL)
+            BTAppContextSwitcher.sharedInstance.handleOpen(returnURL)
         }
     }
 }

--- a/Demo/Application/Base/SceneDelegate.swift
+++ b/Demo/Application/Base/SceneDelegate.swift
@@ -27,9 +27,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        if let returnURL = userActivity.webpageURL {
-            // TODO: implementation - pass full URL to BT SDK
+        if let returnURL = userActivity.webpageURL, returnURL.path == "/braintree-payments" {
             print("Returned to Demo app via universal link: \(returnURL)")
+            _ = BTAppContextSwitcher.sharedInstance.handleOpen(returnURL)
         }
     }
 }

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -86,6 +86,6 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     }
 
     @objc func universalLinkFlow(_ sender: UIButton) {
-        UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev")!)
+        UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!)
     }
 }

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -12,9 +12,11 @@ import UIKit
     
     /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
     /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
+    /// - Note: This property should only be used for the Venmo flow.
     public var returnURLScheme: String = ""
 
-    /// The URL to use for the PayPal universal link flow. Must contain the path `braintree-payments`.
+    /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
+    /// - Note: This property should only be used for the PayPal app switch flow.
     public var universalLink: String = ""
 
     // MARK: - Private Properties

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -29,7 +29,7 @@ import UIKit
     /// - Parameters: url the URL you receive in  `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate) when returning to your app
     /// - Returns: `true` when the SDK can process the return URL
     @objc(handleOpenURLContext:)
-    public func handleOpenURL(context: UIOpenURLContext) -> Bool {
+    @discardableResult public func handleOpenURL(context: UIOpenURLContext) -> Bool {
         handleOpen(context.url)
     }
     
@@ -37,7 +37,7 @@ import UIKit
     /// - Parameter url:  The URL you receive in `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate)
     /// - Returns: `true` when the SDK has handled the URL successfully
     @objc(handleOpenURL:)
-    public func handleOpen(_ url: URL) -> Bool {
+    @discardableResult public func handleOpen(_ url: URL) -> Bool {
         for appContextSwitchClient in appContextSwitchClients {
             if appContextSwitchClient.canHandleReturnURL(url) {
                 appContextSwitchClient.handleReturnURL(url)

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -13,7 +13,10 @@ import UIKit
     /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
     /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
     public var returnURLScheme: String = ""
-    
+
+    /// The URL to use for the PayPal universal link flow. Must contain the path `braintree-payments`.
+    public var universalLink: String = ""
+
     // MARK: - Private Properties
     
     private var appContextSwitchClients = [BTAppContextSwitchClient.Type]()

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -25,7 +25,7 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         appSwitch.register(MockAppContextSwitchClient.self)
         let expectedURL = URL(string: "fake://url")!
 
-        BTAppContextSwitcher.sharedInstance.handleOpen(expectedURL)
+        _ = BTAppContextSwitcher.sharedInstance.handleOpen(expectedURL)
 
         XCTAssertEqual(MockAppContextSwitchClient.lastCanHandleURL!, expectedURL)
     }
@@ -80,13 +80,19 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         XCTAssertFalse(handled)
         XCTAssertNil(MockAppContextSwitchClient.lastHandleReturnURL)
     }
-        
+
     func testHandleOpenURLContext_withNoAppSwitching_returnsFalse() {
         let mockURLContext = BTMockOpenURLContext(url: URL(string: "fake://url")!).mock
         let handled = BTAppContextSwitcher.sharedInstance.handleOpenURL(context: mockURLContext)
         XCTAssertFalse(handled)
     }
 
+    // MARK: - universalLink Tests
+
+    func testSetUniversalLink() {
+        BTAppContextSwitcher.sharedInstance.universalLink = "https://fake.com"
+        XCTAssertEqual(appSwitch.universalLink, "https://fake.com")
+    }
 }
 
 @objcMembers class MockAppContextSwitchClient: BTAppContextSwitchClient {

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -25,7 +25,7 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         appSwitch.register(MockAppContextSwitchClient.self)
         let expectedURL = URL(string: "fake://url")!
 
-        _ = BTAppContextSwitcher.sharedInstance.handleOpen(expectedURL)
+        BTAppContextSwitcher.sharedInstance.handleOpen(expectedURL)
 
         XCTAssertEqual(MockAppContextSwitchClient.lastCanHandleURL!, expectedURL)
     }


### PR DESCRIPTION
This work is going into the `paypal-app-switch-feature` branch

### Summary of changes

- Add `BTAppContextSwitcher.sharedInstance.universalLink` property
- Parse path in return URL `SceneDelegate` method

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 