### PR TITLE
Fix duplicate paypal cancel analytic event

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -313,7 +313,6 @@ import BraintreeDataCollector
 
             // User canceled by breaking out of the PayPal browser switch flow
             // (e.g. System "Cancel" button on permission alert or browser during ASWebAuthenticationSession)
-            apiClient.sendAnalyticsEvent(BTPayPalAnalytics.browserLoginCanceled, payPalContextID: payPalContextID)
             notifyCancel(completion: completion)
             return
         }


### PR DESCRIPTION
### Summary of changes

- Was poking through our analytics for the PP App Switch workflow and found that we're sending the `"paypal:tokenize:browser-login:canceled"` event twice

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 