### PR TITLE
[QL] Update `BTAppContextSwitcher.sharedInstance.universalLink` to URL Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## unreleased
 * Require Xcode 15.0+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
-* BraintreeCore
-  * Add property `BTAppContextSwitcher.sharedInstance.universalLink` for the PayPal app switch flow
 * BraintreePayPal
-  * Add `BTPayPalVault.enablePayPalAppSwitch`
-    * If set to `true` we will attempt to use the PayPal App Switch flow
+  * Add `BTPayPalVaultRequest.init(userAuthenticationEmail:enablePayPalAppSwitch:universalLink:offerCredit:)`
+    * This init should be used for the PayPal App Switch flow
 
 ## 6.16.0 (2024-03-19)
 * Add `BTPayPalVaultRequest.userAuthenticationEmail` optional property

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -4,7 +4,7 @@ import BraintreeCore
 @UIApplicationMain class AppDelegate: UIResponder, UIApplicationDelegate {
         
     private let returnURLScheme = "com.braintreepayments.Demo.payments"
-    private let universalLinkURL = "https://braintree-ios-demo.fly.dev/braintree-payments"
+    private let universalLinkURL = URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
     private let processInfoArgs = ProcessInfo.processInfo.arguments
     private let userDefaults = UserDefaults.standard
     

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -4,7 +4,6 @@ import BraintreeCore
 @UIApplicationMain class AppDelegate: UIResponder, UIApplicationDelegate {
         
     private let returnURLScheme = "com.braintreepayments.Demo.payments"
-    private let universalLinkURL = URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
     private let processInfoArgs = ProcessInfo.processInfo.arguments
     private let userDefaults = UserDefaults.standard
     
@@ -12,7 +11,6 @@ import BraintreeCore
         registerDefaultsFromSettings()
         persistDemoSettings()
         BTAppContextSwitcher.sharedInstance.returnURLScheme = returnURLScheme
-        BTAppContextSwitcher.sharedInstance.universalLink = universalLinkURL
 
         userDefaults.setValue(true, forKey: "magnes.debug.mode")
         

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -87,7 +87,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     @objc func universalLinkFlow(_ sender: UIButton) {
         // TODO: implement in a future PR - used here so we don't have to remove lazy instantiation
-        let request = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        // TODO: replace URL with https://braintree-ios-demo.fly.dev/braintree-payments
+        let request = BTPayPalVaultRequest(
+            userAuthenticationEmail: "sally@gmail.com",
+            enablePayPalAppSwitch: true,
+            universalLink: URL(string: "https://paypal.com")!
+        )
         payPalClient.tokenize(request) { _, _ in }
         UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments/success")!)
     }

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -9,7 +9,8 @@ import UIKit
     
     /// Singleton for shared instance of `BTAppContextSwitcher`
     public static let sharedInstance = BTAppContextSwitcher()
-    
+   
+    // MEXT_MAJOR_VERSION: move this property into the feature client request where it is used
     /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
     /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
     /// - Note: This property should only be used for the Venmo flow.

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -15,10 +15,6 @@ import UIKit
     /// - Note: This property should only be used for the Venmo flow.
     public var returnURLScheme: String = ""
 
-    /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
-    /// - Note: This property should only be used for the PayPal app switch flow.
-    public var universalLink: URL?
-
     // MARK: - Private Properties
     
     private var appContextSwitchClients = [BTAppContextSwitchClient.Type]()

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -17,7 +17,7 @@ import UIKit
 
     /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     /// - Note: This property should only be used for the PayPal app switch flow.
-    public var universalLink: String = ""
+    public var universalLink: URL?
 
     // MARK: - Private Properties
     

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -10,7 +10,7 @@ import UIKit
     /// Singleton for shared instance of `BTAppContextSwitcher`
     public static let sharedInstance = BTAppContextSwitcher()
    
-    // MEXT_MAJOR_VERSION: move this property into the feature client request where it is used
+    // NEXT_MAJOR_VERSION: move this property into the feature client request where it is used
     /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
     /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
     /// - Note: This property should only be used for the Venmo flow.

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -17,7 +17,27 @@ import BraintreeCore
     /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     public var userAuthenticationEmail: String?
 
+    /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
+    var universalLink: URL?
+
     // MARK: - Initializer
+
+    /// Initializes a PayPal Vault request
+    /// - Parameters:
+    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    ///   - enablePayPalAppSwitch: Optional: Used to determine if the customer will use the PayPal app switch flow. Defaults to `false`.
+    ///   This property is currently in beta and may change or be removed in future releases.
+    ///   - universalLink: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
+    public convenience init(
+        offerCredit: Bool = false,
+        userAuthenticationEmail: String,
+        enablePayPalAppSwitch: Bool,
+        universalLink: URL
+    ) {
+        self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail, enablePayPalAppSwitch: enablePayPalAppSwitch)
+        self.universalLink = universalLink
+    }
 
     /// Initializes a PayPal Vault request
     /// - Parameters:
@@ -38,12 +58,12 @@ import BraintreeCore
             baseParameters["payer_email"] = userAuthenticationEmail
         }
         
-        if enablePayPalAppSwitch, let universalLinkURL = BTAppContextSwitcher.sharedInstance.universalLink {
+        if enablePayPalAppSwitch, let universalLink {
             let appSwitchParameters: [String: Any] = [
                 "launch_paypal_app": enablePayPalAppSwitch,
                 "os_version": UIDevice.current.systemVersion,
                 "os_type": UIDevice.current.systemName,
-                "merchant_app_return_url": universalLinkURL.absoluteString
+                "merchant_app_return_url": universalLink.absoluteString
             ]
             return baseParameters.merging(appSwitchParameters) { $1 }
         }

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -23,6 +23,7 @@ import BraintreeCore
     // MARK: - Initializer
 
     /// Initializes a PayPal Vault request
+    /// - Note: This initializer should be used for merchants using the PayPal App Switch flow
     /// - Parameters:
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
@@ -30,10 +31,10 @@ import BraintreeCore
     ///   This property is currently in beta and may change or be removed in future releases.
     ///   - universalLink: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     public convenience init(
-        offerCredit: Bool = false,
         userAuthenticationEmail: String,
         enablePayPalAppSwitch: Bool,
-        universalLink: URL
+        universalLink: URL,
+        offerCredit: Bool = false
     ) {
         self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail, enablePayPalAppSwitch: enablePayPalAppSwitch)
         self.universalLink = universalLink

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 #if canImport(BraintreeCore)
 import BraintreeCore
@@ -36,6 +36,16 @@ import BraintreeCore
 
         if let userAuthenticationEmail {
             baseParameters["payer_email"] = userAuthenticationEmail
+        }
+        
+        if enablePayPalAppSwitch {
+            let appSwitchParameters: [String: Any] = [
+                "launch_paypal_app": enablePayPalAppSwitch,
+                "os_version": UIDevice.current.systemVersion,
+                "os_type": UIDevice.current.systemName,
+                "merchant_app_return_url": BTAppContextSwitcher.sharedInstance.universalLink
+            ]
+            return baseParameters.merging(appSwitchParameters) { $1 }
         }
 
         return baseParameters

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -38,12 +38,12 @@ import BraintreeCore
             baseParameters["payer_email"] = userAuthenticationEmail
         }
         
-        if enablePayPalAppSwitch {
+        if enablePayPalAppSwitch, let universalLinkURL = BTAppContextSwitcher.sharedInstance.universalLink {
             let appSwitchParameters: [String: Any] = [
                 "launch_paypal_app": enablePayPalAppSwitch,
                 "os_version": UIDevice.current.systemVersion,
                 "os_type": UIDevice.current.systemName,
-                "merchant_app_return_url": BTAppContextSwitcher.sharedInstance.universalLink
+                "merchant_app_return_url": universalLinkURL.absoluteString
             ]
             return baseParameters.merging(appSwitchParameters) { $1 }
         }

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -9,34 +9,36 @@ import BraintreeCore
 
     // MARK: - Public Properties
 
+    /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    public var userAuthenticationEmail: String?
+
+    // MARK: - Internal Properties
+
     /// Optional: Used to determine if the customer will use the PayPal app switch flow.
     /// Defaults to `false`.
     /// - Note: This property is currently in beta and may change or be removed in future releases.
-    public var enablePayPalAppSwitch: Bool
-
-    /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    public var userAuthenticationEmail: String?
+    var enablePayPalAppSwitch: Bool = false
 
     /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     var universalLink: URL?
 
-    // MARK: - Initializer
+    // MARK: - Initializers
 
     /// Initializes a PayPal Vault request
     /// - Note: This initializer should be used for merchants using the PayPal App Switch flow
     /// - Parameters:
-    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
-    ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    ///   - enablePayPalAppSwitch: Optional: Used to determine if the customer will use the PayPal app switch flow. Defaults to `false`.
+    ///   - userAuthenticationEmail: Required: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
     ///   This property is currently in beta and may change or be removed in future releases.
-    ///   - universalLink: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
+    ///   - universalLink: Required: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
+    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     public convenience init(
         userAuthenticationEmail: String,
         enablePayPalAppSwitch: Bool,
         universalLink: URL,
         offerCredit: Bool = false
     ) {
-        self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail, enablePayPalAppSwitch: enablePayPalAppSwitch)
+        self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail)
         self.universalLink = universalLink
     }
 
@@ -44,10 +46,7 @@ import BraintreeCore
     /// - Parameters:
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    ///   - enablePayPalAppSwitch: Optional: Used to determine if the customer will use the PayPal app switch flow. Defaults to `false`.
-    ///   This property is currently in beta and may change or be removed in future releases.
-    public init(offerCredit: Bool = false, userAuthenticationEmail: String? = nil, enablePayPalAppSwitch: Bool = false) {
-        self.enablePayPalAppSwitch = enablePayPalAppSwitch
+    public init(offerCredit: Bool = false, userAuthenticationEmail: String? = nil) {
         self.userAuthenticationEmail = userAuthenticationEmail
         super.init(offerCredit: offerCredit)
     }

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -24,14 +24,13 @@ import BraintreeCore
 
     // MARK: - Initializers
 
-    /// Initializes a PayPal Vault request
-    /// - Note: This initializer should be used for merchants using the PayPal App Switch flow
+    /// Initializes a PayPal Vault request for the PayPal App Switch flow
     /// - Parameters:
     ///   - userAuthenticationEmail: Required: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
-    ///   This property is currently in beta and may change or be removed in future releases.
     ///   - universalLink: Required: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    /// - Note: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
     public convenience init(
         userAuthenticationEmail: String,
         enablePayPalAppSwitch: Bool,

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -39,6 +39,7 @@ import BraintreeCore
     ) {
         self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail)
         self.universalLink = universalLink
+        self.enablePayPalAppSwitch = enablePayPalAppSwitch
     }
 
     /// Initializes a PayPal Vault request

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -86,13 +86,6 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         let handled = BTAppContextSwitcher.sharedInstance.handleOpenURL(context: mockURLContext)
         XCTAssertFalse(handled)
     }
-
-    // MARK: - universalLink Tests
-
-    func testSetUniversalLink() {
-        BTAppContextSwitcher.sharedInstance.universalLink = URL(string: "https://fake.com")
-        XCTAssertEqual(appSwitch.universalLink?.absoluteString, "https://fake.com")
-    }
 }
 
 @objcMembers class MockAppContextSwitchClient: BTAppContextSwitchClient {

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -90,8 +90,8 @@ class BTAppContextSwitcher_Tests: XCTestCase {
     // MARK: - universalLink Tests
 
     func testSetUniversalLink() {
-        BTAppContextSwitcher.sharedInstance.universalLink = "https://fake.com"
-        XCTAssertEqual(appSwitch.universalLink, "https://fake.com")
+        BTAppContextSwitcher.sharedInstance.universalLink = URL(string: "https://fake.com")
+        XCTAssertEqual(appSwitch.universalLink?.absoluteString, "https://fake.com")
     }
 }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -703,8 +703,12 @@ class BTPayPalClient_Tests: XCTestCase {
             ]
         ])
         
-        let vaultRequest = BTPayPalVaultRequest(userAuthenticationEmail: "fake@gmail.com", enablePayPalAppSwitch: true)
-        
+        let vaultRequest = BTPayPalVaultRequest(
+            userAuthenticationEmail: "fake@gmail.com",
+            enablePayPalAppSwitch: true,
+            universalLink: URL(string: "https://paypal.com")!
+        )
+
         payPalClient.tokenize(vaultRequest) { _, _ in }
 
         XCTAssertTrue(fakeApplication.openURLWasCalled)

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -96,8 +96,15 @@ class BTPayPalRequest_Tests: XCTestCase {
 
     // MARK: - enablePayPalAppSwitch
 
-    func testEnablePayPalAppSwitch_whenNotPassed_defaultsValueAsFalse() {
-        let request = BTPayPalVaultRequest()
+    func testEnablePayPalAppSwitch_whenInitialized_setsAllRequiredValues() {
+        let request = BTPayPalVaultRequest(
+            userAuthenticationEmail: "fake@gmail.com",
+            enablePayPalAppSwitch: true,
+            universalLink: URL(string: "my-website-is-cool.com")!
+        )
+
+        XCTAssertEqual(request.userAuthenticationEmail, "fake@gmail.com")
         XCTAssertFalse(request.enablePayPalAppSwitch)
+        XCTAssertEqual(request.universalLink?.absoluteString, "my-website-is-cool.com")
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -104,7 +104,7 @@ class BTPayPalRequest_Tests: XCTestCase {
         )
 
         XCTAssertEqual(request.userAuthenticationEmail, "fake@gmail.com")
-        XCTAssertFalse(request.enablePayPalAppSwitch)
+        XCTAssertTrue(request.enablePayPalAppSwitch)
         XCTAssertEqual(request.universalLink?.absoluteString, "my-website-is-cool.com")
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -71,7 +71,7 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
     }
     
     func testParameters_withEnablePayPalAppSwitchTrue_returnsAllParams() {
-        BTAppContextSwitcher.sharedInstance.universalLink = "some-url"
+        BTAppContextSwitcher.sharedInstance.universalLink = URL(string: "some-url")!
         let request = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
 
         let parameters = request.parameters(with: configuration)

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -54,7 +54,11 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         XCTAssertEqual(parameters["description"] as? String, "desc")
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)
         XCTAssertEqual(parameters["payer_email"] as? String, "fake@email.com")
-
+        XCTAssertNil(parameters["launch_paypal_app"])
+        XCTAssertNil(parameters["os_version"])
+        XCTAssertNil(parameters["os_type"])
+        XCTAssertNil(parameters["merchant_app_return_url"])
+        
         guard let shippingParams = parameters["shipping_address"] as? [String:String] else { XCTFail(); return }
 
         XCTAssertEqual(shippingParams["line1"], "123 Main")
@@ -64,5 +68,17 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         XCTAssertEqual(shippingParams["postal_code"], "11111")
         XCTAssertEqual(shippingParams["country_code"], "US")
         XCTAssertEqual(shippingParams["recipient_name"], "Recipient")
+    }
+    
+    func testParameters_withEnablePayPalAppSwitchTrue_returnsAllParams() {
+        BTAppContextSwitcher.sharedInstance.universalLink = "some-url"
+        let request = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+
+        let parameters = request.parameters(with: configuration)
+
+        XCTAssertEqual(parameters["launch_paypal_app"] as? Bool, true)
+        XCTAssertTrue((parameters["os_version"] as! String).matches("\\d+\\.\\d+"))
+        XCTAssertTrue((parameters["os_type"] as! String).matches("iOS|iPadOS"))
+        XCTAssertEqual(parameters["merchant_app_return_url"] as? String, "some-url")
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -71,8 +71,11 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
     }
     
     func testParameters_withEnablePayPalAppSwitchTrue_returnsAllParams() {
-        BTAppContextSwitcher.sharedInstance.universalLink = URL(string: "some-url")!
-        let request = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        let request = BTPayPalVaultRequest(
+            userAuthenticationEmail: "sally@gmail.com",
+            enablePayPalAppSwitch: true,
+            universalLink: URL(string: "some-url")!
+        )
 
         let parameters = request.parameters(with: configuration)
 


### PR DESCRIPTION
### Summary of changes

- Replace `BTAppContextSwitcher.sharedInstance.universalLink` with init:  `BTPayPalVaultRequest(userAuthenticationEmail:enablePayPalAppSwitch:universalLink:offerCredit:)`

- OG convo here: https://github.com/braintree/braintree_ios/pull/1228#discussion_r1530809502

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
