### PR TITLE
[QL] Prefer BA Token over EC Token

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -322,7 +322,7 @@ import BraintreeDataCollector
         guard let query = approvalURL.query else { return "" }
         let queryDictionary = parse(queryString: query)
         
-        return queryDictionary["token"] ?? queryDictionary["ba_token"] ?? ""
+        return queryDictionary["ba_token"] ?? queryDictionary["token"] ?? ""
     }
     
     private func parse(queryString query: String) -> [String: String] {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -240,6 +240,21 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertNil(mockAPIClient.postedPayPalContextID)
     }
 
+    func testTokenize_whenApprovalURLContainsECAndBAToken_sendsBATokenAsPayPalContextIDInAnalytics() {
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paymentResource": [
+                "redirectUrl": "https://www.paypal.com/checkout?token=EC-Random-Value&ba_token=BA-Random-Value"
+            ]
+        ])
+
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
+
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        payPalClient.tokenize(request) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.postedPayPalContextID, "BA-Random-Value")
+    }
+
     // MARK: - Browser switch
 
     func testTokenizePayPalAccount_whenPayPalPayLaterOffered_performsSwitchCorrectly() {


### PR DESCRIPTION
### Summary of changes

- Per [this conversation](https://github.com/braintree/braintree_ios/pull/1234#discussion_r1537752483) we want to prefer BA tokens over EC tokens
- Tested all 3 PayPal flows (Checkout, Vault, and Pay Later) to ensure the flows still worked as expected
- Added unit test for this logic

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 