### PR TITLE
Fix Failing `UnitTest`s

### DIFF
--- a/Sources/BraintreeCore/BTJSON.swift
+++ b/Sources/BraintreeCore/BTJSON.swift
@@ -219,7 +219,7 @@ import Foundation
     /// The `BTJSON` as a `URL`
     /// - Returns: A `URL` representing the `BTJSON` instance
     public func asURL() -> URL? {
-        guard let urlString = value as? String else {
+        guard let urlString = value as? String, urlString.utf8.count == urlString.utf16.count else {
             return nil
         }
         return URL(string: urlString)

--- a/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
@@ -179,12 +179,6 @@ class BTSEPADirectDebitClient_Tests: XCTestCase {
             ]
         )
 
-        mockWebAuthenticationSession.cannedErrorResponse = NSError(
-            domain: BTSEPADirectDebitError.errorDomain,
-            code: BTSEPADirectDebitError.approvalURLInvalid.errorCode,
-            userInfo: ["Description": "Mock approvalURLInvalid error description."]
-        )
-
         let sepaDirectDebitClient = BTSEPADirectDebitClient(
             apiClient: mockAPIClient,
             webAuthenticationSession: mockWebAuthenticationSession,


### PR DESCRIPTION
### Summary of changes

- `BTSEPADirectDebitClient_Tests.testTokenizeWithPresentationContext_handleCreateMandateReturnsInvalidURL_returnsError_andSendsAnalytics()`
    - We were returning a `cannedErrorResponse` here which wasn't needed and was actually returning before the method completed
- `BTJSON_Tests.testLargerMixedJSONWithEmoji()`
    - `"aString": "Hello, JSON 😍!"` and `"anInvalidURL": ":™£¢://://://???!!!"` were failing to evaluate as `nil` when calling `BTJSON.asURL()` - neither of these are URLs so we expect that method to evaluate as `nil`
    - Adding a check of `urlString.utf8.count == urlString.utf16.count` allows us to evaluate the string in the same way that we were in Obj-C
    - More details on this test as a whole below...

#### The Why
I found this super interesting so adding it here if other folks are also interested:
- `NSString` - these are UTF-16 ([more reading here](https://www.objc.io/issues/9-strings/unicode/))
- `String` - these are UTF-8 ([more reading here](https://www.swift.org/blog/utf8-string/#:~:text=Prior%20to%20Swift%205%2C%20string,ASCII%20and%20Unicode%2Drich%20text.))
- The `testLargerMixedJSONWithEmoji` test has been failing because "😍" is 2 extra bytes in UTF-8 vs UTF-16 and "™£¢" is 4 extra bytes in UTF-8 vs UTF-16
- Lots of discussions about eventually adding some logic around this to Foundation directly [in the Swift forums](https://forums.swift.org/t/is-there-a-way-to-validate-a-url-from-a-string/64052/13)

#### Alternatives
There are some alternatives to the check I added here that we can explore, but the approach I took was the closest to our [v5 implementation here](https://github.com/braintree/braintree_ios/blob/78337785b18ebaef80b3efe13fa513b89f35b5c5/Sources/BraintreeCore/BTJSON.m#L161C32-L161C40) which used `asString` to see if it could be cast to a `NSString` (UTF-16) and if not returned `null`. Some alternatives:
- Cast `urlString` to `NSString` - downside, we would then need to cast it back to a string in `return URL(string: urlString)` because `NSString` is not implicitly convertible to `String`
- Using something like `UIApplication.shared.canOpenURL` could be an option but we would need to replace our URLs in tests with actual URLs. This also seems like overkill a bit imo, but open to opinions!
- ... maybe something I haven't thought of yet?

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 