### PR TITLE
[QL] Replace Universal Link in Demo App + Update `paypalAppApprovalUrl` Parsing

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -87,11 +87,10 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     @objc func universalLinkFlow(_ sender: UIButton) {
         // TODO: implement in a future PR - used here so we don't have to remove lazy instantiation
-        // TODO: replace URL with https://braintree-ios-demo.fly.dev/braintree-payments
         let request = BTPayPalVaultRequest(
             userAuthenticationEmail: "sally@gmail.com",
             enablePayPalAppSwitch: true,
-            universalLink: URL(string: "https://paypal.com")!
+            universalLink: URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
         )
         payPalClient.tokenize(request) { _, _ in }
         UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments/success")!)

--- a/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
+++ b/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
@@ -37,7 +37,7 @@ struct BTPayPalApprovalURLParser {
     }
     
     init?(body: BTJSON) {
-        if let payPalAppRedirectURL = body["paymentResource"]["paypalAppApprovalUrl"].asURL() {
+        if let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
             redirectType = .payPalApp(url: payPalAppRedirectURL)
         } else if let approvalURL = body["paymentResource"]["redirectUrl"].asURL() ??
             body["agreementSetup"]["approvalUrl"].asURL() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -190,8 +190,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testTokenizePayPalAccount_whenAllApprovalURLsInvalid_returnsError() {
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
-                "redirectUrl": "",
+            "agreementSetup": [
                 "approvalUrl": "",
                 "paypalAppApprovalUrl": ""
             ]
@@ -230,7 +229,7 @@ class BTPayPalClient_Tests: XCTestCase {
     // TODO: - Un-pend test once app switch flow sends analytics
     func pendTokenize_whenPayPalAppApprovalURLContainsPayPalContextID_sendsPayPalContextIDInAnalytics() {
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
+            "agreementSetup": [
                 "paypalAppApprovalUrl": "https://www.fake.com?ba_token=123"
             ]
         ])
@@ -712,9 +711,8 @@ class BTPayPalClient_Tests: XCTestCase {
         payPalClient.application = fakeApplication
         
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
-                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1",
-                "redirectUrl": "https://www.other-url.com/"
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
             ]
         ])
         
@@ -869,9 +867,8 @@ class BTPayPalClient_Tests: XCTestCase {
         )
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
-                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1",
-                "redirectUrl": "https://www.other-url.com/"
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
             ]
         ])
 
@@ -898,9 +895,8 @@ class BTPayPalClient_Tests: XCTestCase {
         )
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "paymentResource": [
-                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1",
-                "redirectUrl": "https://www.other-url.com/"
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
             ]
         ])
 


### PR DESCRIPTION
### Summary of changes

- Our demo app URL for universal linking of `https://braintree-ios-demo.fly.dev/braintree-payments` has been allowlisted so we can update `PayPalWebCheckoutViewController` with this
- In `BTPayPalApprovalURLParser` we were parsing `paypalAppApprovalUrl` from `paymentResource` (Checkout) when it should be parsed from `agreementSetup` (Vault) - verified via breakpoints and our contracts that this nesting should be updated
    - Updated tests with this correction

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
