### PR TITLE
[QL] Add `handleReturnStarted` Analytics Event

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -21,4 +21,8 @@ enum BTPayPalAnalytics {
     static let browserLoginCanceled = "paypal:tokenize:browser-login:canceled"
     // specific cancel from permisison alert
     static let browserLoginAlertCanceled = "paypal:tokenize:browser-login:alert-canceled"
+
+    // MARK: - Additional Conversion events
+
+    static let handleReturnStarted = "paypal:tokenize:handle-return:started"
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -150,6 +150,11 @@ import BraintreeDataCollector
         paymentType: BTPayPalPaymentType,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
+        apiClient.sendAnalyticsEvent(
+            BTPayPalAnalytics.handleReturnStarted,
+            correlationID: clientMetadataID,
+            payPalContextID: payPalContextID
+        )
         guard let url, isValidURLAction(url: url) else {
             notifyFailure(with: BTPayPalError.invalidURLAction, completion: completion)
             return

--- a/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
@@ -10,5 +10,6 @@ final class BTPayPalAnalytics_Tests: XCTestCase {
         XCTAssertEqual(BTPayPalAnalytics.browserPresentationSucceeded, "paypal:tokenize:browser-presentation:succeeded")
         XCTAssertEqual(BTPayPalAnalytics.browserPresentationFailed, "paypal:tokenize:browser-presentation:failed")
         XCTAssertEqual(BTPayPalAnalytics.browserLoginAlertCanceled, "paypal:tokenize:browser-login:alert-canceled")
+        XCTAssertEqual(BTPayPalAnalytics.handleReturnStarted, "paypal:tokenize:handle-return:started")
     }
 }


### PR DESCRIPTION
### Summary of changes

- This will be used to calculate customer perceived latency from when the SDK is handed back control to when we return a nonce to the merchant
- There will be a ticket made to do this work in Android as well

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
