### PR TITLE
[QL] Update `PayPalWebCheckoutViewController` for E2E App Switch Testing

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -10,9 +10,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
         let payPalPayLaterButton = createButton(title: "PayPal with Pay Later Offered", action: #selector(tappedPayPalPayLater))
-        let universalLinkButton = createButton(title: "Universal Link Flow", action: #selector(universalLinkFlow))
+        let payPalAppSwitchButton = createButton(title: "PayPal App Switch Flow", action: #selector(tappedPayPalAppSwitchFlow))
 
-        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton, universalLinkButton]
+        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton, payPalAppSwitchButton]
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.axis = .vertical
         stackView.alignment = .center
@@ -85,14 +85,21 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         }
     }
 
-    @objc func universalLinkFlow(_ sender: UIButton) {
-        // TODO: implement in a future PR - used here so we don't have to remove lazy instantiation
+    @objc func tappedPayPalAppSwitchFlow(_ sender: UIButton) {
         let request = BTPayPalVaultRequest(
             userAuthenticationEmail: "sally@gmail.com",
             enablePayPalAppSwitch: true,
             universalLink: URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
         )
-        payPalClient.tokenize(request) { _, _ in }
-        UIApplication.shared.open(URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments/success")!)
+        payPalClient.tokenize(request) { nonce, error in
+            sender.isEnabled = true
+
+            guard let nonce else {
+                self.progressBlock(error?.localizedDescription)
+                return
+            }
+
+            self.completionBlock(nonce)
+        }
     }
 }


### PR DESCRIPTION
### Summary of changes

- Update button name from `universalLinkButton` to `payPalAppSwitchButton`
    - Update button text to "PayPal App Switch Flow"
- Update method name from `universalLinkFlow` to `tappedPayPalAppSwitchFlow`
    - Address TODO
    - Handle nonce an errors for this flow - NOTE: this will not work yet but prepares us for stage and end to end stage testing early next week

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
