### PR TITLE
Update Workflows to Use Xcode 15.0.1 + Swift Version 5.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,23 +5,23 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 15.1)
-    runs-on: macOS-13-xlarge
+    name: CocoaPods (Xcode 15.0.1)
+    runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
-    name: Carthage (Xcode 15.1)
-    runs-on: macOS-13-xlarge
+    name: Carthage (Xcode 15.0.1)
+    runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -29,8 +29,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -47,16 +47,16 @@ jobs:
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
-    name: SPM (Xcode 15.1)
-    runs-on: macOS-13-xlarge
+    name: SPM (Xcode 15.0.1)
+    runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-13-xlarge
+    runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,15 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-13-xlarge
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
@@ -23,30 +23,30 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-13-xlarge
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 14,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-13-xlarge
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 15.0.1
+        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.platform         = :ios, "14.0"
   s.compiler_flags   = "-Wall -Werror -Wextra"
-  s.swift_version    = "5.8"
+  s.swift_version    = "5.9"
 
   s.default_subspecs = %w[Core Card PayPal]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Require Xcode 15.0+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
+* Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
 
 ## 6.16.0 (2024-03-19)
 * Add `BTPayPalVaultRequest.userAuthenticationEmail` optional property

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
### Summary of changes

- Update all workflow to use Xcode 15.0.1 - currently using Xcode 15.1 for the release for Carthage will result in merchants using that version to run into errors building with Xcode 15.0 since Xcode 15.1 is built with Swift 5.9.2 and our minimally supported version is Swift 5.9.0 ([resource](https://xcodereleases.com/))
- Bump `Package.swift` and `Braintree.podspec` to use Swift 5.9

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 