### PR TITLE
[QL] Update Docstrings from `Note` to `Warning`

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -16,7 +16,7 @@ import BraintreeCore
 
     /// Optional: Used to determine if the customer will use the PayPal app switch flow.
     /// Defaults to `false`.
-    /// - Note: This property is currently in beta and may change or be removed in future releases.
+    /// - Warning: This property is currently in beta and may change or be removed in future releases.
     var enablePayPalAppSwitch: Bool = false
 
     /// The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
@@ -30,7 +30,7 @@ import BraintreeCore
     ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
     ///   - universalLink: Required: The URL to use for the PayPal app switch flow. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
-    /// - Note: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
+    /// - Warning: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
     public convenience init(
         userAuthenticationEmail: String,
         enablePayPalAppSwitch: Bool,


### PR DESCRIPTION
### Summary of changes

- Update App Switch properties from `Note` to `Warning`

#### Visuals
| Before | After |
|-----|-----|
|<img width="657" alt="Screenshot 2024-04-08 at 3 08 54 PM" src="https://github.com/braintree/braintree_ios/assets/20733831/77c07e2f-68b3-44b8-b536-f88d9ec08e58">|<img width="659" alt="Screenshot 2024-04-08 at 3 08 24 PM" src="https://github.com/braintree/braintree_ios/assets/20733831/322a9b3e-83af-4f46-bcc3-495046e76927">|

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
