### PR TITLE
[QL] Add Missing BA Token to Query Parameters

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -351,6 +351,7 @@ import BraintreeDataCollector
 
         var urlComponents = URLComponents(url: payPalAppRedirectURL, resolvingAgainstBaseURL: true)
         urlComponents?.queryItems = [
+            URLQueryItem(name: "ba_token", value: payPalContextID),
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000))))
         ]

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -727,7 +727,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
-                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?ba_token=value1"
             ]
         ])
         
@@ -745,10 +745,12 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.host, "www.some-url.com")
         XCTAssertEqual(urlComponents?.path, "/some-path")
 
-        XCTAssertEqual(urlComponents?.queryItems?[0].name, "source")
-        XCTAssertEqual(urlComponents?.queryItems?[0].value, "braintree_sdk")
-        XCTAssertEqual(urlComponents?.queryItems?[1].name, "switch_initiated_time")
-        if let urlTimestamp = urlComponents?.queryItems?[1].value {
+        XCTAssertEqual(urlComponents?.queryItems?[0].name, "ba_token")
+        XCTAssertEqual(urlComponents?.queryItems?[0].value, "value1")
+        XCTAssertEqual(urlComponents?.queryItems?[1].name, "source")
+        XCTAssertEqual(urlComponents?.queryItems?[1].value, "braintree_sdk")
+        XCTAssertEqual(urlComponents?.queryItems?[2].name, "switch_initiated_time")
+        if let urlTimestamp = urlComponents?.queryItems?[2].value {
             XCTAssertNotNil(Int(urlTimestamp))
         } else {
             XCTFail("Expected integer value for query param `switch_initiated_time`")


### PR DESCRIPTION
### Summary of changes

- We were not passing the `ba_token` query parameter during the App Switch flow which is required

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
