### PR TITLE
[QL] Add `UILabel` with Token to Allow Troubleshooting for E2E Testing

### DIFF
--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -29,7 +29,7 @@ class PaymentButtonBaseViewController: BaseViewController {
             paymentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             paymentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             paymentButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            paymentButton.heightAnchor.constraint(equalToConstant: 100)
+            paymentButton.heightAnchor.constraint(equalToConstant: 150)
         ])
     }
 

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -7,13 +7,22 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     lazy var payPalClient = BTPayPalClient(apiClient: apiClient)
 
+    // TODO: remove UILabel before merging into main DTBTSDK-3766
+    let baTokenLabel = UILabel()
+
     override func createPaymentButton() -> UIView {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
         let payPalPayLaterButton = createButton(title: "PayPal with Pay Later Offered", action: #selector(tappedPayPalPayLater))
         let payPalAppSwitchButton = createButton(title: "PayPal App Switch Flow", action: #selector(tappedPayPalAppSwitchFlow))
 
-        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton, payPalAppSwitchButton]
+        // TODO: remove tapGesture before merging into main DTBTSDK-3766
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
+        baTokenLabel.isUserInteractionEnabled = true
+        baTokenLabel.addGestureRecognizer(tapGesture)
+        baTokenLabel.textColor = .systemPink
+
+        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton, payPalAppSwitchButton, baTokenLabel]
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.axis = .vertical
         stackView.alignment = .center
@@ -93,6 +102,15 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             enablePayPalAppSwitch: true,
             universalLink: URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
         )
+
+        // TODO: remove NotificationCenter before merging into main DTBTSDK-3766
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(receivedNotification),
+            name: Notification.Name("BAToken"),
+            object: nil
+        )
+
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
 
@@ -103,5 +121,20 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
             self.completionBlock(nonce)
         }
+    }
+
+    // TODO: remove labelTapped and receivedNotification before merging into main DTBTSDK-3766
+
+    @objc func labelTapped(sender: UITapGestureRecognizer) {
+        UIPasteboard.general.string = baTokenLabel.text
+    }
+
+    @objc func receivedNotification(_ notification: Notification) {
+        guard let baToken = notification.object else {
+            baTokenLabel.text = "No token returned"
+            return
+        }
+
+        baTokenLabel.text = "\(baToken)"
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -321,6 +321,9 @@ import BraintreeDataCollector
                 
                 self.payPalContextID = approvalURL.pairingID
 
+                // TODO: remove NotificationCenter before merging into main DTBTSDK-3766
+                NotificationCenter.default.post(name: Notification.Name("BAToken"), object: self.payPalContextID)
+
                 let dataCollector = BTDataCollector(apiClient: self.apiClient)
                 self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(approvalURL.pairingID)
                 


### PR DESCRIPTION
### Summary of changes

- Add `UILabel` with ec-token to allow troubleshooting for E2E testing
- NOTE: this will be removed before merging this feature into `main` - this is being added to allow for easier debugging from E2E testing teams

#### Visuals
https://github.com/braintree/braintree_ios/assets/20733831/b2d563b6-5257-424e-b87f-0071e54d63f0

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
