### PR TITLE
[QL] Allow Nonce to be Copied for E2E Testing

### DIFF
--- a/Demo/Application/Base/BaseViewController.swift
+++ b/Demo/Application/Base/BaseViewController.swift
@@ -5,6 +5,7 @@ class BaseViewController: UIViewController {
 
     var progressBlock: ((String?) -> Void) = { _ in }
     var completionBlock: ((BTPaymentMethodNonce?) -> Void) = { _ in }
+    var nonceCompletionBlock: ((BTPaymentMethodNonce?) -> Void) = { _ in }
 
     init(authorization: String) {
         super.init(nibName: nil, bundle: nil)

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -18,6 +18,7 @@ class ContainmentViewController: UIViewController {
             updateStatus("Presenting \(type(of: currentViewController))")
             currentViewController.progressBlock = progressBlock
             currentViewController.completionBlock = completionBlock
+            currentViewController.nonceCompletionBlock = nonceCompletionBlock
 
             appendViewController(currentViewController)
             title = currentViewController.title
@@ -40,6 +41,11 @@ class ContainmentViewController: UIViewController {
     func completionBlock(_ nonce: BTPaymentMethodNonce?) {
         currentPaymentMethodNonce = nonce
         updateStatus("Got a nonce. Tap to make a transaction.")
+    }
+
+    func nonceCompletionBlock(_ nonce: BTPaymentMethodNonce?) {
+        currentPaymentMethodNonce = nonce
+        updateStatus(currentPaymentMethodNonce?.nonce ?? "no nonce returned")
     }
 
     override func viewDidLoad() {
@@ -109,6 +115,12 @@ class ContainmentViewController: UIViewController {
 
         if let currentPaymentMethodNonce {
             let nonce = currentPaymentMethodNonce.nonce
+
+            if currentViewController?.nonceCompletionBlock != nil {
+                UIPasteboard.general.string = nonce
+                return
+            }
+
             updateStatus("Creating Transaction…")
 
             let merchantAccountID = currentPaymentMethodNonce.type == "UnionPay" ? "fake_switch_usd" : nil

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -31,6 +31,12 @@ class ContainmentViewController: UIViewController {
         }
     }
 
+    private var copiedNonce: BTPaymentMethodNonce? {
+        didSet {
+            statusItem?.isEnabled = (copiedNonce != nil)
+        }
+    }
+
     // MARK: - Progress and Completion Blocks
 
     func progressBlock(_ status: String?) {
@@ -44,8 +50,8 @@ class ContainmentViewController: UIViewController {
     }
 
     func nonceCompletionBlock(_ nonce: BTPaymentMethodNonce?) {
-        currentPaymentMethodNonce = nonce
-        updateStatus(currentPaymentMethodNonce?.nonce ?? "no nonce returned")
+        copiedNonce = nonce
+        updateStatus(copiedNonce?.nonce ?? "no nonce returned")
     }
 
     override func viewDidLoad() {
@@ -113,13 +119,13 @@ class ContainmentViewController: UIViewController {
     @objc private func tappedStatus() {
         print("Tapped status!")
 
+        if let copiedNonce {
+            UIPasteboard.general.string = copiedNonce.nonce
+            return
+        }
+
         if let currentPaymentMethodNonce {
             let nonce = currentPaymentMethodNonce.nonce
-
-            if currentViewController?.nonceCompletionBlock != nil {
-                UIPasteboard.general.string = nonce
-                return
-            }
 
             updateStatus("Creating Transaction…")
 

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -96,6 +96,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     }
 
     @objc func tappedPayPalAppSwitchFlow(_ sender: UIButton) {
+        sender.setTitle("Processing...", for: .disabled)
+        sender.isEnabled = false
+        
         let payPalClient = BTPayPalClient(apiClient: BTAPIClient(authorization: "sandbox_jy4fvpfg_v7x2rb226dx4pr7b")!)
         let request = BTPayPalVaultRequest(
             userAuthenticationEmail: "sally@gmail.com",
@@ -119,7 +122,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
                 return
             }
 
-            self.completionBlock(nonce)
+            self.nonceCompletionBlock(nonce)
         }
     }
 


### PR DESCRIPTION
### Summary of changes

For E2E testing our sample merchant server is not set up with the same credentials we are using for this flow. To avoid breaking all other flows, we want to be able to copy the nonce and add it to a postman request to make the transaction sale API call (this will be built out internally be another team).

- Add `nonceCompletionBlock`
    - When the status bar is tapped and this completion block is not nil we will copy this value just for this flow. All other flows will use their normal completion block and a transaction will be completed on tap of the status bar for those flows. Verified this in the demo app.

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
