### PR TITLE
Add `userAuthenticationEmail` to 1-Time Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Add BraintreeShopperInsights module (BETA)
   * Add PrivacyInfo.xcprivacy file
 * BraintreePayPal
-  * Add `BTPayPalRequest.userAuthenticationEmail` optional property
+  * Add `BTPayPalCheckoutRequest.userAuthenticationEmail` optional property
   
 ## 5.25.0 (2024-04-10)
 * Require Xcode 15.0+ and Swift 5.9+ (per [Apple App Store requirements](https://developer.apple.com/news/upcoming-requirements/?id=04292024a)) 

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -29,7 +29,7 @@ class PaymentButtonBaseViewController: BaseViewController {
             paymentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             paymentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             paymentButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            paymentButton.heightAnchor.constraint(equalToConstant: 100)
+            paymentButton.heightAnchor.constraint(equalToConstant: 300)
         ])
     }
 

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -5,21 +5,50 @@ import BraintreePayPal
 class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     lazy var payPalClient = BTPayPalClient(apiClient: apiClient)
+    
+    lazy var emailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Buyer email:"
+        return label
+    }()
+    
+    lazy var emailTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "placeholder@email.com"
+        textField.backgroundColor = .systemBackground
+        return textField
+    }()
+    
+    lazy var payLaterToggleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Offer Pay Later"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        return label
+    }()
+    
+    let payLaterToggle = UISwitch()
 
     override func createPaymentButton() -> UIView {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
-        let payPalPayLaterButton = createButton(title: "PayPal with Pay Later Offered", action: #selector(tappedPayPalPayLater))
 
-        let buttons = [payPalCheckoutButton, payPalVaultButton, payPalPayLaterButton]
-        let stackView = UIStackView(arrangedSubviews: buttons)
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .fillEqually
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let stackView = UIStackView(arrangedSubviews: [
+            UIStackView(arrangedSubviews: [emailLabel, emailTextField]),
+            buttonsStackView(label: "1-Time Checkout", views: [
+                UIStackView(arrangedSubviews: [payLaterToggleLabel, payLaterToggle]),
+                payPalCheckoutButton
+            ]),
+            buttonsStackView(label: "Vault",views: [payPalVaultButton])
+        ])
         
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 25
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }
+    
+    // MARK: - 1-Time Checkout Flows
 
     @objc func tappedPayPalCheckout(_ sender: UIButton) {
         progressBlock("Tapped PayPal - Checkout using BTPayPalClient")
@@ -27,11 +56,17 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.isEnabled = false
 
         let request = BTPayPalCheckoutRequest(amount: "5.00")
+        request.userAuthenticationEmail = emailTextField.text
+        
         let lineItem = BTPayPalLineItem(quantity: "1", unitAmount: "5.00", name: "item one 1234567", kind: .debit)
         lineItem.upcCode = "123456789"
         lineItem.upcType = .UPC_A
         lineItem.imageURL = URL(string: "https://www.example.com/example.jpg")
         request.lineItems = [lineItem]
+        
+        if payLaterToggle.isOn {
+            request.offerPayLater = true
+        }
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
@@ -44,13 +79,16 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             self.completionBlock(nonce)
         }
     }
-
+    
+    // MARK: - Vault Flows
+    
     @objc func tappedPayPalVault(_ sender: UIButton) {
         progressBlock("Tapped PayPal - Vault using BTPayPalClient")
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
 
         let request = BTPayPalVaultRequest()
+        request.userAuthenticationEmail = emailTextField.text
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
@@ -63,24 +101,21 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             self.completionBlock(nonce)
         }
     }
-
-    @objc func tappedPayPalPayLater(_ sender: UIButton) {
-        progressBlock("Tapped PayPal - initiating with Pay Later offered")
-        sender.setTitle("Processing...", for: .disabled)
-        sender.isEnabled = false
-
-        let request = BTPayPalCheckoutRequest(amount: "4.30")
-        request.offerPayLater = true
-
-        payPalClient.tokenize(request) { nonce, error in
-            sender.isEnabled = true
-
-            guard let nonce else {
-                self.progressBlock(error?.localizedDescription)
-                return
-            }
-
-            self.completionBlock(nonce)
-        }
+    
+    // MARK: - Helpers
+    
+    private func buttonsStackView(label: String, views: [UIView]) -> UIStackView {
+        let titleLabel = UILabel()
+        titleLabel.text = label
+        titleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        let buttonsStackView = UIStackView(arrangedSubviews: [titleLabel] + views)
+        buttonsStackView.axis = .vertical
+        buttonsStackView.distribution = .fillProportionally
+        buttonsStackView.backgroundColor = .systemGray6
+        buttonsStackView.layoutMargins = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+        buttonsStackView.isLayoutMarginsRelativeArrangement = true
+        
+        return buttonsStackView
     }
 }

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -64,9 +64,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         lineItem.imageURL = URL(string: "https://www.example.com/example.jpg")
         request.lineItems = [lineItem]
         
-        if payLaterToggle.isOn {
-            request.offerPayLater = true
-        }
+        request.offerPayLater = payLaterToggle.isOn
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
@@ -107,7 +105,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     private func buttonsStackView(label: String, views: [UIView]) -> UIStackView {
         let titleLabel = UILabel()
         titleLabel.text = label
-        titleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
+        titleLabel.font = .preferredFont(forTextStyle: .title3)
         
         let buttonsStackView = UIStackView(arrangedSubviews: [titleLabel] + views)
         buttonsStackView.axis = .vertical

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -81,6 +81,9 @@ import BraintreeCore
 
     /// Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement during checkout. Defaults to `false`.
     public var requestBillingAgreement: Bool
+    
+    /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    public var userAuthenticationEmail: String?
 
     // MARK: - Initializer
 
@@ -129,6 +132,10 @@ import BraintreeCore
 
         if currencyCode != nil {
             checkoutParameters["currency_iso_code"] = currencyCode
+        }
+        
+        if let userAuthenticationEmail {
+            checkoutParameters["payer_email"] = userAuthenticationEmail
         }
 
         if userAction != .none, var experienceProfile = baseParameters["experience_profile"] as? [String: Any] {

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -10,11 +10,6 @@ import BraintreePayPal
 
 /// Options for the PayPal Checkout flow.
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalCheckoutRequest {
-
-    // MARK: - Public Properties
-
-    /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    public var userAuthenticationEmail: String?
     
     // MARK: - Initializer
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -86,6 +86,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         request.requestBillingAgreement = true
         request.billingAgreementDescription = "description"
         request.userAction = .payNow
+        request.userAuthenticationEmail = "fake@email.com"
 
         let shippingAddress = BTPostalAddress()
         shippingAddress.streetAddress = "123 Main"
@@ -111,6 +112,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(parameters["postal_code"] as? String, "11111")
         XCTAssertEqual(parameters["country_code"] as? String, "US")
         XCTAssertEqual(parameters["recipient_name"] as? String, "Recipient")
+        XCTAssertEqual(parameters["payer_email"] as? String, "fake@email.com")
         XCTAssertEqual(parameters["request_billing_agreement"] as? Bool, true)
 
         guard let billingAgreementDetails = parameters["billing_agreement_details"] as? [String : String] else {


### PR DESCRIPTION
### Background

- See Android PR https://github.com/braintree/braintree_android/pull/978/files

### Summary of changes

- Add `userAuthenticationEmail` property to `BTPayPalCheckoutRequest`
- Expose text field for email in Demo
   - Cherry-picked demo app UI updates from this App Switch PR (https://github.com/braintree/braintree_ios/pull/1273)

### Demo UI

<img width="441" alt="Screenshot 2024-04-18 at 11 13 39 AM" src="https://github.com/braintree/braintree_ios/assets/35243507/dd41866f-7ddf-4a1e-8af7-2270050fbb24">


### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 

