### PR TITLE
Include Magnes Privacy Terms in BTDataCollector Privacy File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-
 * BraintreeDataCollector
   * Updates to ensure all relevant privacy disclosures are surfaced
   * Note on Privacy Term Duplication: Reports generated with Xcode 15.3 SPM will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+
+* BraintreeDataCollector
+  * Updates to ensure all relevant privacy disclosures are surfaced
+  * Note on Privacy Term Duplication: Reports generated with Xcode 15.3 SPM will
+    show some duplication of privacy terms
+
 ## 5.25.0 (2024-04-10)
 * Require Xcode 15.0+ and Swift 5.9+ (per [Apple App Store requirements](https://developer.apple.com/news/upcoming-requirements/?id=04292024a)) 
 * [Meets Apple's new Privacy Update requirements](https://developer.apple.com/news/?id=3d8a9yyh)

--- a/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
+++ b/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
@@ -6,6 +6,30 @@
 	<array>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePreciseLocation</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeDeviceID</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<false/>

--- a/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
+++ b/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
@@ -24,7 +24,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 		<dict>
@@ -36,7 +36,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 		<dict>

--- a/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
+++ b/Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
### Summary of changes

- Include `NSPrivacyCollectedDataTypePerformanceData` and` NSPrivacyCollectedDataTypePreciseLocation` and User Defaults in `BraintreeDataCollector` module that are not surfaced by static version of Magnes for older versions of Xcode and for Cocoapods integrations

Privacy report outputs

Cocoapods:
These two are identical, they display PPRiskMagnes privacy terms as BTDataCollector privacy items
- Xcode 15.3 Cocoapods (excluded Native Checkout because of pod install issue atm with it)
[sammy_coco_15_3_test1-PrivacyReport 2024-04-24 06-13-51.pdf](https://github.com/braintree/braintree_ios/files/15094754/sammy_coco_15_3_test1-PrivacyReport.2024-04-24.06-13-51.pdf)
- Xcode 15.2 Cocoapods (excluded Native Checkout because of pod install issue atm with it)
[sammy_coco_15_2_test1-PrivacyReport 2024-04-24 06-18-01.pdf](https://github.com/braintree/braintree_ios/files/15094808/sammy_coco_15_2_test1-PrivacyReport.2024-04-24.06-18-01.pdf)

SPM:
- Xcode 15.3 - Causes duplication of 2 privacy items for PPRiskMagnes and BTDataCollector modules
[vic_spm_test1-_15_3_PrivacyReport 2024-04-24 06-59-15.pdf](https://github.com/braintree/braintree_ios/files/15095426/vic_spm_test1-_15_3_PrivacyReport.2024-04-24.06-59-15.pdf)
- Xcode 15.2 - PPRiskMagnes privacy terms are shown as BTDataCollector privacy items without duplication
[vic_spm_test1_15_2-PrivacyReport 2024-04-24 07-22-25.pdf](https://github.com/braintree/braintree_ios/files/15095783/vic_spm_test1_15_2-PrivacyReport.2024-04-24.07-22-25.pdf)


### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
