### PR TITLE
Podspec change to incorporate PPRiskMagnes Privacy file into BTDataCollector 

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -50,7 +50,10 @@ Pod::Spec.new do |s|
     s.source_files = "Sources/BraintreeDataCollector/*.swift"
     s.dependency "Braintree/Core"
     s.vendored_frameworks = "Frameworks/XCFrameworks/PPRiskMagnes.xcframework"
-    s.resource_bundle = { "BraintreeDataCollector_PrivacyInfo" => "Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy"}
+    s.resource_bundle = {
+       "BraintreeDataCollector_PrivacyInfo" => "Sources/BraintreeDataCollector/PrivacyInfo.xcprivacy",
+       "PPRiskMagnes_PrivacyInfo" => "Frameworks/XCFrameworks/PPRiskMagnes.xcframework/ios-arm64/PPRiskMagnes.framework/PrivacyInfo.xcprivacy"
+    }
   end
 
   s.subspec "LocalPayment" do |s|


### PR DESCRIPTION
### Summary of changes

- Change Podspec file to incorporate PPriskMagnes Privacy Manifest file into BraintreeDataCollector's resource bundle

Xcode 15.3 output (excluded Native Checkout because of problems atm)
[sammy_coco_15_3_no_native_test1-PrivacyReport 2024-04-24 05-52-14.pdf](https://github.com/braintree/braintree_ios/files/15094518/sammy_coco_15_3_no_native_test1-PrivacyReport.2024-04-24.05-52-14.pdf)

Xcode 15.2 output (excluded Native Checkout because of problems atm) -> identical to Xcode 15.3
[sammy_coco_15_3_test1_no_native-PrivacyReport 2024-04-24 06-02-42.pdf](https://github.com/braintree/braintree_ios/files/15094615/sammy_coco_15_3_test1_no_native-PrivacyReport.2024-04-24.06-02-42.pdf)

As of now, Xocde 15.3 SPM generates PPRiskMagnes privacy items as expected as it is on main.
Xcode 15.2 SPM does not surface PPRiskManges privacy terms and adding this file path in
Package.swift for resource bundle does not add PPRiskMagnes privacy terms to BTDataCollector resource bundle.

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
