### PR TITLE
Fix millisecond timestamp rounding bug in analytics

### DIFF
--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -53,7 +53,7 @@ class BTAnalyticsService: Equatable {
         linkType: String? = nil,
         payPalContextID: String? = nil
     ) async {
-        let timestampInMilliseconds = UInt64(Date().timeIntervalSince1970 * 1000)
+        let timestampInMilliseconds = Int(round(Date().timeIntervalSince1970 * 1000))
         let event = FPTIBatchData.Event(
             correlationID: correlationID,
             errorDescription: errorDescription,


### PR DESCRIPTION
### Summary of changes

- Fix small bug where analytics timestamp was always rounding milliseconds up
- See same manual testing done in [this PR](https://github.com/braintree/braintree_ios/pull/1234#discussion_r1538054171)
    - Unit testing for this rounding IMO requires more trouble than it's worth (creating & injecting a mock of `Date`) 

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 