### PR TITLE
Add `scene(_:willConnectTo:options:)` to the MockVenmo App

### DIFF
--- a/Demo/MockVenmo/SceneDelegate.swift
+++ b/Demo/MockVenmo/SceneDelegate.swift
@@ -7,5 +7,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         AppSwitcher.openVenmoURL = URLContexts.first?.url
     }
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        let urlContexts = connectionOptions.urlContexts
+        AppSwitcher.openVenmoURL = urlContexts.first?.url
+    }
 }
 


### PR DESCRIPTION
### Summary of changes

- The UITs sometimes failed because the MockVenmo app was not running, causing `AppSwitcher. openVenmoURL` to be `nil`. This PR adds `scene(_:willConnectTo:options:)`. When the app is launched for the first time, it calls scene(_:willConnectTo:options:)

[Apple Docs:](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)
> If your app has opted into Scenes, and your app is not running, the system delivers the URL to the scene(_:willConnectTo:options:) delegate method after launch, and to scene(_:openURLContexts:) when your app opens a URL while running or suspended in memory.

### Checklist

- [ ] Added a changelog entry

### Authors

- @richherrera 
