### PR TITLE
Add universal link to Demo.entitlements

### DIFF
--- a/Demo/Demo.entitlements
+++ b/Demo/Demo.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mobile-sdk-demo-site-838cead5d3ab.herokuapp.com</string>
+	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.braintreepayments.apple-pay-demo.Braintree-Demo</string>


### PR DESCRIPTION
### Summary of changes

- Define Demo app associated domain for universal link switches
- Resources
    - See equivalent Android app link PR. This uses the same URL for both our Demo apps - https://github.com/braintree/braintree_android/pull/989
    - See similar iOS PR for app switch workstream - https://github.com/braintree/braintree_ios/pull/1205

### Video

https://github.com/braintree/braintree_ios/assets/35243507/1b34ec93-0c8a-42b1-ba19-d80bcdba4106



### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
