### PR TITLE
Update README - Added upgrade SDK message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Welcome to Braintree's iOS SDK. This library will help you accept card and alternative payments in your iOS app.
 
+📣 **Upgrade your integration to continue accepting Braintree payments** 📣 The SSL certificates for current iOS SDK versions (v5 and v6) are set to expire by June 31, 2025. Upgrade to v5.26.0+ and v6.17.0+, respectively, to continue using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_ios/issues/1277)
+
 v6 is the latest major version of Braintree iOS. To update from v5, see the [v6 migration guide](https://github.com/braintree/braintree_ios/blob/main/V6_MIGRATION.md). If you have not yet migrated to v5, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/5.x/V5_MIGRATION.md)
 
 **The Braintree iOS SDK permits a deployment target of iOS 14.0 or higher**. It requires Xcode 15.0+ and Swift 5.9+.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 Welcome to Braintree's iOS SDK. This library will help you accept card and alternative payments in your iOS app.
 
-📣 **Upgrade your integration to continue accepting Braintree payments** 📣 The SSL certificates for current iOS SDK versions (v5 and v6) are set to expire by June 31, 2025. Upgrade to v5.26.0+ and v6.17.0+, respectively, to continue using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_ios/issues/1277)
+## 📣 Announcements
 
-v6 is the latest major version of Braintree iOS. To update from v5, see the [v6 migration guide](https://github.com/braintree/braintree_ios/blob/main/V6_MIGRATION.md). If you have not yet migrated to v5, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/5.x/V5_MIGRATION.md)
+- **Upgrade your integration to continue accepting Braintree payments** 📣 The SSL certificates for current iOS SDK versions (v5 and v6) are set to expire by June 31, 2025. Upgrade to v5.26.0+ and v6.17.0+, respectively, to continue using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_ios/issues/1277)
+
+- v6 is the latest major version of Braintree iOS. To update from v5, see the [v6 migration guide](https://github.com/braintree/braintree_ios/blob/main/V6_MIGRATION.md). If you have not yet migrated to v5, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/5.x/V5_MIGRATION.md)
 
 **The Braintree iOS SDK permits a deployment target of iOS 14.0 or higher**. It requires Xcode 15.0+ and Swift 5.9+.
 


### PR DESCRIPTION
### Summary of changes

- Added info about upgrading Braintree SDK for latest SSL certs in README. This is because the Client Reference links to an external link for iOS. By updating the README, we can inform Merchant devs about the changes if they click on the reference links
<img width="309" alt="Screenshot 2024-05-06 at 7 10 15 PM" src="https://github.com/braintree/braintree_ios/assets/127455800/c6c29db2-ca5a-42ba-a31d-47bd4806637a">

https://braintree.github.io/braintree_ios/current/



### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 
