### PR TITLE
Added "Origami Checkout" to Web Checkout Flow

### DIFF
--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -28,6 +28,8 @@ import BraintreeCore
             userDefaults.set(BraintreeDemoAuthType.clientToken.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-TokenizationKey") {
             userDefaults.set(BraintreeDemoAuthType.tokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
+        } else if processInfoArgs.contains("-OrigamiTokenizationKey") {
+            userDefaults.set(BraintreeDemoAuthType.origamiTokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-MockedPayPalTokenizationKey") {
             userDefaults.set(BraintreeDemoAuthType.mockedPayPalTokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-UITestHardcodedClientToken") {

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -28,8 +28,8 @@ import BraintreeCore
             userDefaults.set(BraintreeDemoAuthType.clientToken.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-TokenizationKey") {
             userDefaults.set(BraintreeDemoAuthType.tokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
-        } else if processInfoArgs.contains("-OrigamiTokenizationKey") {
-            userDefaults.set(BraintreeDemoAuthType.origamiTokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
+        } else if processInfoArgs.contains("-NewPayPalCheckoutTokenizationKey") {
+            userDefaults.set(BraintreeDemoAuthType.newPayPalCheckoutTokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-MockedPayPalTokenizationKey") {
             userDefaults.set(BraintreeDemoAuthType.mockedPayPalTokenizationKey.rawValue, forKey: BraintreeDemoSettings.AuthorizationTypeDefaultsKey)
         } else if processInfoArgs.contains("-UITestHardcodedClientToken") {

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -176,10 +176,10 @@ class ContainmentViewController: UIViewController {
                 }
             }
 
-        case .origamiTokenizationKey:
+        case .newPayPalCheckoutTokenizationKey:
             updateStatus("Fetching new checkout token...")
-            let origamiTokenizationKey = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c"
-            currentViewController = instantiateViewController(with: origamiTokenizationKey)
+            let newPayPalCheckoutTokenizationKey = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c"
+            currentViewController = instantiateViewController(with: newPayPalCheckoutTokenizationKey)
 
         case .mockedPayPalTokenizationKey:
             let tokenizationKey = "sandbox_q7v35n9n_555d2htrfsnnmfb3"

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -177,7 +177,7 @@ class ContainmentViewController: UIViewController {
             }
 
         case .origamiTokenizationKey:
-            updateStatus("Fetching Origami Token...")
+            updateStatus("Fetching new checkout token...")
             let origamiTokenizationKey = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c"
             currentViewController = instantiateViewController(with: origamiTokenizationKey)
 

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -176,6 +176,11 @@ class ContainmentViewController: UIViewController {
                 }
             }
 
+        case .origamiTokenizationKey:
+            updateStatus("Fetching Origami Token...")
+            let origamiTokenizationKey = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c"
+            currentViewController = instantiateViewController(with: origamiTokenizationKey)
+
         case .mockedPayPalTokenizationKey:
             let tokenizationKey = "sandbox_q7v35n9n_555d2htrfsnnmfb3"
             currentViewController = instantiateViewController(with: tokenizationKey)

--- a/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
+++ b/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
@@ -11,7 +11,7 @@ enum BraintreeDemoEnvironment: Int {
 enum BraintreeDemoAuthType: Int {
     case clientToken
     case tokenizationKey
-    case origamiTokenizationKey
+    case newPayPalCheckoutTokenizationKey
     case mockedPayPalTokenizationKey
     case uiTestHardcodedClientToken
 }

--- a/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
+++ b/Demo/Application/Base/Settings/BraintreeDemoSettings.swift
@@ -11,6 +11,7 @@ enum BraintreeDemoEnvironment: Int {
 enum BraintreeDemoAuthType: Int {
     case clientToken
     case tokenizationKey
+    case origamiTokenizationKey
     case mockedPayPalTokenizationKey
     case uiTestHardcodedClientToken
 }

--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -91,7 +91,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>Origami Tokenization Key</string>
+				<string>New Checkout Tokenization Key</string>
 			</array>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsAuthorizationTypeKey</string>
@@ -101,7 +101,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>Origami Tokenization Key</string>
+				<string>New Checkout Tokenization Key</string>
 			</array>
 			<key>Values</key>
 			<array>

--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -91,7 +91,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>New Checkout Tokenization Key</string>
+				<string>New PayPal Checkout Tokenization Key</string>
 			</array>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsAuthorizationTypeKey</string>
@@ -101,7 +101,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>New Checkout Tokenization Key</string>
+				<string>New PayPal Checkout Tokenization Key</string>
 			</array>
 			<key>Values</key>
 			<array>

--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -91,6 +91,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
+				<string>Origami Tokenization Key</string>
 			</array>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsAuthorizationTypeKey</string>
@@ -100,11 +101,13 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
+				<string>Origami Tokenization Key</string>
 			</array>
 			<key>Values</key>
 			<array>
 				<integer>0</integer>
 				<integer>1</integer>
+				<integer>2</integer>
 			</array>
 		</dict>
 		<dict>

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -28,6 +28,15 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     
     let payLaterToggle = UISwitch()
 
+    lazy var origamiCheckoutToggleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Origami Checkout"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        return label
+    }()
+    
+    let origamiCheckoutToggle = UISwitch()
+
     override func createPaymentButton() -> UIView {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
@@ -36,6 +45,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             UIStackView(arrangedSubviews: [emailLabel, emailTextField]),
             buttonsStackView(label: "1-Time Checkout", views: [
                 UIStackView(arrangedSubviews: [payLaterToggleLabel, payLaterToggle]),
+                UIStackView(arrangedSubviews: [origamiCheckoutToggleLabel, origamiCheckoutToggle]),
                 payPalCheckoutButton
             ]),
             buttonsStackView(label: "Vault",views: [payPalVaultButton])
@@ -65,6 +75,10 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         request.lineItems = [lineItem]
         
         request.offerPayLater = payLaterToggle.isOn
+
+        if origamiCheckoutToggle.isOn {
+            request.intent = .sale
+        }
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -30,7 +30,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     lazy var origamiCheckoutToggleLabel: UILabel = {
         let label = UILabel()
-        label.text = "Origami Checkout"
+        label.text = "New PayPal Checkout"
         label.font = .preferredFont(forTextStyle: .footnote)
         return label
     }()
@@ -78,6 +78,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         if origamiCheckoutToggle.isOn {
             request.intent = .sale
+        } else {
+            request.intent = .authorize
         }
 
         payPalClient.tokenize(request) { nonce, error in

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -28,14 +28,14 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     
     let payLaterToggle = UISwitch()
 
-    lazy var origamiCheckoutToggleLabel: UILabel = {
+    lazy var newPayPalCheckoutToggleLabel: UILabel = {
         let label = UILabel()
-        label.text = "New PayPal Checkout"
+        label.text = "New PayPal Checkout Experience"
         label.font = .preferredFont(forTextStyle: .footnote)
         return label
     }()
     
-    let origamiCheckoutToggle = UISwitch()
+    let newPayPalCheckoutToggle = UISwitch()
 
     override func createPaymentButton() -> UIView {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
@@ -45,7 +45,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             UIStackView(arrangedSubviews: [emailLabel, emailTextField]),
             buttonsStackView(label: "1-Time Checkout", views: [
                 UIStackView(arrangedSubviews: [payLaterToggleLabel, payLaterToggle]),
-                UIStackView(arrangedSubviews: [origamiCheckoutToggleLabel, origamiCheckoutToggle]),
+                UIStackView(arrangedSubviews: [newPayPalCheckoutToggleLabel, newPayPalCheckoutToggle]),
                 payPalCheckoutButton
             ]),
             buttonsStackView(label: "Vault",views: [payPalVaultButton])
@@ -76,7 +76,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         
         request.offerPayLater = payLaterToggle.isOn
 
-        if origamiCheckoutToggle.isOn {
+        if newPayPalCheckoutToggle.isOn {
             request.intent = .sale
         } else {
             request.intent = .authorize

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -76,11 +76,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         
         request.offerPayLater = payLaterToggle.isOn
 
-        if newPayPalCheckoutToggle.isOn {
-            request.intent = .sale
-        } else {
-            request.intent = .authorize
-        }
+        request.intent = newPayPalCheckoutToggle.isOn ? .sale : .authorize
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true


### PR DESCRIPTION

This ticket allows for QA team to test the Origami Checkout flow. We want to add the tokenization key “sandbox_rz48bqvw_jcyycfw6f9j4nj9c" to launch the PayPal checkout Origami experience. To launch this, PayPal intent type must be “Sale”

This tokenization key should only be used when specified in settings (not new default tokenization key).

### Summary of changes

- Branched off of `payment-insights-feature`
- Added to Origami Tokenization Key to Authorization Type in Settings
- Added toggle switch for Origami XO experience to Web Checkout

### To Test
1. Settings: Integration > PayPal - Web Checkout, Authorization Type > Origami Tokenization Key
2. Buyer email (ex: jsdk@bt.com)
3. Toggle Origami Checkout to `on`
4. Tap "PayPal Checkout"

### Known Error
When Authorization Type is set to `Origami Tokenization Key`, there's a known error where HTTP POST request fails. This appears when tapping on `PayPalCheckout` Button, regardless of whether Origami Checkout or PayLater is switched on or off. **You need to enter a Buyer Email (ex: jsdk@bt.com) to before using any of the PayPal Checkout experiences.**

This error doesn't occur when using the other Authorization Types.

![simulator_screenshot_995BA9C5-B5B9-44EC-BBED-24DDFF82FA41](https://github.com/braintree/braintree_ios/assets/127455800/985d180a-577c-4211-ac2d-a025326f361f)

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 
