### PR TITLE
[QL] Don't Allow Empty String For `payer_email` in One-Time Checkout

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -134,7 +134,7 @@ import BraintreeCore
             checkoutParameters["currency_iso_code"] = currencyCode
         }
         
-        if let userAuthenticationEmail {
+        if let userAuthenticationEmail, !userAuthenticationEmail.isEmpty {
             checkoutParameters["payer_email"] = userAuthenticationEmail
         }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -159,4 +159,13 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertNil(parameters["request_billing_agreement"])
         XCTAssertNil(parameters["billing_agreement_details"])
     }
+    
+    func testParametersWithConfiguration_whenUserAuthenticationEmailNotSet_doesNotSetPayerEmailInRequest() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAuthenticationEmail = ""
+        
+        let parameters = request.parameters(with: configuration)
+        
+        XCTAssertNil(parameters["payer_email"])
+    }
 }


### PR DESCRIPTION
### Summary of changes

- If the `userAuthenticalEmail`, do not set the `payer_email` field in the `BTPayPalCheckoutRequest` for one-time checkout flows. 
- This change only applies to the one-time checkout flows and not the vault flows. 
- Relevant Ticket: [DTMOBILES-553](https://paypal.atlassian.net/browse/DTMOBILES-553)


### Checklist

- [ ]~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
