### PR TITLE
Bump MXO Version in `Package.resolved` To Resolve Docs Release Error

### DIFF
--- a/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "024ac5e55a2a469e348385c76e7e63f1e8eaca9804eefeb066d877c063895163",
   "pins" : [
     {
       "identity" : "paypalcheckout-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/paypal/paypalcheckout-ios/",
       "state" : {
-        "revision" : "f477176da4c6780c8586b493c604f0ab74d9be49",
-        "version" : "1.2.0"
+        "revision" : "da1b998dcab91011b05df139a6819cc58dd45ccd",
+        "version" : "1.3.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "024ac5e55a2a469e348385c76e7e63f1e8eaca9804eefeb066d877c063895163",
   "pins" : [
     {
       "identity" : "paypalcheckout-ios",
@@ -11,5 +10,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }


### PR DESCRIPTION
### Summary of changes

- The [docs portion of the release recently failed](https://github.com/braintree/braintree_ios/actions/runs/8972689186/job/24641227565) with the error: `Your local changes to the following files would be overwritten by checkout: Braintree.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- Opening `Braintree.xcodeproj` generates this update for us and should resolve the docs error next time we do a release

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
