### PR TITLE
Add Missing Docstrings to `sendAnalyticsEvent`

### DIFF
--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -24,9 +24,12 @@ class BTAnalyticsService: Equatable {
     /// - Parameters:
     ///   - eventName: Name of analytic event.
     ///   - correlationID: Optional. CorrelationID associated with the checkout session.
+    ///   - endpoint: Optional. The endpoint of the API request send during networking requests.
+    ///   - endTime: Optional. The end time of the roundtrip networking request.
     ///   - errorDescription: Optional. Full error description returned to merchant.
     ///   - linkType: Optional. The type of link the SDK will be handling, currently deeplink or universal.
     ///   - payPalContextID: Optional. PayPal Context ID associated with the checkout session.
+    ///   - startTime: Optional. The start time of the networking request.
     func sendAnalyticsEvent(
         _ eventName: String,
         correlationID: String? = nil,


### PR DESCRIPTION
### Summary of changes

- In PR #1292 I forgot to add the docstrings to `sendAnalyticsEvents`. This PR adds them. 😄 

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
