### PR TITLE
Remove unused `NSCopying` & `isEqual` conformance in `BTHTTP`

### DIFF
--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -2,7 +2,7 @@ import Foundation
 import Security
 
 /// Performs HTTP methods on the Braintree Client API
-class BTHTTP: NSObject, NSCopying, URLSessionTaskDelegate {
+class BTHTTP: NSObject, URLSessionTaskDelegate {
 
     typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
 
@@ -391,30 +391,6 @@ class BTHTTP: NSObject, NSCopying, URLSessionTaskDelegate {
         }
 
         return certificates
-    }
-
-    // MARK: - isEqual override
-    
-    override func isEqual(_ object: Any?) -> Bool {
-        guard object is BTHTTP,
-              let otherObject = object as? BTHTTP else {
-            return false
-        }
-
-        return baseURL == otherObject.baseURL && clientAuthorization == otherObject.clientAuthorization
-    }
-
-    // MARK: - NSCopying conformance
-
-    func copy(with zone: NSZone? = nil) -> Any {
-        switch clientAuthorization {
-        case .authorizationFingerprint(let fingerprint):
-            return BTHTTP(url: baseURL, authorizationFingerprint: fingerprint)
-        case .tokenizationKey(let key):
-            return BTHTTP(url: baseURL, tokenizationKey: key)
-        default:
-            return BTHTTP(url: baseURL)
-        }
     }
 
     // MARK: - URLSessionTaskDelegate conformance

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -865,3 +865,9 @@ final class BTHTTP_Tests: XCTestCase {
         completion()
     }
 }
+
+extension [String: Any] {
+    static func ==(lhs: [String: Any], rhs: [String: Any] ) -> Bool {
+        return NSDictionary(dictionary: lhs).isEqual(to: rhs)
+    }
+}

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -847,47 +847,6 @@ final class BTHTTP_Tests: XCTestCase {
         }
     }
 
-    // MARK: - IsEqual tests
-
-    func testReturnsTrueIfBTHTTPsHaveTheSameBaseURLAndAuthorizationFingerprint() {
-        let baseURL: URL = URL(string: "an-url://hi")!
-        let authorizationFingerprint: String = "test-authorization-fingerprint"
-        let http1: BTHTTP = BTHTTP(url: baseURL, authorizationFingerprint: authorizationFingerprint)
-        let http2: BTHTTP = BTHTTP(url: baseURL, authorizationFingerprint: authorizationFingerprint)
-        XCTAssertEqual(http1, http2)
-    }
-
-    func testReturnsFalseIfBTHTTPsDoNotHaveTheSameBaseURL() {
-        let baseURL1: URL = URL(string: "an-url://hi")!
-        let baseURL2: URL = URL(string: "an-url://hi-again")!
-        let authorizationFingerprint: String = "test-authorization-fingerprint"
-        let http1: BTHTTP = BTHTTP(url: baseURL1, authorizationFingerprint: authorizationFingerprint)
-        let http2: BTHTTP = BTHTTP(url: baseURL2, authorizationFingerprint: authorizationFingerprint)
-        XCTAssertNotEqual(http1, http2)
-    }
-
-    func testReturnsFalseIfBTHTTPsDoNotHaveTheSameAuthorizationFingerprint() {
-        let baseURL: URL = URL(string: "an-url://hi")!
-        let authorizationFingerprint1: String = "test-authorization-fingerprint"
-        let authorizationFingerprint2: String = "OTHER"
-        let http1: BTHTTP = BTHTTP(url: baseURL, authorizationFingerprint: authorizationFingerprint1)
-        let http2: BTHTTP = BTHTTP(url: baseURL, authorizationFingerprint: authorizationFingerprint2)
-        XCTAssertNotEqual(http1, http2)
-    }
-
-    // MARK: - Copy tests
-
-    func testReturnsAnEqualInstance() {
-        http = BTHTTP(url: BTHTTPTestProtocol.testBaseURL(), authorizationFingerprint: "test-authorization-fingerprint")
-        XCTAssertEqual(http, http?.copy() as? BTHTTP)
-    }
-
-    func testReturnedInstanceHasTheSameCertificates() {
-        http = BTHTTP(url: BTHTTPTestProtocol.testBaseURL(), authorizationFingerprint: "test-authorization-fingerprint")
-        let copiedHTTP = http?.copy() as? BTHTTP
-        XCTAssertEqual(http?.pinnedCertificates, copiedHTTP?.pinnedCertificates)
-    }
-
     // MARK: - Helper Methods
 
     func withStub(_ completion: () -> Void) {
@@ -904,11 +863,5 @@ final class BTHTTP_Tests: XCTestCase {
 
         HTTPStubs.removeStub(stub)
         completion()
-    }
-}
-
-extension [String: Any] {
-    static func ==(lhs: [String: Any], rhs: [String: Any] ) -> Bool {
-        return NSDictionary(dictionary: lhs).isEqual(to: rhs)
     }
 }


### PR DESCRIPTION
### Summary of changes

- Remove `NSCopying` conformance in `BTHTTP` & specific unit tests
- Remove `isEqual` override in `BTHTTP` & specifici unit tests

### Note

I did not see anywhere these 2 conformances were actually used by the SDK. 

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
