### PR TITLE
[QL] Investigate Triple v1/config call

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -39,7 +39,7 @@ import Foundation
 
     private static var _analyticsService: BTAnalyticsService?
     private var isLoadingConfig: Bool = false
-    private var fetchConfigQueue: DispatchQueue = DispatchQueue(label: "configQueue", attributes: .concurrent)
+    private var fetchConfigQueue: DispatchQueue = DispatchQueue(label: "configQueue")
     private var configCompletionHandlers: [(BTConfiguration?, Error?) -> Void] = []
 
     // MARK: - Initializers

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -96,6 +96,31 @@ class BTAPIClient_Tests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    func testFetchOrReturnRemoteConfiguration_with_multiple_calls() {
+
+        let mockHTTP = FakeHTTP.fakeHTTP()
+
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
+        apiClient?.configurationHTTP = mockHTTP
+
+        let expectation = expectation(description: "Callback invoked")
+        expectation.expectedFulfillmentCount = 3
+
+        apiClient?.fetchOrReturnRemoteConfiguration() { configuration, error in
+            expectation.fulfill()
+        }
+
+        apiClient?.fetchOrReturnRemoteConfiguration() { configuration, error in
+            expectation.fulfill()
+        }
+
+        apiClient?.fetchOrReturnRemoteConfiguration() { configuration, error in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(mockHTTP.GETRequestCount, 1)
+    }
+
     func testAPIClient_canGetRemoteConfiguration() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
         let mockHTTP = FakeHTTP.fakeHTTP()


### PR DESCRIPTION
### Description
The SDK is sometimes making 3 sequential network calls to `v1/configuration`. This only happens when you create an APIClient, PayPalClient, and then tokenize() all immediately in sequence of one another (on button click).
Technically, our docs snippet shows instantiating the BTAPIClient earlier than button click (ex: viewDidLoad). But ideally our SDK can be more performant if merchants aren’t reading our docs. Also, our docs can better call out this recommendation.

I  was able to reproduce this issue by instantiating `APIClient` immediately prior to checkout flow. 
If the configuration is not cached from earlier instantiation of` APIClient`, `APIClient`  instantiation, `tokenize` call and `sendAnalyticsEvent` try to call `v1/configuration` endpoint since network calls are made in quick succession asynchronously without configuration having been added to cache yet.

This is what I saw:
- BTAPIClient init, `fetchOrGetRemoteConfiguration` about to be called
- bypassed cache (from BTAPIClient instantiation)
- called sendAnalyticsEvent => PayPal:tokenize:started
- bypassed cache (from calls inside sendAnalyticsEvent to fetchOrReturn function)
- bypassed cache (from call to fetchOrReturn in tokenize function)

I considered using actor for `ConfigurationCache` but I don't know of a way of handling this in conjunction
with `BTHTTP` get call in the `fetchOrGetRemoteConfiguration` function which returns via completion handler and
is utilized throughout the code base. Also, the issue is that network calls get made in quick succession before result is written into the cache (this only happens if merchants don't adhere to our recommendation of instantiating `BTAPIClient` early on in their application), so having serialized access in the `ConfigurationCache` would not solve the issue.

I went the route of adding a loading state for `v1/configuration` and adding completion handlers if more calls were made
during loading state and on network call return, returning the same result to completion handlers in the array of completion handlers.

[Commit 2](e703302d889f4f35d740b27da5d016eca4f07da3), I considered just putting sync serial queue around just cache writes but realized that the mutable properties like array and isLoading state were not thread safe.

[Commit 3](3d735fbb9d476a340f5f9416550a9ca1c50970ed) I used concurrent queue for outer block of `fetchOrGetRemoteConfiguration` function (for concurrent reads since it should only write into cache one time during session) and barrier option for tasks that any write to mutable properties

TODO: 
- Examine failing unit tests
- Check out if commit 3 works with wrapping in async await checked continuation for [Jax's PR on batched analytics](https://github.com/braintree/braintree_ios/pull/1295) ✅
Commit 3 worked fine with Jax's PR which wraps fetchOrReturnRemoteConfiguration function in async await for Venmo, ApplePay, PayPal Web checkout features in demo app

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
