### PR TITLE
[QL] Replace App Switch Universal Link URL

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -124,7 +124,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let request = BTPayPalVaultRequest(
             userAuthenticationEmail: userEmail,
             enablePayPalAppSwitch: true,
-            universalLink: URL(string: "https://braintree-ios-demo.fly.dev/braintree-payments")!
+            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
         )
 
         // TODO: remove NotificationCenter before merging into main DTBTSDK-3766

--- a/Demo/Demo.entitlements
+++ b/Demo/Demo.entitlements
@@ -4,7 +4,6 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:braintree-ios-demo.fly.dev</string>
 		<string>applinks:mobile-sdk-demo-site-838cead5d3ab.herokuapp.com</string>
 	</array>
 	<key>com.apple.developer.in-app-payments</key>


### PR DESCRIPTION
### Summary of changes

- Replace app switch Universal Link URL with Heroku site URL - verified that app Switch still works as expected with the new URL

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 