### PR TITLE
Add isEligibleInPayPalNetwork Check to ShopperInsightsResult

### DIFF
--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -112,7 +112,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         Task {
             do {
                 let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request)
-                self.progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)")
+                self.progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nIsInPayPalNetwork: \(result.isInPayPalNetwork)")
                 self.payPalVaultButton.isEnabled = result.isPayPalRecommended
                 self.venmoButton.isEnabled = result.isVenmoRecommended
             } catch {

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -112,7 +112,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         Task {
             do {
                 let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request)
-                self.progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nIsInPayPalNetwork: \(result.isInPayPalNetwork)")
+                self.progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nEligible in PayPal Network: \(result.isEligibleInPayPalNetwork)")
                 self.payPalVaultButton.isEnabled = result.isPayPalRecommended
                 self.venmoButton.isEnabled = result.isVenmoRecommended
             } catch {

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -53,30 +53,14 @@ public class BTShopperInsightsClient {
             }
             let eligiblePaymentMethods = BTEligiblePaymentMethods(json: json)
             let result = BTShopperInsightsResult(
-                isPayPalRecommended: isPaymentRecommended(eligiblePaymentMethods.paypal),
-                isVenmoRecommended: isPaymentRecommended(eligiblePaymentMethods.venmo),
-                isInPayPalNetwork: isEligibleInPaypalNetwork(eligiblePaymentMethods.paypal) || isEligibleInPaypalNetwork(eligiblePaymentMethods.venmo)
+                isPayPalRecommended: eligiblePaymentMethods.paypal?.recommended ?? false,
+                isVenmoRecommended: eligiblePaymentMethods.venmo?.recommended ?? false,
+                isEligibleInPayPalNetwork: eligiblePaymentMethods.paypal?.eligibleInPaypalNetwork ?? false || eligiblePaymentMethods.venmo?.eligibleInPaypalNetwork ?? false
             )
             return self.notifySuccess(with: result)
         } catch {
             throw self.notifyFailure(with: error)
         }
-    }
-    
-    /// This method determines whether a payment source is recommended
-    /// - Parameters:
-    ///    - paymentMethodDetail: a `BTEligiblePaymentMethodDetails` containing the payment source's information
-    /// - Returns: `true` if both `eligibleInPPNetwork` and `recommended` are enabled, otherwise returns false.
-    private func isPaymentRecommended(_ paymentMethodDetail: BTEligiblePaymentMethodDetails?) -> Bool {
-        if let eligibleInPPNetwork = paymentMethodDetail?.eligibleInPaypalNetwork,
-           let recommended = paymentMethodDetail?.recommended {
-            return eligibleInPPNetwork && recommended
-        }
-        return false
-    }
-    
-    private func isEligibleInPaypalNetwork(_ paymentMethodDetails: BTEligiblePaymentMethodDetails?) -> Bool {
-        return paymentMethodDetails?.eligibleInPaypalNetwork ?? false
     }
 
     /// Call this method when the PayPal button has been successfully displayed to the buyer.

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -55,7 +55,7 @@ public class BTShopperInsightsClient {
             let result = BTShopperInsightsResult(
                 isPayPalRecommended: isPaymentRecommended(eligiblePaymentMethods.paypal),
                 isVenmoRecommended: isPaymentRecommended(eligiblePaymentMethods.venmo),
-                isInPayPalNetwork: isEligibleInPaypalNetwork(eligiblePaymentMethods.paypal)
+                isInPayPalNetwork: isEligibleInPaypalNetwork(eligiblePaymentMethods.paypal) || isEligibleInPaypalNetwork(eligiblePaymentMethods.venmo)
             )
             return self.notifySuccess(with: result)
         } catch {

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -54,7 +54,8 @@ public class BTShopperInsightsClient {
             let eligiblePaymentMethods = BTEligiblePaymentMethods(json: json)
             let result = BTShopperInsightsResult(
                 isPayPalRecommended: isPaymentRecommended(eligiblePaymentMethods.paypal),
-                isVenmoRecommended: isPaymentRecommended(eligiblePaymentMethods.venmo)
+                isVenmoRecommended: isPaymentRecommended(eligiblePaymentMethods.venmo),
+                isInPayPalNetwork: isEligibleInPaypalNetwork(eligiblePaymentMethods.paypal)
             )
             return self.notifySuccess(with: result)
         } catch {
@@ -72,6 +73,10 @@ public class BTShopperInsightsClient {
             return eligibleInPPNetwork && recommended
         }
         return false
+    }
+    
+    private func isEligibleInPaypalNetwork(_ paymentMethodDetails: BTEligiblePaymentMethodDetails?) -> Bool {
+        return paymentMethodDetails?.eligibleInPaypalNetwork ?? false
     }
 
     /// Call this method when the PayPal button has been successfully displayed to the buyer.

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsResult.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsResult.swift
@@ -11,5 +11,5 @@ public struct BTShopperInsightsResult {
     public var isVenmoRecommended = false
     
     /// If true, buyer is a member of the PayPal Inc. (PayPal, Venmo, Honey) network. 
-    public var isInPayPalNetwork = false
+    public var isEligibleInPayPalNetwork = false
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsResult.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsResult.swift
@@ -9,4 +9,7 @@ public struct BTShopperInsightsResult {
     
     /// If true, dislpay the Venmo button with high priority.
     public var isVenmoRecommended = false
+    
+    /// If true, buyer is a member of the PayPal Inc. (PayPal, Venmo, Honey) network. 
+    public var isInPayPalNetwork = false
 }


### PR DESCRIPTION
### Summary of changes

- Creates and adds the `isEligibleInPayPalNetwork` check to the `ShopperInsightsResult` object to determine whether the buyer is a member of the PayPal network [including PayPal, Venmo, Honey]. 
- Adds the corresponding unit tests 
-  Refactors the original logic to determine button recommendation to read directly from the response object.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
