### PR TITLE
[QL] Remove `NotificationCenter` and `nonceCompletionBlock` - Previously Added for Stage Testing

### DIFF
--- a/Demo/Application/Base/BaseViewController.swift
+++ b/Demo/Application/Base/BaseViewController.swift
@@ -5,7 +5,6 @@ class BaseViewController: UIViewController {
 
     var progressBlock: ((String?) -> Void) = { _ in }
     var completionBlock: ((BTPaymentMethodNonce?) -> Void) = { _ in }
-    var nonceCompletionBlock: ((BTPaymentMethodNonce?) -> Void) = { _ in }
 
     init(authorization: String) {
         super.init(nibName: nil, bundle: nil)

--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -18,7 +18,6 @@ class ContainmentViewController: UIViewController {
             updateStatus("Presenting \(type(of: currentViewController))")
             currentViewController.progressBlock = progressBlock
             currentViewController.completionBlock = completionBlock
-            currentViewController.nonceCompletionBlock = nonceCompletionBlock
 
             appendViewController(currentViewController)
             title = currentViewController.title
@@ -28,12 +27,6 @@ class ContainmentViewController: UIViewController {
     private var currentPaymentMethodNonce: BTPaymentMethodNonce? {
         didSet {
             statusItem?.isEnabled = (currentPaymentMethodNonce != nil)
-        }
-    }
-
-    private var copiedNonce: BTPaymentMethodNonce? {
-        didSet {
-            statusItem?.isEnabled = (copiedNonce != nil)
         }
     }
 
@@ -47,11 +40,6 @@ class ContainmentViewController: UIViewController {
     func completionBlock(_ nonce: BTPaymentMethodNonce?) {
         currentPaymentMethodNonce = nonce
         updateStatus("Got a nonce. Tap to make a transaction.")
-    }
-
-    func nonceCompletionBlock(_ nonce: BTPaymentMethodNonce?) {
-        copiedNonce = nonce
-        updateStatus(copiedNonce?.nonce ?? "no nonce returned")
     }
 
     override func viewDidLoad() {
@@ -118,12 +106,6 @@ class ContainmentViewController: UIViewController {
 
     @objc private func tappedStatus() {
         print("Tapped status!")
-
-        if let copiedNonce {
-            UIPasteboard.general.string = copiedNonce.nonce
-            self.copiedNonce = nil
-            return
-        }
 
         if let currentPaymentMethodNonce {
             let nonce = currentPaymentMethodNonce.nonce

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -23,20 +23,11 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     let appSwitchStageToggle = UISwitch()
 
-    // TODO: remove UILabel before merging into main DTBTSDK-3766
-    let baTokenLabel = UILabel()
-
     override func createPaymentButton() -> UIView {
         let payPalCheckoutButton = createButton(title: "PayPal Checkout", action: #selector(tappedPayPalCheckout))
         let payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(tappedPayPalVault))
         let payPalPayLaterButton = createButton(title: "PayPal with Pay Later Offered", action: #selector(tappedPayPalPayLater))
         let payPalAppSwitchButton = createButton(title: "PayPal App Switch", action: #selector(tappedPayPalAppSwitch))
-
-        // TODO: remove tapGesture before merging into main DTBTSDK-3766
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
-        baTokenLabel.isUserInteractionEnabled = true
-        baTokenLabel.addGestureRecognizer(tapGesture)
-        baTokenLabel.textColor = .systemPink
 
         let stackView = UIStackView(arrangedSubviews: [
             buttonsStackView(label: "1-Time Checkout Flows", views: [payPalCheckoutButton, payPalPayLaterButton]),
@@ -48,8 +39,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
                     payPalAppSwitchButton,
                     UIStackView(arrangedSubviews: [appSwitchStageToggleLabel, appSwitchStageToggle])
                 ]
-            ),
-            baTokenLabel
+            )
         ])
         
         stackView.axis = .vertical
@@ -143,14 +133,6 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
         )
 
-        // TODO: remove NotificationCenter before merging into main DTBTSDK-3766
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(receivedNotification),
-            name: Notification.Name("BAToken"),
-            object: nil
-        )
-
         if appSwitchStageToggle.isOn {
             let stagePayPalClient = BTPayPalClient(apiClient: BTAPIClient(authorization: "sandbox_jy4fvpfg_v7x2rb226dx4pr7b")!)
 
@@ -162,7 +144,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
                     return
                 }
 
-                self.nonceCompletionBlock(nonce)
+                self.completionBlock(nonce)
             }
         } else {
             payPalClient.tokenize(request) { nonce, error in
@@ -192,20 +174,5 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         buttonsStackView.isLayoutMarginsRelativeArrangement = true
         
         return buttonsStackView
-    }
-
-    // TODO: remove labelTapped and receivedNotification before merging into main DTBTSDK-3766
-
-    @objc func labelTapped(sender: UITapGestureRecognizer) {
-        UIPasteboard.general.string = baTokenLabel.text
-    }
-
-    @objc func receivedNotification(_ notification: Notification) {
-        guard let baToken = notification.object else {
-            baTokenLabel.text = "No token returned"
-            return
-        }
-
-        baTokenLabel.text = "\(baToken)"
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -331,9 +331,6 @@ import BraintreeDataCollector
                 
                 self.payPalContextID = approvalURL.baToken ?? approvalURL.ecToken
 
-                // TODO: remove NotificationCenter before merging into main DTBTSDK-3766
-                NotificationCenter.default.post(name: Notification.Name("BAToken"), object: self.payPalContextID)
-
                 let dataCollector = BTDataCollector(apiClient: self.apiClient)
                 self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.payPalContextID)
 


### PR DESCRIPTION
### Summary of changes

- Remove posting BA token via `NotificationCenter` - this was added for testing, as we prepare for release we need to remove this logic
- Remove `nonceCompletionBlock` logic - this was added for testing since stage does not work with our sample merchant server, now that we have moved to sand/prod testing we can remove this logic
    - Note: this PR still leaves the stage toggle, but that will be cleaned up in a follow up PR once we have confirmed sand/prod testing works for the broader group, currently it is only working for a few people

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
