### PR TITLE
Update existing PayPalMessagingView

### DIFF
--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -11,7 +11,7 @@ import BraintreeCore
 public class BTPayPalMessagingView: UIView {
 
     // MARK: - Properties
-    
+
     public weak var delegate: BTPayPalMessagingDelegate?
 
     var messageView: PayPalMessageView?

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -12,6 +12,8 @@ public class BTPayPalMessagingView: UIView {
 
     // MARK: - Properties
 
+    private var messageView: PayPalMessageView?
+    
     public weak var delegate: BTPayPalMessagingDelegate?
 
     var apiClient: BTAPIClient
@@ -72,16 +74,26 @@ public class BTPayPalMessagingView: UIView {
                 )
             )
 
-            let messageView = PayPalMessageView(config: messageConfig, stateDelegate: self, eventDelegate: self)
-            messageView.translatesAutoresizingMaskIntoConstraints = false
-            self.addSubview(messageView)
-
+            self.setupMessageView(withConfig: messageConfig)
+        }
+    }
+    
+    private func setupMessageView(withConfig config: PayPalMessageConfig) {
+        if let messageView {
+            messageView.setConfig(config)
+        } else {
+            let payPalMessageView = PayPalMessageView(config: config, stateDelegate: self, eventDelegate: self)
+            payPalMessageView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(payPalMessageView)
+            
             NSLayoutConstraint.activate([
-                messageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-                messageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-                messageView.topAnchor.constraint(equalTo: self.topAnchor),
-                messageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                payPalMessageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                payPalMessageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                payPalMessageView.topAnchor.constraint(equalTo: topAnchor),
+                payPalMessageView.bottomAnchor.constraint(equalTo: bottomAnchor)
             ])
+            
+            messageView = payPalMessageView
         }
     }
 

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -11,11 +11,10 @@ import BraintreeCore
 public class BTPayPalMessagingView: UIView {
 
     // MARK: - Properties
-
-    private var messageView: PayPalMessageView?
     
     public weak var delegate: BTPayPalMessagingDelegate?
 
+    var messageView: PayPalMessageView?
     var apiClient: BTAPIClient
 
     // MARK: - Initializers
@@ -79,11 +78,11 @@ public class BTPayPalMessagingView: UIView {
                 )
             )
 
-            self.setupMessageView(withConfig: messageConfig)
+            self.setupMessageView(with: messageConfig)
         }
     }
     
-    private func setupMessageView(withConfig config: PayPalMessageConfig) {
+    private func setupMessageView(with config: PayPalMessageConfig) {
         if let messageView {
             messageView.setConfig(config)
         } else {

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -72,6 +72,8 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         
         let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
         payPalMessageView.delegate = mockDelegate
+        XCTAssertEqual(payPalMessageView.subviews.count, 0)
+        
         payPalMessageView.start()
         
         XCTAssertTrue(mockDelegate.willAppear)

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -62,4 +62,26 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         XCTAssertTrue(mockDelegate.willAppear)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
     }
+    
+    func testStart_withClientID_callingMultipleTimes_doesNotIncreaseNumberOfSubviews() {
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(
+            value: [
+                "paypal": ["clientId": "a-fake-client-id"]
+            ] as [String: Any?]
+        )
+        
+        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        payPalMessageView.delegate = mockDelegate
+        payPalMessageView.start()
+        
+        XCTAssertTrue(mockDelegate.willAppear)
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
+        XCTAssertEqual(payPalMessageView.subviews.count, 1)
+
+        payPalMessageView.start()
+        
+        XCTAssertTrue(mockDelegate.willAppear)
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
+        XCTAssertEqual(payPalMessageView.subviews.count, 1)
+    }
 }


### PR DESCRIPTION
### Summary of changes

- This PR allows merchants to pass a new `BTPayPalMessagingRequest` and update the view. 
- `PayPalMessageView.init` is called on first load and `PayPalMessageView.setConfig` on subsequent loads using the same `PayPalMessageView`.

https://github.com/braintree/braintree_ios/assets/149086692/ee9e495c-f82f-4e14-a77e-0cc63c266c82

### Checklist

- [ ] Added a changelog entry

### Authors

- @richherrera 
