### PR TITLE
[QL] Measure API Request Latency for all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-* Send `start_time`, `end_time`, and `endpoint` to FPTI for tracking API request latency
 * BraintreeCore
   * Batch analytics events to FPTI
+  * Send `start_time`, `end_time`, and `endpoint` to FPTI for tracking API request latency
 
 ## 6.18.2 (2024-05-15)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* Send `start_time`, `end_time`, and `endpoint` to FPTI for tracking API request latency
 * BraintreeCore
   * Batch analytics events to FPTI
 

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -19,10 +19,6 @@ import Foundation
     /// Client metadata that is used for tracking the client session
     public private(set) var metadata: BTClientMetadata
 
-    /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    @_documentation(visibility: private)
-    public var shouldSendAPIRequestLatency: Bool = false
-
     // MARK: - Internal Properties
     
     var configurationHTTP: BTHTTP?
@@ -510,7 +506,7 @@ import Foundation
     func fetchAPITiming(path: String, startTime: Int, endTime: Int) {
         let cleanedPath = path.replacingOccurrences(of: "/merchants/([A-Za-z0-9]+)/client_api", with: "", options: .regularExpression)
 
-        if (shouldSendAPIRequestLatency || path.contains("v1/configuration")) && cleanedPath != "/v1/tracking/batch/events" {
+        if cleanedPath != "/v1/tracking/batch/events" {
             analyticsService?.sendAnalyticsEvent(
                 BTCoreAnalytics.apiRequestLatency,
                 endpoint: cleanedPath,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -498,6 +498,8 @@ import Foundation
             } else if let tokenizationKey, let graphQLBaseURL {
                 graphQLHTTP = BTGraphQLHTTP(url: graphQLBaseURL, tokenizationKey: tokenizationKey)
             }
+            
+            graphQLHTTP?.networkTimingDelegate = self
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -48,8 +48,6 @@ import BraintreeDataCollector
     /// - Parameter apiClient: The API Client
     @objc(initWithAPIClient:)
     public init(apiClient: BTAPIClient) {
-        apiClient.shouldSendAPIRequestLatency = true
-
         self.apiClient = apiClient
         self.webAuthenticationSession = BTWebAuthenticationSession()
 

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -428,7 +428,6 @@ class BTAPIClient_Tests: XCTestCase {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
         let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
         apiClient.analyticsService = mockAnalyticsService
-        apiClient.shouldSendAPIRequestLatency = true
 
         apiClient.fetchAPITiming(path: "/v1/tracking/batch/events", startTime: 12345678, endTime: 0987654)
 
@@ -436,16 +435,15 @@ class BTAPIClient_Tests: XCTestCase {
         XCTAssertNil(mockAnalyticsService.endpoint)
     }
 
-    func testFetchAPITiming_whenShouldSendAPIRequestLatencyIsFalse_doesNotSendLatencyEvent() {
+    func testFetchAPITiming_whenPathIsNotBatchEvents_sendLatencyEvent() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
         let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
         apiClient.analyticsService = mockAnalyticsService
-        apiClient.shouldSendAPIRequestLatency = false
 
         apiClient.fetchAPITiming(path: "/merchants/1234567890/client_api/v1/paypal_hermes/create_payment_resource", startTime: 12345678, endTime: 0987654)
 
-        XCTAssertNil(mockAnalyticsService.lastEvent)
-        XCTAssertNil(mockAnalyticsService.endpoint)
+        XCTAssertEqual(mockAnalyticsService.lastEvent, "core:api-request-latency")
+        XCTAssertEqual(mockAnalyticsService.endpoint, "/v1/paypal_hermes/create_payment_resource")
     }
 
     // MARK: - Client SDK Metadata

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -59,10 +59,6 @@ class BTPayPalClient_Tests: XCTestCase {
         self.waitForExpectations(timeout: 1)
     }
 
-    func testInitBTPayPalClient_setsShouldSendAPIRequestLatencyOnBTAPIClient() {
-        XCTAssertTrue(payPalClient.apiClient.shouldSendAPIRequestLatency)
-    }
-
     // MARK: - POST request to Hermes endpoint
 
     func testTokenizePayPalAccount_checkout_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {


### PR DESCRIPTION
### Summary of changes

- Send `start_time`, `end_time`, and `endpoint` to FPTI for tracking API request latency for all modules
- Update `UnitTests`

### Checklist

- [x] Added a changelog entry

### Authors

- @richherrera  
