### PR TITLE
Fix PayPal Unit Tests

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -123,8 +123,8 @@ import BraintreeDataCollector
         _ request: BTPayPalCheckoutRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        tokenize(request: request, completion: completion)
         isVaultRequest = false
+        tokenize(request: request, completion: completion)
     }
 
     /// Tokenize a PayPal request to be used with the PayPal Checkout or Pay Later flow.

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -19,6 +19,7 @@ class BTPayPalClient_Tests: XCTestCase {
             "paymentResource": ["redirectUrl": "http://fakeURL.com"]
         ])
         payPalClient = BTPayPalClient(apiClient: mockAPIClient)
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
     }
 
     func testTokenizePayPalAccount_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
@@ -220,8 +221,6 @@ class BTPayPalClient_Tests: XCTestCase {
             ]
         ])
 
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
-
         let request = BTPayPalCheckoutRequest(amount: "1")
         payPalClient.tokenize(request) { _, _ in }
 
@@ -234,8 +233,6 @@ class BTPayPalClient_Tests: XCTestCase {
                 "redirectUrl": "https://www.paypal.com/checkout?token="
             ]
         ])
-
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
 
         let request = BTPayPalCheckoutRequest(amount: "1")
         payPalClient.tokenize(request) { _, _ in }
@@ -250,8 +247,6 @@ class BTPayPalClient_Tests: XCTestCase {
             ]
         ])
 
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
-
         let request = BTPayPalCheckoutRequest(amount: "1")
         payPalClient.tokenize(request) { _, _ in }
 
@@ -265,7 +260,6 @@ class BTPayPalClient_Tests: XCTestCase {
         request.currencyCode = "GBP"
         request.offerPayLater = true
 
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
         payPalClient.tokenize(request) { _, _ in }
 
         XCTAssertNotNil(payPalClient.webAuthenticationSession)
@@ -288,7 +282,6 @@ class BTPayPalClient_Tests: XCTestCase {
         let request = BTPayPalVaultRequest()
         request.offerCredit = true
 
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
         payPalClient.tokenize(request) { _, _ in }
 
         XCTAssertNotNil(payPalClient.webAuthenticationSession)
@@ -685,7 +678,6 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testTokenize_whenVaultRequest_setsVaultAnalyticsTag() async {
         let vaultRequest = BTPayPalVaultRequest()
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
 
         let _ = try? await payPalClient.tokenize(vaultRequest)
 
@@ -694,8 +686,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testTokenize_whenCheckoutRequest_setsVaultAnalyticsTag() async {
         let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
-        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
-        
+
         let _ = try? await payPalClient.tokenize(checkoutRequest)
 
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -685,15 +685,19 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testTokenize_whenVaultRequest_setsVaultAnalyticsTag() async {
         let vaultRequest = BTPayPalVaultRequest()
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
+
         let _ = try? await payPalClient.tokenize(vaultRequest)
 
-        XCTAssertTrue(mockAPIClient.lastPostedVaultType)
+        XCTAssertTrue(mockAPIClient.postedIsVaultRequest)
     }
 
     func testTokenize_whenCheckoutRequest_setsVaultAnalyticsTag() async {
         let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
+        payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
+        
         let _ = try? await payPalClient.tokenize(checkoutRequest)
 
-        XCTAssertFalse(mockAPIClient.lastPostedVaultType)
+        XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
 }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -9,11 +9,11 @@ public class MockAPIClient: BTAPIClient {
     public var lastGETPath = ""
     public var lastGETParameters = [:] as [String: Any]?
     public var lastGETAPIClientHTTPType: BTAPIClientHTTPService?
-    public var lastPostedVaultType = false
 
     public var postedAnalyticsEvents : [String] = []
     public var postedPayPalContextID: String? = nil
     public var postedLinkType: String? = nil
+    public var postedIsVaultRequest = false
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -93,6 +93,7 @@ public class MockAPIClient: BTAPIClient {
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType
+        postedIsVaultRequest = isVaultRequest ?? false
         postedAnalyticsEvents.append(name)
     }
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -785,7 +785,7 @@ class BTVenmoClient_Tests: XCTestCase {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         let _ = try? await venmoClient.tokenize(venmoRequest)
 
-        XCTAssertFalse(mockAPIClient.lastPostedVaultType)
+        XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
     
     // MARK: - BTAppContextSwitchClient


### PR DESCRIPTION
### Summary of changes

- Unit tests for this PR have been running since last week: https://github.com/braintree/braintree_ios/actions/runs/9215293641/job/25353361230, this is causing failures across multiple PRs where Unit Tests are running continuously
- I observed the same locally and tracked it down to an issue where new tests were not properly setting `webAuthenticationSession` this was causing the tests to never stop running both locally and on CI
- Renamed `lastPostedVaultType` to `postedIsVaultRequest` to properly represent the posted tag name for that event

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
