### PR TITLE
Add `PayPalMessaging` to Sample apps and Demo app

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		42C574BA25FA66FB008B3681 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 42C574B825FA66FB008B3681 /* LaunchScreen.storyboard */; };
 		42C574D525FA6CAC008B3681 /* AppSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C574D425FA6CAC008B3681 /* AppSwitcher.swift */; };
 		42C5BDD625A4CE4800E8FF40 /* AmericanExpress_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C5BDD525A4CE4800E8FF40 /* AmericanExpress_UITests.swift */; };
+		45DDDDA92C08FB0B00C262E5 /* PayPalMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 45DDDDA82C08FB0B00C262E5 /* PayPalMessages */; };
 		57108A152832E789004EB870 /* PayPalNativeCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57108A142832E789004EB870 /* PayPalNativeCheckoutViewController.swift */; };
 		57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; };
 		57108A182832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -57,10 +58,10 @@
 		BE35FCD82A1BD162008F0326 /* BraintreeLocalPayment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE35FCD72A1BD162008F0326 /* BraintreeLocalPayment.framework */; };
 		BE35FCD92A1BD162008F0326 /* BraintreeLocalPayment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE35FCD72A1BD162008F0326 /* BraintreeLocalPayment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BE45D7162AD97C340047E2C7 /* ContainmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE45D7152AD97C340047E2C7 /* ContainmentViewController.swift */; };
+		BE6442D12B4DE2B00096E562 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BE6442D02B4DE2B00096E562 /* PayPalCheckout */; };
 		BE67CDC02B29FF7B00BA4904 /* PayPalMessagingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE67CDBF2B29FF7B00BA4904 /* PayPalMessagingViewController.swift */; };
 		BE67CDC22B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE67CDC12B2A023F00BA4904 /* BraintreePayPalMessaging.framework */; };
 		BE67CDC32B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE67CDC12B2A023F00BA4904 /* BraintreePayPalMessaging.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BE6442D12B4DE2B00096E562 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BE6442D02B4DE2B00096E562 /* PayPalCheckout */; };
 		BE777AC427D9370400487D23 /* SEPADirectDebitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE777AC327D9370400487D23 /* SEPADirectDebitViewController.swift */; };
 		BE994B0B2AD8377D00470773 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE994B0A2AD8377D00470773 /* BaseViewController.swift */; };
 		BE994B0D2AD838A500470773 /* PaymentButtonBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE994B0C2AD838A500470773 /* PaymentButtonBaseViewController.swift */; };
@@ -206,6 +207,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45DDDDA92C08FB0B00C262E5 /* PayPalMessages in Frameworks */,
 				BE67CDC22B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Frameworks */,
 				57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */,
 				803D64FB256DAF9A00ACE692 /* BraintreeCore.framework in Frameworks */,
@@ -494,6 +496,7 @@
 			name = Demo;
 			packageProductDependencies = (
 				BE6442D02B4DE2B00096E562 /* PayPalCheckout */,
+				45DDDDA82C08FB0B00C262E5 /* PayPalMessages */,
 			);
 			productName = Demo;
 			productReference = A0988E4924DB43DC0095EEEE /* Demo.app */;
@@ -571,6 +574,7 @@
 			mainGroup = A0988E4024DB43DC0095EEEE;
 			packageReferences = (
 				BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */,
+				45DDDDA72C08FB0B00C262E5 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */,
 			);
 			productRefGroup = A0988E4A24DB43DC0095EEEE /* Products */;
 			projectDirPath = "";
@@ -1052,6 +1056,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		45DDDDA72C08FB0B00C262E5 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/paypal/paypal-messages-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
@@ -1063,6 +1075,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		45DDDDA82C08FB0B00C262E5 /* PayPalMessages */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 45DDDDA72C08FB0B00C262E5 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */;
+			productName = PayPalMessages;
+		};
 		BE6442D02B4DE2B00096E562 /* PayPalCheckout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		429925BB266189020085F77D /* BraintreeCard.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A5266189010085F77D /* BraintreeCard.xcframework */; };
 		429925BF266189020085F77D /* BraintreePayPal.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A7266189010085F77D /* BraintreePayPal.xcframework */; };
 		429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */; };
+		45DDDD992C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */; };
+		45DDDDA12C08F6E800C262E5 /* PayPalMessages.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */; };
+		45DDDDA22C08F6E800C262E5 /* PayPalMessages.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		805656572A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 805656562A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework */; };
 		8056565B2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */; };
 		8056565F2A38C7D200686579 /* BraintreeLocalPayment.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */; };
@@ -27,6 +30,20 @@
 		A74D4AFF1BFBB3FB00BF36CD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74D4AFD1BFBB3FB00BF36CD /* LaunchScreen.storyboard */; };
 		BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		45DDDDA32C08F6E800C262E5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				45DDDDA22C08F6E800C262E5 /* PayPalMessages.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		4299259D266189010085F77D /* BraintreeAmericanExpress.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeAmericanExpress.xcframework; path = Carthage/Build/BraintreeAmericanExpress.xcframework; sourceTree = "<group>"; };
@@ -40,10 +57,12 @@
 		429925A6266189010085F77D /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = Carthage/Build/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		429925A7266189010085F77D /* BraintreePayPal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPal.xcframework; path = Carthage/Build/BraintreePayPal.xcframework; sourceTree = "<group>"; };
 		429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeThreeDSecure.xcframework; path = Carthage/Build/BraintreeThreeDSecure.xcframework; sourceTree = "<group>"; };
+		45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalMessaging.xcframework; path = Carthage/Build/BraintreePayPalMessaging.xcframework; sourceTree = "<group>"; };
+		45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:43253H4X22:Braintree Payment Solutions, LLC"; lastKnownFileType = wrapper.xcframework; name = PayPalMessages.xcframework; path = ../../../Desktop/CarthageDependencyTest/Carthage/Build/PayPalMessages.xcframework; sourceTree = "<group>"; };
 		805656562A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
 		8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
 		8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeLocalPayment.xcframework; path = Carthage/Build/BraintreeLocalPayment.xcframework; sourceTree = "<group>"; };
-		805656612A38C7F500686579 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = Carthage/Build/PayPalCheckout.xcframework; sourceTree = "<group>"; };
+		805656612A38C7F500686579 /* PayPalCheckout.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:43253H4X22:Braintree Payment Solutions, LLC"; lastKnownFileType = wrapper.xcframework; name = PayPalCheckout.xcframework; path = Carthage/Build/PayPalCheckout.xcframework; sourceTree = "<group>"; };
 		A74D4AF11BFBB3FB00BF36CD /* CarthageTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarthageTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A74D4AF41BFBB3FB00BF36CD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A74D4AF61BFBB3FB00BF36CD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -52,7 +71,7 @@
 		A74D4AFE1BFBB3FB00BF36CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A74D4B001BFBB3FB00BF36CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BE35FCDC2A1BE866008F0326 /* BraintreeLocalPayment.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeLocalPayment.xcframework; path = ../../Carthage/Build/BraintreeLocalPayment.xcframework; sourceTree = "<group>"; };
-		BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../../Frameworks/XCFrameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
+		BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:H7M4G5NDNU:CardinalCommerce Corp"; lastKnownFileType = wrapper.xcframework; name = CardinalMobile.xcframework; path = ../../Frameworks/XCFrameworks/CardinalMobile.xcframework; sourceTree = "<group>"; };
 		BE777AA127D90DA900487D23 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = ../../Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
 		BE9D76A92A02FD2000DF9023 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = ../../Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -62,9 +81,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45DDDDA12C08F6E800C262E5 /* PayPalMessages.xcframework in Frameworks */,
 				BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */,
 				8056565B2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */,
 				429925B5266189020085F77D /* BraintreeCore.xcframework in Frameworks */,
+				45DDDD992C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework in Frameworks */,
 				8056565F2A38C7D200686579 /* BraintreeLocalPayment.xcframework in Frameworks */,
 				429925B1266189020085F77D /* PPRiskMagnes.xcframework in Frameworks */,
 				429925AF266189010085F77D /* BraintreeApplePay.xcframework in Frameworks */,
@@ -85,6 +106,8 @@
 		03BFA5C81FB2F0BB0003ABCE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */,
+				45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */,
 				805656612A38C7F500686579 /* PayPalCheckout.xcframework */,
 				8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */,
 				8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */,
@@ -148,6 +171,7 @@
 				A74D4AED1BFBB3FB00BF36CD /* Sources */,
 				A74D4AEE1BFBB3FB00BF36CD /* Frameworks */,
 				A74D4AEF1BFBB3FB00BF36CD /* Resources */,
+				45DDDDA32C08F6E800C262E5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		429925BF266189020085F77D /* BraintreePayPal.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A7266189010085F77D /* BraintreePayPal.xcframework */; };
 		429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */; };
 		45DDDD992C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */; };
-		45DDDDA12C08F6E800C262E5 /* PayPalMessages.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */; };
+		45DDDDAB2C091F2C00C262E5 /* PayPalMessages.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDAA2C091F2C00C262E5 /* PayPalMessages.xcframework */; };
 		805656572A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 805656562A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework */; };
 		8056565B2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */; };
 		8056565F2A38C7D200686579 /* BraintreeLocalPayment.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */; };
@@ -43,7 +43,7 @@
 		429925A7266189010085F77D /* BraintreePayPal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPal.xcframework; path = Carthage/Build/BraintreePayPal.xcframework; sourceTree = "<group>"; };
 		429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeThreeDSecure.xcframework; path = Carthage/Build/BraintreeThreeDSecure.xcframework; sourceTree = "<group>"; };
 		45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalMessaging.xcframework; path = Carthage/Build/BraintreePayPalMessaging.xcframework; sourceTree = "<group>"; };
-		45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:43253H4X22:Braintree Payment Solutions, LLC"; lastKnownFileType = wrapper.xcframework; name = PayPalMessages.xcframework; path = ../../../Desktop/CarthageDependencyTest/Carthage/Build/PayPalMessages.xcframework; sourceTree = "<group>"; };
+		45DDDDAA2C091F2C00C262E5 /* PayPalMessages.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:43253H4X22:Braintree Payment Solutions, LLC"; lastKnownFileType = wrapper.xcframework; name = PayPalMessages.xcframework; path = Carthage/Build/PayPalMessages.xcframework; sourceTree = "<group>"; };
 		805656562A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeSEPADirectDebit.xcframework; path = Carthage/Build/BraintreeSEPADirectDebit.xcframework; sourceTree = "<group>"; };
 		8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreePayPalNativeCheckout.xcframework; path = Carthage/Build/BraintreePayPalNativeCheckout.xcframework; sourceTree = "<group>"; };
 		8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeLocalPayment.xcframework; path = Carthage/Build/BraintreeLocalPayment.xcframework; sourceTree = "<group>"; };
@@ -66,7 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				45DDDDA12C08F6E800C262E5 /* PayPalMessages.xcframework in Frameworks */,
+				45DDDDAB2C091F2C00C262E5 /* PayPalMessages.xcframework in Frameworks */,
 				BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */,
 				8056565B2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */,
 				429925B5266189020085F77D /* BraintreeCore.xcframework in Frameworks */,
@@ -91,7 +91,7 @@
 		03BFA5C81FB2F0BB0003ABCE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */,
+				45DDDDAA2C091F2C00C262E5 /* PayPalMessages.xcframework */,
 				45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */,
 				805656612A38C7F500686579 /* PayPalCheckout.xcframework */,
 				8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */,

--- a/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
+++ b/SampleApps/CarthageTest/CarthageTest.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		429925C1266189020085F77D /* BraintreeThreeDSecure.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 429925A8266189010085F77D /* BraintreeThreeDSecure.xcframework */; };
 		45DDDD992C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDD982C08F4A100C262E5 /* BraintreePayPalMessaging.xcframework */; };
 		45DDDDA12C08F6E800C262E5 /* PayPalMessages.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */; };
-		45DDDDA22C08F6E800C262E5 /* PayPalMessages.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 45DDDDA02C08F6E800C262E5 /* PayPalMessages.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		805656572A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 805656562A38C7BF00686579 /* BraintreeSEPADirectDebit.xcframework */; };
 		8056565B2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565A2A38C7CB00686579 /* BraintreePayPalNativeCheckout.xcframework */; };
 		8056565F2A38C7D200686579 /* BraintreeLocalPayment.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8056565E2A38C7D200686579 /* BraintreeLocalPayment.xcframework */; };
@@ -30,20 +29,6 @@
 		A74D4AFF1BFBB3FB00BF36CD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74D4AFD1BFBB3FB00BF36CD /* LaunchScreen.storyboard */; };
 		BE57E0E32846A4FF002CFBAC /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE57E0E22846A4FF002CFBAC /* CardinalMobile.xcframework */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		45DDDDA32C08F6E800C262E5 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				45DDDDA22C08F6E800C262E5 /* PayPalMessages.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		4299259D266189010085F77D /* BraintreeAmericanExpress.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraintreeAmericanExpress.xcframework; path = Carthage/Build/BraintreeAmericanExpress.xcframework; sourceTree = "<group>"; };
@@ -171,7 +156,6 @@
 				A74D4AED1BFBB3FB00BF36CD /* Sources */,
 				A74D4AEE1BFBB3FB00BF36CD /* Frameworks */,
 				A74D4AEF1BFBB3FB00BF36CD /* Resources */,
-				45DDDDA32C08F6E800C262E5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -6,6 +6,7 @@ import BraintreeCore
 import BraintreeDataCollector
 import BraintreeLocalPayment
 import BraintreePayPal
+import BraintreePayPalMessaging
 import BraintreeThreeDSecure
 import BraintreeVenmo
 import BraintreePayPalNativeCheckout
@@ -22,6 +23,7 @@ class ViewController: UIViewController {
         let dataCollector = BTDataCollector(apiClient: apiClient)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)
         let payPalClient = BTPayPalClient(apiClient: apiClient)
+        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
         let venmoClient = BTVenmoClient(apiClient: apiClient)
         let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45B2CA822C08D70E00FCCD4C /* BraintreePayPalMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45B2CA812C08D70E00FCCD4C /* BraintreePayPalMessaging */; };
 		80214E042551FB5A00695A6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E032551FB5A00695A6F /* AppDelegate.swift */; };
 		80214E062551FB5A00695A6F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E052551FB5A00695A6F /* SceneDelegate.swift */; };
 		80214E082551FB5A00695A6F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80214E072551FB5A00695A6F /* ViewController.swift */; };
@@ -57,6 +58,7 @@
 				BE35FCF42A1C0885008F0326 /* BraintreeThreeDSecure in Frameworks */,
 				BE35FCF22A1C0885008F0326 /* BraintreeSEPADirectDebit in Frameworks */,
 				BE35FCEA2A1C0885008F0326 /* BraintreeDataCollector in Frameworks */,
+				45B2CA822C08D70E00FCCD4C /* BraintreePayPalMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,6 +142,7 @@
 				BE35FCF12A1C0885008F0326 /* BraintreeSEPADirectDebit */,
 				BE35FCF32A1C0885008F0326 /* BraintreeThreeDSecure */,
 				BE35FCF52A1C0885008F0326 /* BraintreeVenmo */,
+				45B2CA812C08D70E00FCCD4C /* BraintreePayPalMessaging */,
 			);
 			productName = SPMTest;
 			productReference = 80214E002551FB5A00695A6F /* SPMTest.app */;
@@ -430,6 +433,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		45B2CA812C08D70E00FCCD4C /* BraintreePayPalMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BraintreePayPalMessaging;
+		};
 		BE35FCDA2A1BD2EF008F0326 /* BraintreeLocalPayment */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BraintreeLocalPayment;

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -5,6 +5,7 @@ import BraintreeCard
 import BraintreeCore
 import BraintreeDataCollector
 import BraintreeLocalPayment
+import BraintreePayPalMessaging
 import BraintreePayPal
 import BraintreeThreeDSecure
 import BraintreeVenmo
@@ -21,6 +22,7 @@ class ViewController: UIViewController {
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)
+        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let payPalClient = BTPayPalClient(apiClient: apiClient)
         let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
         let venmoClient = BTVenmoClient(apiClient: apiClient)

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -5,8 +5,8 @@ import BraintreeCard
 import BraintreeCore
 import BraintreeDataCollector
 import BraintreeLocalPayment
-import BraintreePayPalMessaging
 import BraintreePayPal
+import BraintreePayPalMessaging
 import BraintreeThreeDSecure
 import BraintreeVenmo
 import BraintreePayPalNativeCheckout
@@ -22,8 +22,8 @@ class ViewController: UIViewController {
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)
-        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let payPalClient = BTPayPalClient(apiClient: apiClient)
+        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
         let venmoClient = BTVenmoClient(apiClient: apiClient)
         let payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)


### PR DESCRIPTION
### Summary of changes

- Add `PayPalMessaging` to `CathageTest` app
- Add `PayPalMessaging` to `SPMTest` app
- Add `PayPalMessages` package dependency in `Demo` app

### Checklist

- [ ] Added a changelog entry

### Authors

- @richherrera 
