### PR TITLE
Fix Demo app crash (PayPalMessages dependency)

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		809E86A62AD00AF4004998B0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809E86A52AD00AF4004998B0 /* AppDelegate.swift */; };
 		809E86A82AD01FE7004998B0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809E86A72AD01FE7004998B0 /* SceneDelegate.swift */; };
 		80D36DEE2A7967F20035380E /* VenmoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D36DED2A7967F20035380E /* VenmoViewController.swift */; };
+		80D920E62C0E4B3F004CA333 /* PayPalMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 80D920E52C0E4B3F004CA333 /* PayPalMessages */; };
 		9C36BD2926B3071B00F0A559 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD2826B3071A00F0A559 /* PPRiskMagnes.xcframework */; };
 		9C36BD4C26B311D900F0A559 /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; };
 		9C36BD4D26B311D900F0A559 /* CardinalMobile.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -57,10 +58,10 @@
 		BE35FCD82A1BD162008F0326 /* BraintreeLocalPayment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE35FCD72A1BD162008F0326 /* BraintreeLocalPayment.framework */; };
 		BE35FCD92A1BD162008F0326 /* BraintreeLocalPayment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE35FCD72A1BD162008F0326 /* BraintreeLocalPayment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BE45D7162AD97C340047E2C7 /* ContainmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE45D7152AD97C340047E2C7 /* ContainmentViewController.swift */; };
+		BE6442D12B4DE2B00096E562 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BE6442D02B4DE2B00096E562 /* PayPalCheckout */; };
 		BE67CDC02B29FF7B00BA4904 /* PayPalMessagingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE67CDBF2B29FF7B00BA4904 /* PayPalMessagingViewController.swift */; };
 		BE67CDC22B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE67CDC12B2A023F00BA4904 /* BraintreePayPalMessaging.framework */; };
 		BE67CDC32B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE67CDC12B2A023F00BA4904 /* BraintreePayPalMessaging.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BE6442D12B4DE2B00096E562 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = BE6442D02B4DE2B00096E562 /* PayPalCheckout */; };
 		BE777AC427D9370400487D23 /* SEPADirectDebitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE777AC327D9370400487D23 /* SEPADirectDebitViewController.swift */; };
 		BE994B0B2AD8377D00470773 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE994B0A2AD8377D00470773 /* BaseViewController.swift */; };
 		BE994B0D2AD838A500470773 /* PaymentButtonBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE994B0C2AD838A500470773 /* PaymentButtonBaseViewController.swift */; };
@@ -206,6 +207,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				80D920E62C0E4B3F004CA333 /* PayPalMessages in Frameworks */,
 				BE67CDC22B2A023F00BA4904 /* BraintreePayPalMessaging.framework in Frameworks */,
 				57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */,
 				803D64FB256DAF9A00ACE692 /* BraintreeCore.framework in Frameworks */,
@@ -494,6 +496,7 @@
 			name = Demo;
 			packageProductDependencies = (
 				BE6442D02B4DE2B00096E562 /* PayPalCheckout */,
+				80D920E52C0E4B3F004CA333 /* PayPalMessages */,
 			);
 			productName = Demo;
 			productReference = A0988E4924DB43DC0095EEEE /* Demo.app */;
@@ -571,6 +574,7 @@
 			mainGroup = A0988E4024DB43DC0095EEEE;
 			packageReferences = (
 				BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */,
+				80D920E42C0E4B3F004CA333 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */,
 			);
 			productRefGroup = A0988E4A24DB43DC0095EEEE /* Products */;
 			projectDirPath = "";
@@ -1052,6 +1056,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		80D920E42C0E4B3F004CA333 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/paypal/paypal-messages-ios/";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.0;
+			};
+		};
 		BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios/";
@@ -1063,6 +1075,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		80D920E52C0E4B3F004CA333 /* PayPalMessages */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 80D920E42C0E4B3F004CA333 /* XCRemoteSwiftPackageReference "paypal-messages-ios" */;
+			productName = PayPalMessages;
+		};
 		BE6442D02B4DE2B00096E562 /* PayPalCheckout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BE6442CF2B4DE2B00096E562 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;


### PR DESCRIPTION
**JIRA:** DTMOBILES-702

### Summary

The demo app currently crashes when running on device. It crashes with the following:

```
dyld[2527]: Library not loaded: @rpath/PayPalMessages.framework/PayPalMessages
  Referenced from: <13BF88A7-5934-34EF-B939-0432239ADD13> /private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/BraintreePayPalMessaging.framework/BraintreePayPalMessaging
  Reason: tried: '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/BraintreePayPalMessaging.framework/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/preboot/Cryptexes/OS@rpath/PayPalMessages.framework/PayPalMessages' (errno=2), '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/BraintreePayPalMessaging.framework/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2, not in dyld cache), '/private/preboot/Cryptexes/OS/usr/lib/swift/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2), '/private/var/containers/Bundle/Application/64E0AE18-8E3E-4B36-99E5-04C5A34A0029/Demo.app/Frameworks/PayPalMessages.framework/PayPalMessages' (errno=2)
```

### Changes

- Add PayPalMessages SPM package as direct dependency to Demo app
   - _Note_: This is not ideal since the dependency is already included in our BraintreePayPalMessaging wrapper target. This is a current/known limitation of our xcworkspace setup. See this PR https://github.com/braintree/braintree_ios/pull/1170 for a full description.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 