### PR TITLE
Analytics - only fetch config before flushing events cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
+
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal
   * Add PayPal App Switch vault flow (BETA)

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -142,7 +142,6 @@ class BTAnalyticsService: Equatable {
         if await !BTAnalyticsService.events.isEmpty {
             do {
                 let configuration = try await apiClient.fetchConfiguration()
-
                 let postParameters = await createAnalyticsEvent(config: configuration, sessionID: apiClient.metadata.sessionID, events: BTAnalyticsService.events.allValues)
                 http?.post("v1/tracking/batch/events", parameters: postParameters) { _, _, _ in }
                 await BTAnalyticsService.events.removeAll()

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -103,52 +103,52 @@ class BTAnalyticsService: Equatable {
 
         await BTAnalyticsService.events.append(event)
         
-        do {
-            let configuration = try await apiClient.fetchConfiguration()
-            
-            // TODO: - Refactor to make HTTP non-optional property and instantiate in init()
-            if self.http == nil {
-                self.http = BTHTTP(authorization: self.apiClient.authorization, customBaseURL: BTAnalyticsService.url)
-            }
-
-            // A special value passed in by unit tests to prevent BTHTTP from actually posting
-            if let http = self.http, http.customBaseURL?.absoluteString == "test://do-not-send.url" {
-                return
-            }
-            
-            if shouldBypassTimerQueue {
-                await self.sendQueuedAnalyticsEvents(configuration: configuration)
-                return
-            }
-
-            if BTAnalyticsService.timer == nil {
-                BTAnalyticsService.timer = DispatchSource.makeTimerSource(queue: self.http?.dispatchQueue)
-                BTAnalyticsService.timer?.schedule(
-                    deadline: .now() + .seconds(self.timerInterval),
-                    repeating: .seconds(self.timerInterval),
-                    leeway: .seconds(1)
-                )
-
-                BTAnalyticsService.timer?.setEventHandler {
-                    Task {
-                        await self.sendQueuedAnalyticsEvents(configuration: configuration)
-                    }
-                }
-
-                BTAnalyticsService.timer?.resume()
-            }
-        } catch {
+        // TODO: - Refactor to make HTTP non-optional property and instantiate in init()
+        if self.http == nil {
+            self.http = BTHTTP(authorization: self.apiClient.authorization, customBaseURL: BTAnalyticsService.url)
+        }
+        
+        // A special value passed in by unit tests to prevent BTHTTP from actually posting
+        if let http = self.http, http.customBaseURL?.absoluteString == "test://do-not-send.url" {
             return
+        }
+        
+        if shouldBypassTimerQueue {
+            await self.sendQueuedAnalyticsEvents()
+            return
+        }
+        
+        if BTAnalyticsService.timer == nil {
+            BTAnalyticsService.timer = DispatchSource.makeTimerSource(queue: self.http?.dispatchQueue)
+            BTAnalyticsService.timer?.schedule(
+                deadline: .now() + .seconds(self.timerInterval),
+                repeating: .seconds(self.timerInterval),
+                leeway: .seconds(1)
+            )
+            
+            BTAnalyticsService.timer?.setEventHandler {
+                Task {
+                    await self.sendQueuedAnalyticsEvents()
+                }
+            }
+            
+            BTAnalyticsService.timer?.resume()
         }
     }
 
     // MARK: - Helpers
 
-    func sendQueuedAnalyticsEvents(configuration: BTConfiguration) async {
+    func sendQueuedAnalyticsEvents() async {
         if await !BTAnalyticsService.events.isEmpty {
-            let postParameters = await createAnalyticsEvent(config: configuration, sessionID: apiClient.metadata.sessionID, events: BTAnalyticsService.events.allValues)
-            http?.post("v1/tracking/batch/events", parameters: postParameters) { _, _, _ in }
-            await BTAnalyticsService.events.removeAll()
+            do {
+                let configuration = try await apiClient.fetchConfiguration()
+
+                let postParameters = await createAnalyticsEvent(config: configuration, sessionID: apiClient.metadata.sessionID, events: BTAnalyticsService.events.allValues)
+                http?.post("v1/tracking/batch/events", parameters: postParameters) { _, _, _ in }
+                await BTAnalyticsService.events.removeAll()
+            } catch {
+                return
+            }
         }
     }
 


### PR DESCRIPTION
### Background

- We have seen an unexpectedly high number of `"core:api-request-latency"` analytics for the `/v1/configuration` endpoint in FPTI, compared to the number of occurrences for each attempted payment method flow (see data below)
   - This analytic event was added in https://github.com/braintree/braintree_ios/pull/1292
- We haven't been able to replicate the exact issue we see in the FPTI dataset, but we do know that it is related to a quick succession of calls to `/v1/configuration`, while another is in-flight, resulting in duplicate/overlapping requests.

![Screenshot 2024-06-05 at 11 12 54 AM](https://github.com/braintree/braintree_ios/assets/35243507/4ce3519b-d3a0-42ed-9028-cf56f082549c)

This PR reduces the number of calls to `BTAPIClient.fetchConfiguration()` in our Analytics layer. I don't know if this will solve 100% of the issue, but it should help.

### Changes

- Move `BTAPIClient.fetchConfiguration()` call in  `BTAnalyticsService`
    - Before it was being called in every `sendAnalyticsEvent()` method call
    - Now it is only called right before we flush our batch of analytics (every 20 seconds)
    - Shoutout to @sshropshire for this idea in stand-up!

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
