### PR TITLE
Fix Button Overlap on `ShopperInsightsViewController`

### DIFF
--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -29,7 +29,7 @@ class PaymentButtonBaseViewController: BaseViewController {
             paymentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             paymentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             paymentButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            paymentButton.heightAnchor.constraint(equalToConstant: 300)
+            paymentButton.heightAnchor.constraint(equalToConstant: 100)
         ])
     }
 

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -40,42 +40,25 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     lazy var shopperInsightsButton = createButton(title: "Fetch Shopper Insights", action: #selector(shopperInsightsButtonTapped))
     
     lazy var shopperInsightsInputView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView,])
+        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView])
         stackView.axis = .vertical
         stackView.spacing = 10
-        stackView.distribution = .fill
+        stackView.distribution = .fillEqually
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.layoutMargins = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
-        stackView.insetsLayoutMarginsFromSafeArea = false
         return stackView
     }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        view.addSubview(shopperInsightsInputView)
-        view.addSubview(shopperInsightsButton)
-        
-        NSLayoutConstraint.activate(
-            [
-                shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                shopperInsightsInputView.topAnchor.constraint(equalTo: view.topAnchor),
-                shopperInsightsInputView.widthAnchor.constraint(equalTo: view.widthAnchor),
-                shopperInsightsButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
-                shopperInsightsButton.topAnchor.constraint(equalTo: shopperInsightsInputView.bottomAnchor, constant: 10),
-                shopperInsightsButton.widthAnchor.constraint(
-                    equalTo: shopperInsightsInputView.widthAnchor,
-                    multiplier: 0.8
-                ),
-            ]
-        )
+        createSubviews()
+        layoutConstraints()
     }
     
     override func createPaymentButton() -> UIView {
-        let buttons = [payPalVaultButton, venmoButton]
-        buttons.forEach { $0.isEnabled = false }
+        let buttons = [shopperInsightsButton, payPalVaultButton, venmoButton]
+        shopperInsightsButton.isEnabled = true
+        payPalVaultButton.isEnabled = false
+        venmoButton.isEnabled = false
 
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.axis = .vertical
@@ -149,6 +132,22 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         } else {
             self.progressBlock("Canceled")
         }
+    }
+
+    private func createSubviews() {
+        shopperInsightsInputView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(shopperInsightsInputView)
+    }
+
+    private func layoutConstraints() {
+        NSLayoutConstraint.activate(
+            [
+                shopperInsightsInputView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 200)
+            ]
+        )
     }
 }
 

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -143,8 +143,8 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         NSLayoutConstraint.activate(
             [
                 shopperInsightsInputView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-                shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+                shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
                 shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 200)
             ]
         )


### PR DESCRIPTION
### Summary of changes

- There was some button overlap on the `ShopperInsightsViewController`

### Visuals
| Before | After |
|-----|-----|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-17 at 14 29 32](https://github.com/braintree/braintree_ios/assets/20733831/1a646d2c-8851-4fba-9044-2ebd0b739588)|![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-17 at 15 46 33](https://github.com/braintree/braintree_ios/assets/20733831/302ca228-1dfa-4351-a6bd-47fba0ddc684)|
|![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-17 at 11 19 31](https://github.com/braintree/braintree_ios/assets/20733831/887ae7ea-13da-42c7-8af1-83f95fa2a7de)|![Simulator Screenshot - iPhone 15 - 2024-06-17 at 15 47 59](https://github.com/braintree/braintree_ios/assets/20733831/c8261f7d-39fd-4ed1-8e3f-5215e838b932)

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
