### PR TITLE
Add customFields for 3DS verifyCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeThreeDSecure
-  * Add `customFields` param to `verifyCard`
+  * Add `customFields` param to `BTThreeDSecureRequest`
 * BraintreeCore
   * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* BraintreeThreeDSecure
+  * Add `customFields` param to `verifyCard`
 * BraintreeCore
   * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
 

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -92,7 +92,12 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
     private func createThreeDSecureRequest(with nonce: String) -> BTThreeDSecureRequest {
         let request = BTThreeDSecureRequest()
         
-        request.customFields = ["poop": "poop"]
+        let customFields = [
+            "test" : "test",
+            "test1": "test1",
+        ]
+        
+        request.customFields = customFields
         request.threeDSecureRequestDelegate = self
         request.amount = 10.32
         request.nonce = nonce

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -91,6 +91,8 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
 
     private func createThreeDSecureRequest(with nonce: String) -> BTThreeDSecureRequest {
         let request = BTThreeDSecureRequest()
+        
+        request.customFields = ["poop": "poop"]
         request.threeDSecureRequestDelegate = self
         request.amount = 10.32
         request.nonce = nonce

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -351,7 +351,8 @@ import BraintreeCore
                 "challengeRequested": request.challengeRequested,
                 "exemptionRequested": request.exemptionRequested,
                 "requestedExemptionType": request.requestedExemptionType.stringValue,
-                "dataOnlyRequested": request.dataOnlyRequested
+                "dataOnlyRequested": request.dataOnlyRequested,
+                "customFields": request.customFields
             ]
 
             if request._cardAddChallenge == .requested || request.cardAddChallengeRequested == true {

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -11,6 +11,9 @@ import BraintreeCore
 
     /// A nonce to be verified by ThreeDSecure
     public var nonce: String?
+    
+    /// Object where each key is the name of a custom field which has been configured in the Control Panel. In the Control Panel you can configure 3D Secure Rules which trigger on certain values.
+    public var customFields: [String: Any]? = [:]
 
     /// The amount for the transaction
     public var amount: NSDecimalNumber? = 0

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -13,7 +13,7 @@ import BraintreeCore
     public var nonce: String?
     
     /// Object where each key is the name of a custom field which has been configured in the Control Panel. In the Control Panel you can configure 3D Secure Rules which trigger on certain values.
-    public var customFields: [String: Any]? = [:]
+    public var customFields: [String: String]? = nil
 
     /// The amount for the transaction
     public var amount: NSDecimalNumber? = 0

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureRequest_Tests.swift
@@ -7,6 +7,14 @@ class BTThreeDSecureRequest_Tests: XCTestCase {
 
     // MARK: - accountTypeAsString
 
+    func testCustomFields_notNil() {
+        let request = BTThreeDSecureRequest()
+        XCTAssertNil(request.customFields)
+        
+        request.customFields = ["test": "test"]
+        XCTAssertNotNil(request.customFields)
+    }
+
     func testAccountTypeAsString_whenAccountTypeIsCredit_returnsCredit() {
         let request = BTThreeDSecureRequest()
         request.accountType = .credit


### PR DESCRIPTION
### Summary of changes

Accept a raw JSON format for customFields in BTThreeDSecureRequest for VerifyCard.

### Checklist

- [X] Added a changelog entry

### Authors
@agedd 
@jwarmkessel 
@warmkesselj 
