### PR TITLE
Deprecation Lines for BTPayPalNativeCheckout Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeCore
   * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
+* BraintreePayPalNativeCheckout
+  * Add deprecated warning in public classes and methods
 
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## unreleased
 * BraintreeCore
   * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
-* BraintreePayPalNativeCheckout
-  * Add deprecated warning in public classes and methods
+* BraintreePayPalNativeCheckout (DEPRECATED)  
+  * **Note:** This module is deprecated and will be removed in a future version of the SDK
+  * Add deprecated warning message to all public classes and methods
 
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal

--- a/Demo/Application/Features/PayPalNativeCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalNativeCheckoutViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import BraintreePayPalNativeCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class PayPalNativeCheckoutViewController: PaymentButtonBaseViewController {
 	lazy var payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
 

--- a/Demo/Application/Features/PayPalNativeCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalNativeCheckoutViewController.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 import BraintreePayPalNativeCheckout
 
-@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class PayPalNativeCheckoutViewController: PaymentButtonBaseViewController {
 	lazy var payPalNativeCheckoutClient = BTPayPalNativeCheckoutClient(apiClient: apiClient)
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
@@ -10,6 +10,7 @@ import BraintreePayPal
 
 import PayPalCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 /// Contains information about a PayPal payment method.
 @objcMembers public class BTPayPalNativeCheckoutAccountNonce: BTPaymentMethodNonce {
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -10,6 +10,7 @@ import BraintreePayPal
 
 import PayPalCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 /// Client used to collect PayPal payment methods. If possible, this client will present a native flow; otherwise, it will fall back to a web flow.
 @objc public class BTPayPalNativeCheckoutClient: NSObject {
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -26,6 +26,7 @@ import PayPalCheckout
     private let nativeCheckoutProvider: BTPayPalNativeCheckoutStartable
 
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     ///  Initializes a PayPal Native client.
     /// - Parameter apiClient: The Braintree API client
     @objc(initWithAPIClient:)
@@ -38,6 +39,7 @@ import PayPalCheckout
         self.nativeCheckoutProvider = nativeCheckoutProvider
     }
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     // MARK: - Public Methods
 
     /// Tokenize a PayPal request to be used with the PayPal Native Checkout flow.
@@ -57,6 +59,7 @@ import PayPalCheckout
         tokenize(request: request, userAuthenticationEmail: request.userAuthenticationEmail, completion: completion)
     }
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     /// Tokenize a PayPal request to be used with the PayPal Native Checkout flow.
     ///
     /// On success, you will receive an instance of `BTPayPalNativeCheckoutAccountNonce`.
@@ -78,6 +81,7 @@ import PayPalCheckout
         }
     }
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     /// Tokenize a PayPal request to be used with the PayPal Native Vault flow.
     ///
     /// On success, you will receive an instance of `BTPayPalNativeCheckoutAccountNonce`.
@@ -95,6 +99,7 @@ import PayPalCheckout
         tokenize(request: request, completion: completion)
     }
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     /// Tokenize a PayPal request to be used with the PayPal Native Vault flow.
     ///
     /// On success, you will receive an instance of `BTPayPalNativeCheckoutAccountNonce`.

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -39,9 +39,9 @@ import PayPalCheckout
         self.nativeCheckoutProvider = nativeCheckoutProvider
     }
 
-    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     // MARK: - Public Methods
 
+    @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
     /// Tokenize a PayPal request to be used with the PayPal Native Checkout flow.
     ///
     /// On success, you will receive an instance of `BTPayPalNativeCheckoutAccountNonce`.

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutError.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PayPalCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 /// Error returned from the native PayPal flow
 public enum BTPayPalNativeCheckoutError: Error, CustomNSError, LocalizedError, Equatable {
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProvider.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProvider.swift
@@ -5,6 +5,7 @@ import PayPalCheckout
 import BraintreePayPal
 #endif
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class BTPayPalNativeCheckoutProvider: BTPayPalNativeCheckoutStartable {
 
     /// Used in POST body for FPTI analytics.

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutRequest.swift
@@ -8,6 +8,7 @@ import BraintreeCore
 import BraintreePayPal
 #endif
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 /// Options for the PayPal Checkout flow.
 @objcMembers public class BTPayPalNativeCheckoutRequest: BTPayPalCheckoutRequest {
     

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutStartable.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutStartable.swift
@@ -5,6 +5,7 @@ import PayPalCheckout
 import BraintreePayPal
 #endif
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 protocol BTPayPalNativeCheckoutStartable {
 
     typealias StartableApproveCallback = (String?, User?) -> Void

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -14,6 +14,7 @@ struct BTPayPalNativeOrder: Equatable {
     let orderID: String
 }
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class BTPayPalNativeOrderCreationClient {
 
     var payPalContextID: String? = nil

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -8,6 +8,7 @@ import BraintreePayPal
 
 import PayPalCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class BTPayPalNativeTokenizationClient {
 
     private let apiClient: BTAPIClient

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
@@ -8,6 +8,7 @@ import BraintreePayPal
 
 import PayPalCheckout
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class BTPayPalNativeTokenizationRequest {
 
     private let request: BTPayPalRequest

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeVaultRequest.swift
@@ -8,6 +8,7 @@ import BraintreeCore
 import BraintreePayPal
 #endif
 
+@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 /// Options for the PayPal Vault flow.
 @objcMembers public class BTPayPalNativeVaultRequest: BTPayPalVaultBaseRequest {
 


### PR DESCRIPTION
### Summary of changes

- Add deprecation message -
@available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead") for all public classes and enums for BraintreePayPalNativeCheckout module

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
