### PR TITLE
Fix Xcode 16-beta2 duplicate file warning

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -705,7 +705,6 @@
 				BE994B0B2AD8377D00470773 /* BaseViewController.swift in Sources */,
 				80D36DEE2A7967F20035380E /* VenmoViewController.swift in Sources */,
 				BEE930492A98FE9200C85779 /* DataCollectorViewController.swift in Sources */,
-				BEAAAD052970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift in Sources */,
 				57108A152832E789004EB870 /* PayPalNativeCheckoutViewController.swift in Sources */,
 				BEBD52832AAB62FB005D6687 /* ApplePayViewController.swift in Sources */,
 				BEAAAD052970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift in Sources */,


### PR DESCRIPTION
### Summary

Running our Demo app with XCode 16-beta2 shows the following warning:

![Screenshot 2024-06-26 at 12 14 22 PM](https://github.com/braintree/braintree_ios/assets/35243507/3ca0a7b0-dab0-450f-b3c8-a5c54ecc4695)


### Changes

- Remove duplicate Demo pbxproj entry for `BTSEPADirectDebitTestHelper.swift`

### Checklist

- ~ Added a changelog entry~

### Authors
@scannillo 
