### PR TITLE
[Bug Fix] Add new `BTShopperInsightsError.invalidAuthorization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * BraintreeCore
   * For analytics, only call `fetchOrReturnRemoteConfig()` when batch uploading, not on each analytic event enqueue
   * For analytics, add additional metrics on networking timing
+* BraintreeShopperInsights (BETA)
+  * Add error when using an invalid authorization type
 
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -322,11 +322,11 @@ import Foundation
         httpType: BTAPIClientHTTPService = .gateway
     ) async throws -> (BTJSON?, HTTPURLResponse?) {
         try await withCheckedThrowingContinuation { continuation in
-            post(path, parameters: parameters, headers: headers, httpType: httpType) { json, httpResonse, error in
+            post(path, parameters: parameters, headers: headers, httpType: httpType) { json, httpResponse, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
-                    continuation.resume(returning: (json, httpResonse))
+                    continuation.resume(returning: (json, httpResponse))
                 }
             }
         }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -39,7 +39,11 @@ public class BTShopperInsightsClient {
             email: request.email,
             phone: request.phone
         )
-        
+
+        if apiClient.authorization.type != .clientToken {
+            throw notifyFailure(with: BTShopperInsightsError.invalidAuthorization)
+        }
+
         do {
             let (json, _) = try await apiClient.post(
                 "/v2/payments/find-eligible-methods",

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -34,15 +34,15 @@ public class BTShopperInsightsClient {
     ///         Venmo recommendation is only available for US merchants.
     public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest) async throws -> BTShopperInsightsResult {
         apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.recommendedPaymentsStarted)
-        
-        let postParameters = BTEligiblePaymentsRequest(
-            email: request.email,
-            phone: request.phone
-        )
 
         if apiClient.authorization.type != .clientToken {
             throw notifyFailure(with: BTShopperInsightsError.invalidAuthorization)
         }
+
+        let postParameters = BTEligiblePaymentsRequest(
+            email: request.email,
+            phone: request.phone
+        )
 
         do {
             let (json, _) = try await apiClient.post(

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsError.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsError.swift
@@ -4,7 +4,10 @@ public enum BTShopperInsightsError: Int, Error, CustomNSError, LocalizedError, E
     
     /// 0. A nil body was returned from the payment method request and no error was returned.
     case emptyBodyReturned
-    
+
+    /// 1. Invalid authorization type
+    case invalidAuthorization
+
     public static var errorDomain: String {
         "com.braintreepayments.BTShopperInsightsErrorDomain"
     }
@@ -17,6 +20,8 @@ public enum BTShopperInsightsError: Int, Error, CustomNSError, LocalizedError, E
         switch self {
         case .emptyBodyReturned:
             return "An empty body was returned from the Eligible Payments API during the request."
+        case .invalidAuthorization:
+            return "Invalid authorization. This feature can only be used with a client token."
         }
     }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 class BTShopperInsightsClient_Tests: XCTestCase {
     
     let clientToken = TestClientTokenFactory.token(withVersion: 3)
-    var mockAPIClient: MockAPIClient?
+    var mockAPIClient: MockAPIClient!
     var sut: BTShopperInsightsClient!
     
     let request = BTShopperInsightsRequest(
@@ -29,11 +29,11 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     func testGetRecommendedPaymentMethods_callsEligiblePaymentsAPI() async {
         _ = try? await sut.getRecommendedPaymentMethods(request: request)
         
-        XCTAssertEqual(mockAPIClient?.lastPOSTPath, "/v2/payments/find-eligible-methods")
-        XCTAssertEqual(mockAPIClient?.lastPOSTAPIClientHTTPType, .payPalAPI)
-        XCTAssertEqual(mockAPIClient?.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], mockAPIClient?.metadata.sessionID)
+        XCTAssertEqual(mockAPIClient.lastPOSTPath, "/v2/payments/find-eligible-methods")
+        XCTAssertEqual(mockAPIClient.lastPOSTAPIClientHTTPType, .payPalAPI)
+        XCTAssertEqual(mockAPIClient.lastPOSTAdditionalHeaders?["PayPal-Client-Metadata-Id"], mockAPIClient.metadata.sessionID)
 
-        guard let lastPostParameters = mockAPIClient?.lastPOSTParameters else {
+        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else {
             XCTFail()
             return
         }
@@ -56,7 +56,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     }
     
     func testGetRecommendedPaymentMethods_whenAPIError_throws() async {
-        mockAPIClient?.cannedResponseError = NSError(domain: "fake-error-domain", code: 123, userInfo: [NSLocalizedDescriptionKey:"fake-error-description"])
+        mockAPIClient.cannedResponseError = NSError(domain: "fake-error-domain", code: 123, userInfo: [NSLocalizedDescriptionKey:"fake-error-description"])
 
         do {
             _ = try await sut.getRecommendedPaymentMethods(request: request)
@@ -66,7 +66,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertEqual(error.localizedDescription, "fake-error-description")
             XCTAssertEqual(error.domain, "fake-error-domain")
             
-            XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:failed")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:failed")
         }
     }
     
@@ -84,12 +84,12 @@ class BTShopperInsightsClient_Tests: XCTestCase {
                     ]
                 ]
             )
-            mockAPIClient?.cannedResponseBody = mockEligiblePaymentMethodResponse
+            mockAPIClient.cannedResponseBody = mockEligiblePaymentMethodResponse
             let result = try await sut.getRecommendedPaymentMethods(request: request)
             XCTAssertNotNil(result)
             XCTAssertTrue(result.isVenmoRecommended)
             XCTAssertFalse(result.isPayPalRecommended)
-            XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
         } catch let error as NSError {
             XCTFail("An error was not expected.")
         }
@@ -109,12 +109,12 @@ class BTShopperInsightsClient_Tests: XCTestCase {
                     ]
                 ]
             )
-            mockAPIClient?.cannedResponseBody = mockPayPalRecommendedResponse
+            mockAPIClient.cannedResponseBody = mockPayPalRecommendedResponse
             let result = try await sut.getRecommendedPaymentMethods(request: request)
             XCTAssertTrue(result.isPayPalRecommended)
             XCTAssertFalse(result.isVenmoRecommended)
             XCTAssertTrue(result.isEligibleInPayPalNetwork)
-            XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -134,12 +134,12 @@ class BTShopperInsightsClient_Tests: XCTestCase {
                     ]
                 ]
             )
-            mockAPIClient?.cannedResponseBody = mockVenmoRecommendedResponse
+            mockAPIClient.cannedResponseBody = mockVenmoRecommendedResponse
             let result = try await sut.getRecommendedPaymentMethods(request: request)
             XCTAssertFalse(result.isPayPalRecommended)
             XCTAssertTrue(result.isVenmoRecommended)
             XCTAssertTrue(result.isEligibleInPayPalNetwork)
-            XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -163,12 +163,12 @@ class BTShopperInsightsClient_Tests: XCTestCase {
                     ]
                 ]
             )
-            mockAPIClient?.cannedResponseBody = mockPayPalRecommendedResponse
+            mockAPIClient.cannedResponseBody = mockPayPalRecommendedResponse
             let result = try await sut.getRecommendedPaymentMethods(request: request)
             XCTAssertFalse(result.isPayPalRecommended)
             XCTAssertFalse(result.isVenmoRecommended)
             XCTAssertFalse(result.isEligibleInPayPalNetwork)
-            XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -191,21 +191,21 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     
     func testSendPayPalPresentedEvent_sendsAnalytic() {
         sut.sendPayPalPresentedEvent()
-        XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
     }
     
     func testSendPayPalSelectedEvent_sendsAnalytic() {
         sut.sendPayPalSelectedEvent()
-        XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.first, "shopper-insights:paypal-selected")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-selected")
     }
     
     func testSendVenmoPresentedEvent_sendsAnalytic() {
         sut.sendVenmoPresentedEvent()
-        XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.first, "shopper-insights:venmo-presented")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-presented")
     }
     
     func testSendVenmoSelectedEvent_sendsAnalytic() {
         sut.sendVenmoSelectedEvent()
-        XCTAssertEqual(mockAPIClient?.postedAnalyticsEvents.first, "shopper-insights:venmo-selected")
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-selected")
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add new `BTShopperInsightsError.invalidAuthorization` and check authorization type in `BTShopperInsightsClient`
    - This fixes a bug where you would see `SWIFT TASK CONTINUATION MISUSE: post(_:parameters:headers:httpType:) leaked its continuation!` when using shopper insights with a tokenization key

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
