### PR TITLE
Add BTPayPalEditRequest and Tokenize for Edit FI

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3B29C3952B90F12F0077741D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3B29C3942B90F12F0077741D /* PrivacyInfo.xcprivacy */; };
 		3B57E9EA29ECC1AF00245174 /* BTLocalPaymentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B57E9E929ECC1AF00245174 /* BTLocalPaymentAnalytics.swift */; };
 		3B5A41E92BA2375600921922 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3B5A41E82BA2375600921922 /* PrivacyInfo.xcprivacy */; };
+		3B5CD9B02C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5CD9AF2C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift */; };
 		3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */; };
 		3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */; };
 		3BC0E09229E4673C009217D6 /* BTSEPADirectAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0E09129E4673C009217D6 /* BTSEPADirectAnalytics.swift */; };
@@ -53,10 +54,10 @@
 		428F976626727333001042E1 /* BTMockOpenURLContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 428F976526727333001042E1 /* BTMockOpenURLContext.m */; };
 		42FC218B25CDE0290047C49A /* BTPayPalRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */; };
 		42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */; };
-		457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */; };
-		457D7FCA2C2A250E00EF6523 /* RepeatingTimer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */; };
 		45227FC52C330FDE00A15018 /* MockURLSessionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */; };
 		45227FC72C33104100A15018 /* MockBTHTTPNetworkTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */; };
+		457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */; };
+		457D7FCA2C2A250E00EF6523 /* RepeatingTimer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
 		5708E0A828809BC6007946B9 /* BTJSONError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A728809BC6007946B9 /* BTJSONError.swift */; };
@@ -730,6 +731,7 @@
 		3B29C3942B90F12F0077741D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B57E9E929ECC1AF00245174 /* BTLocalPaymentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentAnalytics.swift; sourceTree = "<group>"; };
 		3B5A41E82BA2375600921922 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3B5CD9AF2C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalEditRequest.swift; sourceTree = "<group>"; };
 		3B668B7D2BFD12BE0024FB29 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics.swift; sourceTree = "<group>"; };
 		3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics_Tests.swift; sourceTree = "<group>"; };
@@ -776,10 +778,10 @@
 		42F75E5A24D48138007DC5E7 /* BTThreeDSecureClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureClient_Tests.swift; sourceTree = "<group>"; };
 		42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalRequest_Tests.swift; sourceTree = "<group>"; };
 		42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
-		457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
-		457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer_Tests.swift; sourceTree = "<group>"; };
 		45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionTask.swift; sourceTree = "<group>"; };
 		45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBTHTTPNetworkTiming.swift; sourceTree = "<group>"; };
+		457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
+		457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer_Tests.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5708E0A528809AD9007946B9 /* BTJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON.swift; sourceTree = "<group>"; };
@@ -1380,6 +1382,7 @@
 				BE6BC22B2BA9C67600C3E321 /* BTPayPalVaultBaseRequest.swift */,
 				BE349110294B77E100D2CF68 /* BTPayPalVaultRequest.swift */,
 				62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */,
+				3B5CD9AF2C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift */,
 			);
 			path = BraintreePayPal;
 			sourceTree = "<group>";
@@ -3204,6 +3207,7 @@
 				BE549F122BF5449E00B6F441 /* BTPayPalVaultBaseRequest.swift in Sources */,
 				3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */,
 				BE8E5CEF294B6937001BF017 /* BTPayPalCheckoutRequest.swift in Sources */,
+				3B5CD9B02C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift in Sources */,
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3B57E9EA29ECC1AF00245174 /* BTLocalPaymentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B57E9E929ECC1AF00245174 /* BTLocalPaymentAnalytics.swift */; };
 		3B5A41E92BA2375600921922 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3B5A41E82BA2375600921922 /* PrivacyInfo.xcprivacy */; };
 		3B5CD9B02C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5CD9AF2C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift */; };
+		3B610FD32C3DEE220098EFBB /* BTPayPalEditRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B610FD12C3DEE1C0098EFBB /* BTPayPalEditRequest_Tests.swift */; };
 		3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */; };
 		3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */; };
 		3BC0E09229E4673C009217D6 /* BTSEPADirectAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0E09129E4673C009217D6 /* BTSEPADirectAnalytics.swift */; };
@@ -732,6 +733,7 @@
 		3B57E9E929ECC1AF00245174 /* BTLocalPaymentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTLocalPaymentAnalytics.swift; sourceTree = "<group>"; };
 		3B5A41E82BA2375600921922 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B5CD9AF2C3C3FCC002EE8F7 /* BTPayPalEditRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalEditRequest.swift; sourceTree = "<group>"; };
+		3B610FD12C3DEE1C0098EFBB /* BTPayPalEditRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalEditRequest_Tests.swift; sourceTree = "<group>"; };
 		3B668B7D2BFD12BE0024FB29 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B7A261029C0CAA40087059D /* BTPayPalAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics.swift; sourceTree = "<group>"; };
 		3B7A261229C35B670087059D /* BTPayPalAnalytics_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalAnalytics_Tests.swift; sourceTree = "<group>"; };
@@ -1952,6 +1954,7 @@
 				BEBA590E2BB1B5B9005FA8A2 /* BTPayPalReturnURL_Tests.swift */,
 				427F328F25D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift */,
 				A9E5C1E424FD665D00EE691F /* Info.plist */,
+				3B610FD12C3DEE1C0098EFBB /* BTPayPalEditRequest_Tests.swift */,
 			);
 			path = BraintreePayPalTests;
 			sourceTree = "<group>";
@@ -3554,6 +3557,7 @@
 				42FC218B25CDE0290047C49A /* BTPayPalRequest_Tests.swift in Sources */,
 				42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */,
 				BEDEAF112AC1D049004EA970 /* BTPayPalAccountNonce_Tests.swift in Sources */,
+				3B610FD32C3DEE220098EFBB /* BTPayPalEditRequest_Tests.swift in Sources */,
 				427F329025D1A7B900435294 /* BTPayPalVaultRequest_Tests.swift in Sources */,
 				BECB10C62B5999EE008D398E /* BTPayPalLineItem_Tests.swift in Sources */,
 				3B7A261429C35BD00087059D /* BTPayPalAnalytics_Tests.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * BraintreePayPal
    * Add PayPal edit funding instrument flow (BETA)
      * Add `BTPayPalEditRequest` for edit FI flow
-     * Add `tokenizetokenize(_:completion:)` method that takes in a `BTPayPalEditRequest`
+     * Add `BTPayPalClient.tokenize(_:completion:)` method that takes in a `BTPayPalEditRequest`
      * **Note:** This feature is currently in beta and may change or be removed in future releases
   
 ## 6.22.0 (2024-07-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## unreleased
 * BraintreePayPal
-   * Add PayPal edit funding instrument flow (BETA)
-     * Add `BTPayPalEditRequest` for edit FI flow
-     * Add `BTPayPalClient.tokenize(_:completion:)` method that takes in a `BTPayPalEditRequest`
-     * **Note:** This feature is currently in beta and may change or be removed in future releases
+  * Add PayPal edit funding instrument flow (BETA)
+    * Add `BTPayPalEditRequest` for edit FI flow
+    * Add `BTPayPalClient.tokenize(_:completion:)` method that takes in a `BTPayPalEditRequest`
+    * **Note:** This feature is currently in beta and may change or be removed in future releases
   
 ## 6.22.0 (2024-07-02)
 * BraintreeThreeDSecure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * BraintreePayPalNativeCheckout (DEPRECATED)  
   * **Note:** This module is deprecated and will be removed in a future version of the SDK
   * Add deprecated warning message to all public classes and methods
+* BraintreePayPal
+  * Add `BTPayPalEditRequest` for edit FI flow (Beta)
+  * Add `tokenize` method for edit FI flow (Beta)
 
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPal
+   * Add PayPal edit funding instrument flow (BETA)
+     * Add `BTPayPalEditRequest` for edit FI flow
+     * Add `tokenizetokenize(_:completion:)` method that takes in a `BTPayPalEditRequest`
+     * **Note:** This feature is currently in beta and may change or be removed in future releases
+  
 ## 6.22.0 (2024-07-02)
 * BraintreeThreeDSecure
   * Add `customFields` param to `BTThreeDSecureRequest`
@@ -10,9 +17,6 @@
 * BraintreePayPalNativeCheckout (DEPRECATED)  
   * **Note:** This module is deprecated and will be removed in a future version of the SDK
   * Add deprecated warning message to all public classes and methods
-* BraintreePayPal
-  * Add `BTPayPalEditRequest` for edit FI flow (Beta)
-  * Add `tokenize` method for edit FI flow (Beta)
 
 ## 6.21.0 (2024-06-12)
 * BraintreePayPal

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -192,7 +192,6 @@ import BraintreeDataCollector
     ///   - request: A `BTPayPalEditRequest`
     ///   - completion: This completion will be invoked exactly once when tokenization is complete or an error occurs.
     /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-    @objc(tokenizeWithEditRequest:completion:)
     public func tokenize(
         _ request: BTPayPalEditRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
@@ -221,7 +220,6 @@ import BraintreeDataCollector
             }
         }
     }
-
 
     // MARK: - Internal Methods
     

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -183,6 +183,46 @@ import BraintreeDataCollector
         }
     }
 
+    /// Tokenize a PayPal request to be used with the Edit FI flow.
+    ///
+    /// On success, you will receive an instance of `BTPayPalAccountNonce`; on failure or user cancelation you will receive an error.
+    /// If the user cancels out of the flow, the error code will be `.canceled`.
+    ///
+    /// - Parameters:
+    ///   - request: A `BTPayPalEditRequest`
+    ///   - completion: This completion will be invoked exactly once when tokenization is complete or an error occurs.
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    @objc(tokenizeWithEditRequest:completion:)
+    public func tokenize(
+        _ request: BTPayPalEditRequest,
+        completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
+    ) {
+        // TODO: call API to get FI URL and return a BTPayPalNonce or Error
+        completion(nil, nil)
+    }
+
+    /// Tokenize a PayPal request to be used with the Edit FI flow.
+    ///
+    /// On success, you will receive an instance of `BTPayPalAccountNonce`; on failure or user cancelation you will receive an error.
+    /// If the user cancels out of the flow, the error code will be `.canceled`.
+    ///
+    /// - Parameter request: A `BTPayPalEditRequest`
+    /// - Returns: A `BTPayPalAccountNonce` if successful
+    /// - Throws: An `Error` describing the failure
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    public func tokenize(_ request: BTPayPalEditRequest) async throws -> BTPayPalAccountNonce {
+        try await withCheckedThrowingContinuation { continuation in
+            tokenize(request) { nonce, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let nonce {
+                    continuation.resume(returning: nonce)
+                }
+            }
+        }
+    }
+
+
     // MARK: - Internal Methods
     
     func handleReturn(

--- a/Sources/BraintreePayPal/BTPayPalEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalEditRequest.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif
+
+/// Options for the PayPal Edit FI flow
+/// - Warning: This feature is currently in beta and may change or be removed in future releases.
+@objcMembers open class BTPayPalEditRequest {
+    public let token: String
+
+    /// Initializes a PayPal Edit Request for the Edit FI flow
+    /// - Parameters:
+    ///   - token: Required: Used to initiate tokenize call to edit funding instrument in customer's PayPal account.
+    public init(token: String) {
+        self.token = token
+    }
+}

--- a/Sources/BraintreePayPal/BTPayPalEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalEditRequest.swift
@@ -7,7 +7,7 @@ import BraintreeCore
 /// Options for the PayPal Edit FI flow
 /// - Warning: This feature is currently in beta and may change or be removed in future releases.
 public class BTPayPalEditRequest {
-    private let token: String
+    let token: String
 
     /// Initializes a PayPal Edit Request for the Edit FI flow
     /// - Parameters:

--- a/Sources/BraintreePayPal/BTPayPalEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalEditRequest.swift
@@ -6,8 +6,8 @@ import BraintreeCore
 
 /// Options for the PayPal Edit FI flow
 /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-@objcMembers open class BTPayPalEditRequest: NSObject {
-    public let token: String
+public class BTPayPalEditRequest {
+    private let token: String
 
     /// Initializes a PayPal Edit Request for the Edit FI flow
     /// - Parameters:

--- a/Sources/BraintreePayPal/BTPayPalEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalEditRequest.swift
@@ -6,7 +6,7 @@ import BraintreeCore
 
 /// Options for the PayPal Edit FI flow
 /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-@objcMembers open class BTPayPalEditRequest {
+@objcMembers open class BTPayPalEditRequest: NSObject {
     public let token: String
 
     /// Initializes a PayPal Edit Request for the Edit FI flow

--- a/Sources/BraintreePayPal/BTPayPalEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalEditRequest.swift
@@ -7,11 +7,12 @@ import BraintreeCore
 /// Options for the PayPal Edit FI flow
 /// - Warning: This feature is currently in beta and may change or be removed in future releases.
 public class BTPayPalEditRequest {
-    let token: String
+    private let token: String
 
     /// Initializes a PayPal Edit Request for the Edit FI flow
     /// - Parameters:
     ///   - token: Required: Used to initiate tokenize call to edit funding instrument in customer's PayPal account.
+    //   TODO: specify endpoint for merchant to retrieve the token
     public init(token: String) {
         self.token = token
     }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -126,6 +126,25 @@ class BTPayPalClient_Tests: XCTestCase {
         self.waitForExpectations(timeout: 1)
     }
 
+    func testTokenizePayPalEditRequest_whenResponseIsSuccessful_returnsPayPalAccountNonce() {
+
+        let editRequest = BTPayPalEditRequest(token: "test-token")
+
+        // TODO: implement test to return PayPalAccountNonce
+    }
+
+    func testTokenizePayPalEditRequest_whenResposneIsErorr_returnsError() {
+        let editRequest = BTPayPalEditRequest(token: "test-token")
+
+        // TODO: implement test to return Error
+    }
+
+    func testTokenizePayPalEditRequest_whenUserCancels_returnsError() {
+        let editRequest = BTPayPalEditRequest(token: "test-token")
+
+        // TODO: implement test to return Error
+    }
+
     // MARK: - PayPal approval URL to present in browser
 
     func testTokenizePayPalAccount_checkout_whenUserActionIsNotSet_approvalUrlIsNotModified() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -127,13 +127,12 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testTokenizePayPalEditRequest_whenResponseIsSuccessful_returnsPayPalAccountNonce() {
-
         let editRequest = BTPayPalEditRequest(token: "test-token")
 
         // TODO: implement test to return PayPalAccountNonce
     }
 
-    func testTokenizePayPalEditRequest_whenResposneIsErorr_returnsError() {
+    func testTokenizePayPalEditRequest_whenResponseIsError_returnsError() {
         let editRequest = BTPayPalEditRequest(token: "test-token")
 
         // TODO: implement test to return Error

--- a/UnitTests/BraintreePayPalTests/BTPayPalEditRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalEditRequest_Tests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import BraintreeCore
+@testable import BraintreePayPal
+
+class BTPayPalEditRequest_Tests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testBTPayPalEditRequestInitializer() {
+        let expectedToken = "test-token"
+        let editRequest = BTPayPalEditRequest(token: expectedToken)
+        XCTAssertEqual(editRequest.token, expectedToken)
+    }
+}

--- a/UnitTests/BraintreePayPalTests/BTPayPalEditRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalEditRequest_Tests.swift
@@ -8,9 +8,10 @@ class BTPayPalEditRequest_Tests: XCTestCase {
         super.setUp()
     }
 
-    func testBTPayPalEditRequestInitializer() {
+    func test_returnsAllParams() {
         let expectedToken = "test-token"
         let editRequest = BTPayPalEditRequest(token: expectedToken)
-        XCTAssertEqual(editRequest.token, expectedToken)
+
+        // TODO: implement checking expected params returned
     }
 }


### PR DESCRIPTION
### Summary of changes

- Create `PayPalEditRequest` that takes in a String `token`
- Add `tokenize` function that takes in` PayPalEditRequest` and returns` BTPayPalAccountNonce` or `Error`

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
