### PR TITLE
Update `URLOpener.openURL(_:options:completionHandler:)` for Xcode 16 beta 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeShopperInsights (BETA)
   * Add error when using an invalid authorization type
+* BraintreeCore
+  * Update `URLOpener.openURL(_:options:completionHandler:)` protocol method to fix method signature change in Xcode 16 beta 3 (fixes #1359)
 
 ## 6.22.0 (2024-07-02)
 * BraintreeThreeDSecure

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -7,7 +7,7 @@ import UIKit
 public protocol URLOpener {
 
     func canOpenURL(_ url: URL) -> Bool
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
+    func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
     func isPayPalAppInstalled() -> Bool
     func isVenmoAppInstalled() -> Bool
 }
@@ -32,5 +32,9 @@ extension UIApplication: URLOpener {
             return false
         }
         return canOpenURL(payPalURL)
+    }
+
+    public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
+        UIApplication.shared.open(url, options: options, completionHandler: completion)
     }
 }

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -36,6 +36,7 @@ extension UIApplication: URLOpener {
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Indicates whether the PayPal App is installed.
+    // TODO: once Xcode 16 is the minimum supported version remove this method and update the protocol to the default open signature from UIApplication
     @_documentation(visibility: private)
     public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
         UIApplication.shared.open(url, options: options, completionHandler: completion)

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -34,6 +34,9 @@ extension UIApplication: URLOpener {
         return canOpenURL(payPalURL)
     }
 
+    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    /// Indicates whether the PayPal App is installed.
+    @_documentation(visibility: private)
     public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
         UIApplication.shared.open(url, options: options, completionHandler: completion)
     }

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -7,7 +7,7 @@ import UIKit
 public protocol URLOpener {
 
     func canOpenURL(_ url: URL) -> Bool
-    func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
+    func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?)
     func isPayPalAppInstalled() -> Bool
     func isVenmoAppInstalled() -> Bool
 }
@@ -38,7 +38,7 @@ extension UIApplication: URLOpener {
     /// Indicates whether the PayPal App is installed.
     // TODO: once Xcode 16 is the minimum supported version remove this method and update the protocol to the default open signature from UIApplication
     @_documentation(visibility: private)
-    public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
-        UIApplication.shared.open(url, options: options, completionHandler: completion)
+    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
+        UIApplication.shared.open(url, options: [:], completionHandler: completion)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -389,7 +389,7 @@ import BraintreeDataCollector
             return
         }
 
-        application.open(redirectURL, options: [:]) { success in
+        application.openURL(redirectURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, completion: completion)
         }
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -389,7 +389,7 @@ import BraintreeDataCollector
             return
         }
 
-        application.openURL(redirectURL, options: [:]) { success in
+        application.open(redirectURL) { success in
             self.invokedOpenURLSuccessfully(success, completion: completion)
         }
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -253,7 +253,7 @@ import BraintreeCore
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
-        application.openURL(appStoreURL, options: [:], completionHandler: nil)
+        application.open(appStoreURL, completionHandler: nil)
     }
 
     // MARK: - Internal Methods
@@ -343,7 +343,7 @@ import BraintreeCore
     }
 
     func startVenmoFlow(with appSwitchURL: URL, shouldVault vault: Bool, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        application.openURL(appSwitchURL, options: [:]) { success in
+        application.open(appSwitchURL) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
         }
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -253,7 +253,7 @@ import BraintreeCore
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
-        application.open(appStoreURL, options: [:], completionHandler: nil)
+        application.openURL(appStoreURL, options: [:], completionHandler: nil)
     }
 
     // MARK: - Internal Methods
@@ -343,7 +343,7 @@ import BraintreeCore
     }
 
     func startVenmoFlow(with appSwitchURL: URL, shouldVault vault: Bool, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        application.open(appSwitchURL, options: [:]) { success in
+        application.openURL(appSwitchURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
         }
     }

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -9,7 +9,7 @@ public class FakeApplication: URLOpener {
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
 
-    public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
+    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
         lastOpenURL = url
         openURLWasCalled = true
         completion?(cannedOpenURLSuccess)

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -9,10 +9,10 @@ public class FakeApplication: URLOpener {
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
 
-    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler: ((Bool) -> Void)?) {
+    public func openURL(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
         lastOpenURL = url
         openURLWasCalled = true
-        completionHandler?(cannedOpenURLSuccess)
+        completion?(cannedOpenURLSuccess)
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {


### PR DESCRIPTION
### Summary of changes

- Update `URLOpener.openURL(_:options:completionHandler:)` protocol method to fix method signature change in Xcode 16 beta 3 (fixes #1359)
    - This method signature changed and I expect it will change moving forward in future version of Xcode 16 based on the apple dev docs: https://developer.apple.com/documentation/uikit/uiapplication/1648685-open?changes=latest_minor


### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
