### PR TITLE
Remove `Authorization` argument in `ConfigurationLoader.getConfig` method

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -99,7 +99,7 @@ import Foundation
     /// cached on subsequent calls for better performance.
     @_documentation(visibility: private)
     public func fetchOrReturnRemoteConfiguration(_ completion: @escaping (BTConfiguration?, Error?) -> Void) {
-        configurationLoader.getConfig(authorization) { [weak self] configuration, error in
+        configurationLoader.getConfig() { [weak self] configuration, error in
             guard let self else {
                 completion(nil, BTAPIClientError.deallocated)
                 return
@@ -116,7 +116,7 @@ import Foundation
     }
     
     func fetchConfiguration() async throws -> BTConfiguration {
-        try await configurationLoader.getConfig(authorization)
+        try await configurationLoader.getConfig()
     }
 
     /// Fetches a customer's vaulted payment method nonces.

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -99,7 +99,7 @@ import Foundation
     /// cached on subsequent calls for better performance.
     @_documentation(visibility: private)
     public func fetchOrReturnRemoteConfiguration(_ completion: @escaping (BTConfiguration?, Error?) -> Void) {
-        configurationLoader.getConfig() { [weak self] configuration, error in
+        configurationLoader.getConfig { [weak self] configuration, error in
             guard let self else {
                 completion(nil, BTAPIClientError.deallocated)
                 return

--- a/Sources/BraintreeCore/ConfigurationLoader.swift
+++ b/Sources/BraintreeCore/ConfigurationLoader.swift
@@ -28,15 +28,14 @@ class ConfigurationLoader {
     /// 3. If fetching the configuration fails, it returns an error.
     ///
     /// - Parameters:
-    ///   - authorization: An `ClientAuthorization` object required to access the configuration.
     ///   - completion: A completion handler that is called with the fetched or cached `BTConfiguration` object or an `Error`.
     ///
     /// - Completion:
     ///   - `BTConfiguration?`: The configuration object if it is successfully fetched or retrieved from the cache.
     ///   - `Error?`: An error object if fetching the configuration fails or if the instance is deallocated.
     @_documentation(visibility: private)
-    func getConfig(_ authorization: ClientAuthorization, completion: @escaping (BTConfiguration?, Error?) -> Void) {
-        if let cachedConfig = try? configurationCache.getFromCache(authorization: authorization.bearer) {
+    func getConfig(completion: @escaping (BTConfiguration?, Error?) -> Void) {
+        if let cachedConfig = try? configurationCache.getFromCache(authorization: http.authorization.bearer) {
             completion(cachedConfig, nil)
             return
         }
@@ -56,7 +55,7 @@ class ConfigurationLoader {
             } else {
                 let configuration = BTConfiguration(json: body)
 
-                try? configurationCache.putInCache(authorization: authorization.bearer, configuration: configuration)
+                try? configurationCache.putInCache(authorization: http.authorization.bearer, configuration: configuration)
                 
                 completion(configuration, nil)
                 return
@@ -64,9 +63,9 @@ class ConfigurationLoader {
         }
     }
     
-    func getConfig(_ authorization: ClientAuthorization) async throws -> BTConfiguration {
+    func getConfig() async throws -> BTConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            getConfig(authorization) { configuration, error in
+            getConfig() { configuration, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let configuration {

--- a/Sources/BraintreeCore/ConfigurationLoader.swift
+++ b/Sources/BraintreeCore/ConfigurationLoader.swift
@@ -65,7 +65,7 @@ class ConfigurationLoader {
     
     func getConfig() async throws -> BTConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            getConfig() { configuration, error in
+            getConfig { configuration, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let configuration {

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -52,7 +52,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         mockHTTP.cannedStatusCode = 200
         
         let expectation = expectation(description: "Fetch configuration")
-        sut.getConfig() { configuration, error in
+        sut.getConfig { configuration, error in
             XCTAssertNotNil(configuration)
             XCTAssertNil(error)
             XCTAssertGreaterThanOrEqual(self.mockHTTP.GETRequestCount, 1)

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -25,7 +25,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         try? ConfigurationCache.shared.putInCache(authorization: "development_tokenization_key", configuration: BTConfiguration(json: BTJSON(value: sampleJSON)))
         
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig() { configuration, error in
+        sut.getConfig { configuration, error in
             XCTAssertEqual(configuration?.environment, "fake-env1")
             XCTAssertEqual(configuration?.json?["test"].asString(), "value")
             XCTAssertNil(self.mockHTTP.lastRequestEndpoint)

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -23,10 +23,9 @@ class ConfigurationLoader_Tests: XCTestCase {
     func testGetConfig_whenCached_returnsConfigFromCache() {
         let sampleJSON = ["test": "value", "environment": "fake-env1"]
         try? ConfigurationCache.shared.putInCache(authorization: "development_tokenization_key", configuration: BTConfiguration(json: BTJSON(value: sampleJSON)))
-        let mockClientAuthorization = MockClientAuthorization(bearer: "development_tokenization_key")
         
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig(mockClientAuthorization) { configuration, error in
+        sut.getConfig() { configuration, error in
             XCTAssertEqual(configuration?.environment, "fake-env1")
             XCTAssertEqual(configuration?.json?["test"].asString(), "value")
             XCTAssertNil(self.mockHTTP.lastRequestEndpoint)
@@ -37,10 +36,9 @@ class ConfigurationLoader_Tests: XCTestCase {
 
     func testGetConfig_performsGETWithCorrectPayload() {
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
-        let mockClientAuthorization = MockClientAuthorization()
-
+        
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig(mockClientAuthorization) { _,_ in
+        sut.getConfig() { _,_ in
             XCTAssertEqual(self.mockHTTP.lastRequestEndpoint, "v1/configuration")
             XCTAssertEqual(self.mockHTTP.lastRequestParameters?["configVersion"] as? String, "3")
             expectation.fulfill()
@@ -52,10 +50,9 @@ class ConfigurationLoader_Tests: XCTestCase {
     func testGetConfig_canGetRemoteConfiguration() {
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
-        let mockClientAuthorization = MockClientAuthorization()
         
         let expectation = expectation(description: "Fetch configuration")
-        sut.getConfig(mockClientAuthorization) { configuration, error in
+        sut.getConfig() { configuration, error in
             XCTAssertNotNil(configuration)
             XCTAssertNil(error)
             XCTAssertGreaterThanOrEqual(self.mockHTTP.GETRequestCount, 1)
@@ -75,10 +72,9 @@ class ConfigurationLoader_Tests: XCTestCase {
             respondWith: ["error_message": "Something bad happened"],
             statusCode: 503
         )
-        let mockClientAuthorization = MockClientAuthorization()
-
+        
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig(mockClientAuthorization) { configuration, error in
+        sut.getConfig() { configuration, error in
             guard let error = error as NSError? else { return }
             XCTAssertNil(configuration)
             XCTAssertEqual(error.domain, BTAPIClientError.errorDomain)
@@ -93,11 +89,10 @@ class ConfigurationLoader_Tests: XCTestCase {
     func testGetConfig_whenNetworkHasError_returnsNetworkErrorInCallback() {
         ConfigurationCache.shared.cacheInstance.removeAllObjects()
         let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
-        let mockClientAuthorization = MockClientAuthorization()
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
         let expectation = expectation(description: "Fetch configuration")
-        sut.getConfig(mockClientAuthorization) { configuration, error in
+        sut.getConfig() { configuration, error in
             // BTAPIClient fetches the config when initialized so there can potentially be 2 requests here
             XCTAssertLessThanOrEqual(self.mockHTTP.GETRequestCount, 2)
             XCTAssertNil(configuration)
@@ -111,10 +106,9 @@ class ConfigurationLoader_Tests: XCTestCase {
     func testGetConfig_returnsConfiguration() async throws {
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
-        let mockClientAuthorization = MockClientAuthorization()
         
         let asyncTask = Task {
-            return try await sut.getConfig(mockClientAuthorization)
+            return try await sut.getConfig()
         }
         
         let returnedConfig = try await asyncTask.value
@@ -124,11 +118,10 @@ class ConfigurationLoader_Tests: XCTestCase {
     
     func testGetConfig_returnsNetworkErrorInCallback() async throws  {
         let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
-        let mockClientAuthorization = MockClientAuthorization()
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
         
         let asyncTask = Task {
-            return try await sut.getConfig(mockClientAuthorization)
+            return try await sut.getConfig()
         }
         
         do {

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -74,7 +74,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         )
         
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig() { configuration, error in
+        sut.getConfig { configuration, error in
             guard let error = error as NSError? else { return }
             XCTAssertNil(configuration)
             XCTAssertEqual(error.domain, BTAPIClientError.errorDomain)

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -92,7 +92,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
         let expectation = expectation(description: "Fetch configuration")
-        sut.getConfig() { configuration, error in
+        sut.getConfig { configuration, error in
             // BTAPIClient fetches the config when initialized so there can potentially be 2 requests here
             XCTAssertLessThanOrEqual(self.mockHTTP.GETRequestCount, 2)
             XCTAssertNil(configuration)

--- a/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/ConfigurationLoader_Tests.swift
@@ -38,7 +38,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/v1/configuration", respondWith: [] as [Any?], statusCode: 200)
         
         let expectation = expectation(description: "Callback invoked")
-        sut.getConfig() { _,_ in
+        sut.getConfig { _, _ in
             XCTAssertEqual(self.mockHTTP.lastRequestEndpoint, "v1/configuration")
             XCTAssertEqual(self.mockHTTP.lastRequestParameters?["configVersion"] as? String, "3")
             expectation.fulfill()

--- a/UnitTests/BraintreeCoreTests/MockConfigurationLoader.swift
+++ b/UnitTests/BraintreeCoreTests/MockConfigurationLoader.swift
@@ -12,7 +12,7 @@ class MockConfigurationLoader: ConfigurationLoader {
         super.init(http: http)
     }
     
-    override func getConfig(_ authorization: ClientAuthorization, completion: @escaping (BTConfiguration?, Error?) -> Void) {
+    override func getConfig(completion: @escaping (BTConfiguration?, Error?) -> Void) {
         if let error = mockError {
             completion(nil, error)
         } else {
@@ -20,7 +20,7 @@ class MockConfigurationLoader: ConfigurationLoader {
         }
     }
     
-    override func getConfig(_ authorization: ClientAuthorization) async throws -> BTConfiguration {
+    override func getConfig() async throws -> BTConfiguration {
         if let error = mockError {
             throw error
         } else if let config = mockConfig {


### PR DESCRIPTION
### Summary of changes

- Remove `authorization` argument from `ConfigurationLoader.getConfig()` method since the `authorization` is already available on the `BTHTTP` instance (which is required via the `ConfigurationLoader.init`)
- This will help in a following PR to ensure the `GET` requests triggered from `ConfigurationLoader` are idempotent

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
