### PR TITLE
Update Custom Fields Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeShopperInsights (BETA)
   * Add error when using an invalid authorization type
+* BraintreeThreeDSecure
+  * Fix bug to conditionally unwrap `customFields` - this caused an error when this value was not set on `BTThreeDSecureRequest`
 
 ## 6.22.0 (2024-07-02)
 * BraintreeThreeDSecure

--- a/Demo/Application/Features/ThreeDSecureViewController.swift
+++ b/Demo/Application/Features/ThreeDSecureViewController.swift
@@ -92,12 +92,6 @@ class ThreeDSecureViewController: PaymentButtonBaseViewController {
     private func createThreeDSecureRequest(with nonce: String) -> BTThreeDSecureRequest {
         let request = BTThreeDSecureRequest()
         
-        let customFields = [
-            "test" : "test",
-            "test1": "test1",
-        ]
-        
-        request.customFields = customFields
         request.threeDSecureRequestDelegate = self
         request.amount = 10.32
         request.nonce = nonce

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -351,9 +351,12 @@ import BraintreeCore
                 "challengeRequested": request.challengeRequested,
                 "exemptionRequested": request.exemptionRequested,
                 "requestedExemptionType": request.requestedExemptionType.stringValue,
-                "dataOnlyRequested": request.dataOnlyRequested,
-                "customFields": request.customFields
+                "dataOnlyRequested": request.dataOnlyRequested
             ]
+
+            if let customFields = request.customFields {
+                requestParameters["customFields"] = customFields
+            }
 
             if request._cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
                 requestParameters["cardAdd"] = true


### PR DESCRIPTION
### Summary of changes

- I noticed on recent CI runs that all of the UI tests for 3D Secure were failing, this is due to the additional of custom fields that are not set up in the gateway - updated to remove these from the ViewController since they were not set on the Android PR: https://github.com/braintree/braintree_android/pull/1044
- Additionally I noticed that with this removed 3DS was still not launching, this is because we were not checking that `customFields` was not nil before adding it to the request dictionary - this is implemented correctly in the Android PR

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
