### PR TITLE
[OPEN DEV] Add Swiftlint to `BraintreeApplePay`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@
 # Paths to include in lint
 included:
   - Sources/BraintreeCore
+  - Sources/BraintreeApplePay
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -59,7 +59,7 @@ import BraintreeCore
     /// - Throws: An `Error` describing the failure
     public func makePaymentRequest() async throws -> PKPaymentRequest {
         try await withCheckedThrowingContinuation { continuation in
-            makePaymentRequest() { paymentRequest, error in
+            makePaymentRequest { paymentRequest, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let paymentRequest {
@@ -102,7 +102,7 @@ import BraintreeCore
                     return
                 }
 
-                guard let applePayNonce: BTApplePayCardNonce = BTApplePayCardNonce(json: body["applePayCards"][0]) else {
+                guard let applePayNonce = BTApplePayCardNonce(json: body["applePayCards"][0]) else {
                     self.notifyFailure(with: BTApplePayError.failedToCreateNonce, completion: completion)
                     return
                 }

--- a/Sources/BraintreeApplePay/BTApplePayError.swift
+++ b/Sources/BraintreeApplePay/BTApplePayError.swift
@@ -28,7 +28,9 @@ public enum BTApplePayError: Int, Error, CustomNSError, LocalizedError, Equatabl
         case .unknown:
             return ""
         case .unsupported:
+            // swiftlint:disable line_length
             return "Apple Pay is not enabled for this merchant. Please ensure that Apple Pay is enabled in the control panel and then try saving an Apple Pay payment method again."
+            // swiftlint:enable line_length
         case .noApplePayCardsReturned:
             return "No Apple Pay Card data was returned. Please contact support."
         case .failedToCreateNonce:


### PR DESCRIPTION
### Summary of changes

- Add `BraintreeApplePay` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreeApplePay` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 