### PR TITLE
Set `URLSessionConfiguration` timeouts to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## unreleased
 * BraintreeThreeDSecure
   * Add error code and error message for `exceededTimeoutLimit`  
-* Prevent duplicate outbound `v1/configuration` requests
+* BraintreeCore
+  * Prevent duplicate outbound `v1/configuration` requests
+  * Add network timeout of 30 seconds
 
 ## 6.23.0 (2024-07-15)
 * BraintreeShopperInsights (BETA)

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -26,6 +26,8 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
     lazy var session: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = defaultHeaders
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30
         
         let delegateQueue = OperationQueue()
         delegateQueue.name = "com.braintreepayments.BTHTTP"

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -779,6 +779,12 @@ final class BTHTTP_Tests: XCTestCase {
         XCTAssertNotNil(mockDelegate.receivedStartTime)
         XCTAssertNotNil(mockDelegate.receivedEndTime)
     }
+    
+    func testURLSessionConfiguration_hasCustomTimeoutSettings() {
+        let sut = BTHTTP(authorization: fakeTokenizationKey)
+        XCTAssertEqual(sut.session.configuration.timeoutIntervalForRequest, 30)
+        XCTAssertEqual(sut.session.configuration.timeoutIntervalForRequest, 30)
+    }
 
     // MARK: - Helper Methods
 


### PR DESCRIPTION
### Summary of changes

- Now that we are collecting data ([original PR](https://github.com/braintree/braintree_ios/pull/1292)) on how much time the SDK spends waiting for each network request to complete, we observed some incredibly long outlier datapoints. See the below image for examples:
![Screenshot 2024-07-19 at 10 25 09 AM](https://github.com/user-attachments/assets/dcfe94c7-3983-4c75-95c5-b69575fef875)
- The goal of this PR is to reduce the max timeout for each API request. Currently, we're using Apple's defaults which are:
     - The default [timeoutIntervalForRequest](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest) is 60 seconds.
    - The default [timeoutIntervalForResource](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408153-timeoutintervalforresource) is 7 days.
- This PR matches our [Android SDK](https://github.com/braintree/braintree_android/blob/556ec64baf80e6811438e3eef1313bc42ce199dc/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpRequest.java#L45) and reduces the timeout to 30 seconds.
    - This will allow our merchants to get notified of network errors sooner and allow them to retry or proceed however they please.
    
### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 