### PR TITLE
Cleanup - remove BTAnalyticsService singleton pattern

### DIFF
--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -13,6 +13,9 @@ class BTAnalyticsService {
     var http: BTHTTP
 
     /// Exposed for testing only
+    var configurationLoader: ConfigurationLoader
+    
+    /// Exposed for testing only
     var shouldBypassTimerQueue = false
 
     // MARK: - Private Properties
@@ -25,7 +28,6 @@ class BTAnalyticsService {
     private static let timer = RepeatingTimer(timeInterval: timeInterval)
     
     private let authorization: ClientAuthorization
-    private let configurationLoader: ConfigurationLoader
     private let metadata: BTClientMetadata
     
     // MARK: - Initializer

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -25,14 +25,7 @@ import Foundation
     var configurationLoader: ConfigurationLoader
     
     /// Exposed for testing analytics
-    /// By default, the `BTAnalyticsService` instance is static/shared so that only one queue of events exists.
-    /// The "singleton" is managed here because the analytics service depends on `BTAPIClient`.
-    weak var analyticsService: BTAnalyticsService? {
-        get { BTAPIClient._analyticsService }
-        set { BTAPIClient._analyticsService = newValue }
-    }
-
-    private static var _analyticsService: BTAnalyticsService?
+    var analyticsService: BTAnalyticsService
 
     // MARK: - Initializers
 
@@ -63,9 +56,9 @@ import Foundation
         let btHttp = BTHTTP(authorization: self.authorization)
         http = btHttp
         configurationLoader = ConfigurationLoader(http: btHttp)
-        
+        analyticsService = BTAnalyticsService(authorization: self.authorization, metadata: self.metadata)
+
         super.init()
-        BTAPIClient._analyticsService = BTAnalyticsService(apiClient: self)
         http?.networkTimingDelegate = self
 
         // Kickoff the background request to fetch the config
@@ -319,7 +312,7 @@ import Foundation
         linkType: String? = nil,
         payPalContextID: String? = nil
     ) {
-        analyticsService?.sendAnalyticsEvent(
+        analyticsService.sendAnalyticsEvent(
             eventName,
             correlationID: correlationID,
             errorDescription: errorDescription,
@@ -404,7 +397,7 @@ import Foundation
         let cleanedPath = path.replacingOccurrences(of: "/merchants/([A-Za-z0-9]+)/client_api", with: "", options: .regularExpression)
 
         if cleanedPath != "/v1/tracking/batch/events" {
-            analyticsService?.sendAnalyticsEvent(
+            analyticsService.sendAnalyticsEvent(
                 BTCoreAnalytics.apiRequestLatency,
                 connectionStartTime: connectionStartTime,
                 endpoint: cleanedPath,

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -8,7 +8,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
     var oneSecondLater: UInt64!
     var analyticsService: BTAnalyticsService!
     let fakeAuth = try! TokenizationKey("development_tokenization_key")
-    let fakeConfig = BTConfiguration(json: BTJSON(value: ["test": "value", "environment": "fake-env1"]))
+    let fakeConfig = BTConfiguration(json: BTJSON(value: ["merchantId": "fake-id", "environment": "fake-env1"]))
     
     override func setUp() {
         super.setUp()

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -6,7 +6,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
 
     var currentTime: UInt64!
     var oneSecondLater: UInt64!
-    var sut: BTAnalyticsService!
+    var analyticsService: BTAnalyticsService!
     let fakeAuth = try! TokenizationKey("development_tokenization_key")
     let fakeConfig = BTConfiguration(json: BTJSON(value: ["test": "value", "environment": "fake-env1"]))
     
@@ -15,22 +15,22 @@ final class BTAnalyticsService_Tests: XCTestCase {
         currentTime = UInt64(Date().timeIntervalSince1970 * 1000)
         oneSecondLater = UInt64((Date().timeIntervalSince1970 * 1000) + 999)
         
-        sut = BTAnalyticsService(authorization: fakeAuth, configuration: fakeConfig, metadata: BTClientMetadata())
+        analyticsService = BTAnalyticsService(authorization: fakeAuth, configuration: fakeConfig, metadata: BTClientMetadata())
     }
 
     func testSendAnalyticsEvent_whenConfigFetchCompletes_setsUpAnalyticsHTTPToUseBaseURL() async {
-        await sut.performEventRequest("any.analytics.event")
+        await analyticsService.performEventRequest("any.analytics.event")
         
-        XCTAssertEqual(sut.http.customBaseURL?.absoluteString, "https://api.paypal.com")
+        XCTAssertEqual(analyticsService.http.customBaseURL?.absoluteString, "https://api.paypal.com")
     }
 
     func testSendAnalyticsEvent_sendsAnalyticsEvent() async {
         let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
         
-        sut.shouldBypassTimerQueue = true
-        sut.http = mockAnalyticsHTTP
+        analyticsService.shouldBypassTimerQueue = true
+        analyticsService.http = mockAnalyticsHTTP
         
-        await sut.performEventRequest("any.analytics.event")
+        await analyticsService.performEventRequest("any.analytics.event")
         
         XCTAssertEqual(mockAnalyticsHTTP.lastRequestEndpoint, "v1/tracking/batch/events")
         

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -7,7 +7,8 @@ final class BTAnalyticsService_Tests: XCTestCase {
     var currentTime: UInt64!
     var oneSecondLater: UInt64!
     let fakeAuth = try! TokenizationKey("development_tokenization_key")
-
+    let fakeConfig = BTConfiguration(json: BTJSON(value: ["test": "value", "environment": "fake-env1"]))
+    
     override func setUp() {
         super.setUp()
         currentTime = UInt64(Date().timeIntervalSince1970 * 1000)
@@ -15,7 +16,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
     }
 
     func testSendAnalyticsEvent_whenConfigFetchCompletes_setsUpAnalyticsHTTPToUseBaseURL() async {
-        let analyticsService = BTAnalyticsService(authorization: fakeAuth, metadata: BTClientMetadata())
+        let analyticsService = BTAnalyticsService(authorization: fakeAuth, configuration: fakeConfig, metadata: BTClientMetadata())
         
         await analyticsService.performEventRequest("any.analytics.event")
         
@@ -24,13 +25,10 @@ final class BTAnalyticsService_Tests: XCTestCase {
 
     func testSendAnalyticsEvent_sendsAnalyticsEvent() async {
         let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
-        let mockConfigLoader = MockConfigurationLoader(http: mockAnalyticsHTTP)
-        mockConfigLoader.mockConfig = BTConfiguration(json: BTJSON(value: ["merchantId": "a-fake-merchantID"]))
         
-        let analyticsService = BTAnalyticsService(authorization: fakeAuth, metadata: BTClientMetadata())
+        let analyticsService = BTAnalyticsService(authorization: fakeAuth, configuration: fakeConfig, metadata: BTClientMetadata())
         analyticsService.shouldBypassTimerQueue = true
         analyticsService.http = mockAnalyticsHTTP
-        analyticsService.configurationLoader = mockConfigLoader
         
         await analyticsService.performEventRequest("any.analytics.event")
         

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -4,6 +4,14 @@ import Foundation
 class FakeAnalyticsService: BTAnalyticsService {
     var lastEvent: String? = nil
     var endpoint: String? = nil
+    
+    convenience init() {
+        self.init(
+            authorization: try! TokenizationKey("development_tokenization_key"),
+            configuration:  BTConfiguration(json: BTJSON(value: ["environment": "fake-env1"])),
+            metadata: BTClientMetadata()
+        )
+    }
 
     override func sendAnalyticsEvent(
         _ eventName: String,

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -290,6 +290,8 @@ class BTAPIClient_Tests: XCTestCase {
 
     func testAnalyticsService_isCreatedDuringInitialization() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
+        
+        let mockConfigurationLoader = MockConfigurationLoader(
         XCTAssertTrue(apiClient?.analyticsService is BTAnalyticsService)
     }
 

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -294,28 +294,20 @@ class BTAPIClient_Tests: XCTestCase {
     }
 
     func testSendAnalyticsEvent_whenCalled_callsAnalyticsService() {
-        let tokenizationKey = "development_tokenization_key"
-        let apiClient = BTAPIClient(authorization: tokenizationKey)!
-        let mockAnalyticsService = FakeAnalyticsService(
-            authorization: try! TokenizationKey(tokenizationKey),
-            metadata: BTClientMetadata()
-        )
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
+        let mockAnalyticsService = FakeAnalyticsService()
+
         apiClient.analyticsService = mockAnalyticsService
-        
         apiClient.sendAnalyticsEvent("blahblah")
 
         XCTAssertEqual(mockAnalyticsService.lastEvent, "blahblah")
     }
 
     func testFetchAPITiming_whenConfigurationPathIsValid_sendsLatencyEvent() {
-        let tokenizationKey = "development_tokenization_key"
-        let apiClient = BTAPIClient(authorization: tokenizationKey)!
-        let mockAnalyticsService = FakeAnalyticsService(
-            authorization: try! TokenizationKey(tokenizationKey),
-            metadata: BTClientMetadata()
-        )
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
+        let mockAnalyticsService = FakeAnalyticsService()
         apiClient.analyticsService = mockAnalyticsService
-        
+
         apiClient.fetchAPITiming(
             path: "/merchants/1234567890/client_api/v1/configuration",
             connectionStartTime: 123,
@@ -329,12 +321,8 @@ class BTAPIClient_Tests: XCTestCase {
     }
 
     func testFetchAPITiming_whenPathIsBatchEvents_doesNotSendLatencyEvent() {
-        let tokenizationKey = "development_tokenization_key"
-        let apiClient = BTAPIClient(authorization: tokenizationKey)!
-        let mockAnalyticsService = FakeAnalyticsService(
-            authorization: try! TokenizationKey(tokenizationKey),
-            metadata: BTClientMetadata()
-        )
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
+        let mockAnalyticsService = FakeAnalyticsService()
         apiClient.analyticsService = mockAnalyticsService
 
         apiClient.fetchAPITiming(
@@ -350,12 +338,8 @@ class BTAPIClient_Tests: XCTestCase {
     }
 
     func testFetchAPITiming_whenPathIsNotBatchEvents_sendLatencyEvent() {
-        let tokenizationKey = "development_tokenization_key"
-        let apiClient = BTAPIClient(authorization: tokenizationKey)!
-        let mockAnalyticsService = FakeAnalyticsService(
-            authorization: try! TokenizationKey(tokenizationKey),
-            metadata: BTClientMetadata()
-        )
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
+        let mockAnalyticsService = FakeAnalyticsService()
         apiClient.analyticsService = mockAnalyticsService
 
         apiClient.fetchAPITiming(

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -288,32 +288,34 @@ class BTAPIClient_Tests: XCTestCase {
 
     // MARK: - Analytics
 
-    func testAnalyticsService_byDefault_isASingleton() {
-        let firstAPIClient = BTAPIClient(authorization: "development_testing_integration_merchant_id")
-        let secondAPIClient = BTAPIClient(authorization: "development_testing_integration_merchant_id")
-        XCTAssertEqual(firstAPIClient?.analyticsService, secondAPIClient?.analyticsService)
-    }
-
     func testAnalyticsService_isCreatedDuringInitialization() {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
         XCTAssertTrue(apiClient?.analyticsService is BTAnalyticsService)
     }
 
     func testSendAnalyticsEvent_whenCalled_callsAnalyticsService() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
-
+        let tokenizationKey = "development_tokenization_key"
+        let apiClient = BTAPIClient(authorization: tokenizationKey)!
+        let mockAnalyticsService = FakeAnalyticsService(
+            authorization: try! TokenizationKey(tokenizationKey),
+            metadata: BTClientMetadata()
+        )
         apiClient.analyticsService = mockAnalyticsService
+        
         apiClient.sendAnalyticsEvent("blahblah")
 
         XCTAssertEqual(mockAnalyticsService.lastEvent, "blahblah")
     }
 
     func testFetchAPITiming_whenConfigurationPathIsValid_sendsLatencyEvent() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
+        let tokenizationKey = "development_tokenization_key"
+        let apiClient = BTAPIClient(authorization: tokenizationKey)!
+        let mockAnalyticsService = FakeAnalyticsService(
+            authorization: try! TokenizationKey(tokenizationKey),
+            metadata: BTClientMetadata()
+        )
         apiClient.analyticsService = mockAnalyticsService
-
+        
         apiClient.fetchAPITiming(
             path: "/merchants/1234567890/client_api/v1/configuration",
             connectionStartTime: 123,
@@ -327,8 +329,12 @@ class BTAPIClient_Tests: XCTestCase {
     }
 
     func testFetchAPITiming_whenPathIsBatchEvents_doesNotSendLatencyEvent() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
+        let tokenizationKey = "development_tokenization_key"
+        let apiClient = BTAPIClient(authorization: tokenizationKey)!
+        let mockAnalyticsService = FakeAnalyticsService(
+            authorization: try! TokenizationKey(tokenizationKey),
+            metadata: BTClientMetadata()
+        )
         apiClient.analyticsService = mockAnalyticsService
 
         apiClient.fetchAPITiming(
@@ -344,8 +350,12 @@ class BTAPIClient_Tests: XCTestCase {
     }
 
     func testFetchAPITiming_whenPathIsNotBatchEvents_sendLatencyEvent() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
-        let mockAnalyticsService = FakeAnalyticsService(apiClient: apiClient)
+        let tokenizationKey = "development_tokenization_key"
+        let apiClient = BTAPIClient(authorization: tokenizationKey)!
+        let mockAnalyticsService = FakeAnalyticsService(
+            authorization: try! TokenizationKey(tokenizationKey),
+            metadata: BTClientMetadata()
+        )
         apiClient.analyticsService = mockAnalyticsService
 
         apiClient.fetchAPITiming(

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -288,11 +288,15 @@ class BTAPIClient_Tests: XCTestCase {
 
     // MARK: - Analytics
 
-    func testAnalyticsService_isCreatedDuringInitialization() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
+    func testAnalyticsService_afterConfigFetch_isCreatedDuringInitialization() {
+        try? ConfigurationCache.shared.putInCache(
+            authorization: "development_tokenization_key",
+            configuration: BTConfiguration(json: BTJSON(value: ["merchantId": "fake-id", "environment": "fake-env1"]))
+        )
         
-        let mockConfigurationLoader = MockConfigurationLoader(
-        XCTAssertTrue(apiClient?.analyticsService is BTAnalyticsService)
+        let apiClient = BTAPIClient(authorization: "development_tokenization_key")!
+        
+        XCTAssertNotNil(apiClient.analyticsService)
     }
 
     func testSendAnalyticsEvent_whenCalled_callsAnalyticsService() {

--- a/UnitTests/BraintreeCoreTests/Configuration/MockConfigurationLoader.swift
+++ b/UnitTests/BraintreeCoreTests/Configuration/MockConfigurationLoader.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class MockConfigurationLoader: ConfigurationLoader {
     
-    private let mockConfig: BTConfiguration?
+    var mockConfig: BTConfiguration?
     private let mockError: Error?
     
     init(http: BTHTTP, mockConfig: BTConfiguration? = nil, mockError: Error? = nil) {

--- a/UnitTests/BraintreeCoreTests/Configuration/MockConfigurationLoader.swift
+++ b/UnitTests/BraintreeCoreTests/Configuration/MockConfigurationLoader.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class MockConfigurationLoader: ConfigurationLoader {
     
-    var mockConfig: BTConfiguration?
+    private let mockConfig: BTConfiguration?
     private let mockError: Error?
     
     init(http: BTHTTP, mockConfig: BTConfiguration? = nil, mockError: Error? = nil) {


### PR DESCRIPTION
### Summary of changes

- Remove [this weird singleton instance logic](https://github.com/braintree/braintree_ios/blob/94e22368d4aea7f1dd79f2c74177eff17afe5e21/Sources/BraintreeCore/BTAPIClient.swift#L27-L35) in BTAPIClient
    - This was a remnant from our Objective-C days. It's original intent was to make sure we persisted the pending queue/list of events, even if a new BTAPIClient instance was instantiated. This is now taken care of by using a static array of events (see `BTAnalyticsEventsStorage` in this PR https://github.com/braintree/braintree_ios/pull/1295)
- Remove cyclic dependency b/w BTAPIClient <--> BTAnalyticsService
- Move to dependency injection of `BTConfiguration` into `BTAnalyticsService` vs having `BTAnalyticsService` make another fetch (or reference to ConfigurationLoader)
    - Rich, Jax, and I discussed this internally. This is OK because each APIClient instance is associated with 1 auth credential. The auth credential is the unique key to our ConfigurationCache.

Note: I was trying to fix the bug in DTMOBILES-882. This PR doesn't fix that bug, but cleans things up. We will need an additional fix to address that issue.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
