### PR TITLE
Update 3DS and GraphQL Endpoint Sent to FPTI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * BraintreeCore
   * Prevent duplicate outbound `v1/configuration` requests
   * Add network timeout of 30 seconds
+  * Update `endpoint` syntax sent to FPTI for 3D Secure and Venmo flows
 
 ## 6.23.0 (2024-07-15)
 * BraintreeShopperInsights (BETA)

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -403,7 +403,21 @@ import Foundation
     func fetchAPITiming(path: String, connectionStartTime: Int?, requestStartTime: Int?, startTime: Int, endTime: Int) {
         let cleanedPath = path.replacingOccurrences(of: "/merchants/([A-Za-z0-9]+)/client_api", with: "", options: .regularExpression)
 
-        if cleanedPath != "/v1/tracking/batch/events" {
+        if cleanedPath.contains("three_d_secure") {
+            let threeDSecurePath = cleanedPath.replacingOccurrences(
+                of: "payment_methods/.*/three_d_secure",
+                with: "payment_methods/three_d_secure",
+                options: .regularExpression
+            )
+            analyticsService?.sendAnalyticsEvent(
+                BTCoreAnalytics.apiRequestLatency,
+                connectionStartTime: connectionStartTime,
+                endpoint: threeDSecurePath,
+                endTime: endTime,
+                requestStartTime: requestStartTime,
+                startTime: startTime
+            )
+        } else if cleanedPath != "/v1/tracking/batch/events" {
             analyticsService?.sendAnalyticsEvent(
                 BTCoreAnalytics.apiRequestLatency,
                 connectionStartTime: connectionStartTime,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -401,23 +401,14 @@ import Foundation
     // MARK: BTAPITimingDelegate conformance
 
     func fetchAPITiming(path: String, connectionStartTime: Int?, requestStartTime: Int?, startTime: Int, endTime: Int) {
-        let cleanedPath = path.replacingOccurrences(of: "/merchants/([A-Za-z0-9]+)/client_api", with: "", options: .regularExpression)
+        var cleanedPath = path.replacingOccurrences(of: "/merchants/([A-Za-z0-9]+)/client_api", with: "", options: .regularExpression)
+        cleanedPath = cleanedPath.replacingOccurrences(
+            of: "payment_methods/.*/three_d_secure",
+            with: "payment_methods/three_d_secure",
+            options: .regularExpression
+        )
 
-        if cleanedPath.contains("three_d_secure") {
-            let threeDSecurePath = cleanedPath.replacingOccurrences(
-                of: "payment_methods/.*/three_d_secure",
-                with: "payment_methods/three_d_secure",
-                options: .regularExpression
-            )
-            analyticsService?.sendAnalyticsEvent(
-                BTCoreAnalytics.apiRequestLatency,
-                connectionStartTime: connectionStartTime,
-                endpoint: threeDSecurePath,
-                endTime: endTime,
-                requestStartTime: requestStartTime,
-                startTime: startTime
-            )
-        } else if cleanedPath != "/v1/tracking/batch/events" {
+        if cleanedPath != "/v1/tracking/batch/events" {
             analyticsService?.sendAnalyticsEvent(
                 BTCoreAnalytics.apiRequestLatency,
                 connectionStartTime: connectionStartTime,

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -446,14 +446,12 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
         let json = try? JSONSerialization.jsonObject(with: data)
         let body = BTJSON(value: json)
         
-        if let mutationName = body["operationName"].asString() {
-            return "mutation \(mutationName)"
-        } else if let query = body["query"].asString() {
-            let queryDiscardHolder = query.replacingOccurrences(of: #"^[^\(]*"#, with: "", options: .regularExpression)
-            let finalQuery = query.replacingOccurrences(of: queryDiscardHolder, with: "")
-            return finalQuery
+        guard let query = body["query"].asString() else {
+            return nil
         }
 
-        return nil
+        let queryDiscardHolder = query.replacingOccurrences(of: #"^[^\(]*"#, with: "", options: .regularExpression)
+        let finalQuery = query.replacingOccurrences(of: queryDiscardHolder, with: "")
+        return finalQuery
     }
 }

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -446,8 +446,14 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
         let json = try? JSONSerialization.jsonObject(with: data)
         let body = BTJSON(value: json)
         
-        guard let mutationName = body["operationName"].asString() else { return nil }
-        
-        return "mutation \(mutationName)"
+        if let mutationName = body["operationName"].asString() {
+            return "mutation \(mutationName)"
+        } else if let query = body["query"].asString() {
+            let queryDiscardHolder = query.replacingOccurrences(of: #"^[^\(]*"#, with: "", options: .regularExpression)
+            let finalQuery = query.replacingOccurrences(of: queryDiscardHolder, with: "")
+            return finalQuery
+        }
+
+        return nil
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -757,7 +757,8 @@ final class BTHTTP_Tests: XCTestCase {
         var originalRequest = URLRequest(url: URL(string: "https://example.com/graphql")!)
         originalRequest.httpBody = """
             {
-                "operationName": "TestMutation"
+                "operationName": "TestMutation",
+                "query": "mutation TestMutation()"
             }
             """.data(using: .utf8)
         let task = testURLSession.dataTask(with: originalRequest)


### PR DESCRIPTION
### Summary of changes

- 3D Secure: remove token/unique ID from path
- GraphQL: remove reliance on `operationName` since this is only present for card, causing us not to send the correct path for the Venmo flow
- Both endpoints sending as expected have been verified in FPTI and via breakpoints, additionally all endpoint have been checked to ensure we are sending the expected paths now

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
