### PR TITLE
PayPal Payment Type Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPal
+  * Fix bug where `BTPayPalCheckoutRequest` was not passing the correct data causing issues with some transaction attempts
+
 ## 6.23.1 (2024-07-24)
 * BraintreeThreeDSecure
   * Add error code and error message for `exceededTimeoutLimit`  

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -291,7 +291,12 @@ import BraintreeDataCollector
 
         switch returnURL.state {
         case .succeeded, .canceled:
-            handleReturn(url, paymentType: .vault, completion: appSwitchCompletion)
+            guard let payPalRequest else {
+                notifyFailure(with: BTPayPalError.missingPayPalRequest, completion: appSwitchCompletion)
+                return
+            }
+
+            handleReturn(url, paymentType: payPalRequest.paymentType, completion: appSwitchCompletion)
         case .unknownPath:
             notifyFailure(with: BTPayPalError.appSwitchReturnURLPathInvalid, completion: appSwitchCompletion)
         }
@@ -443,6 +448,7 @@ import BraintreeDataCollector
                     notifyFailure(with: BTPayPalError.missingPayPalRequest, completion: appSwitchCompletion)
                     return
                 }
+
                 handleReturn(url, paymentType: payPalRequest.paymentType, completion: completion)
             case .unknownPath:
                 notifyFailure(with: BTPayPalError.asWebAuthenticationSessionURLInvalid(url.absoluteString), completion: completion)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -291,7 +291,11 @@ import BraintreeDataCollector
 
         switch returnURL.state {
         case .succeeded, .canceled:
-            handleReturn(url, paymentType: .vault, completion: appSwitchCompletion)
+            guard let payPalRequest else {
+                notifyFailure(with: BTPayPalError.missingPayPalRequest, completion: appSwitchCompletion)
+                return
+            }
+            handleReturn(url, paymentType: payPalRequest.paymentType, completion: appSwitchCompletion)
         case .unknownPath:
             notifyFailure(with: BTPayPalError.appSwitchReturnURLPathInvalid, completion: appSwitchCompletion)
         }
@@ -439,7 +443,11 @@ import BraintreeDataCollector
 
             switch returnURL.state {
             case .succeeded, .canceled:
-                handleReturn(url, paymentType: .vault, completion: completion)
+                guard let payPalRequest else {
+                    notifyFailure(with: BTPayPalError.missingPayPalRequest, completion: appSwitchCompletion)
+                    return
+                }
+                handleReturn(url, paymentType: payPalRequest.paymentType, completion: completion)
             case .unknownPath:
                 notifyFailure(with: BTPayPalError.asWebAuthenticationSessionURLInvalid(url.absoluteString), completion: completion)
             }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -291,11 +291,7 @@ import BraintreeDataCollector
 
         switch returnURL.state {
         case .succeeded, .canceled:
-            guard let payPalRequest else {
-                notifyFailure(with: BTPayPalError.missingPayPalRequest, completion: appSwitchCompletion)
-                return
-            }
-            handleReturn(url, paymentType: payPalRequest.paymentType, completion: appSwitchCompletion)
+            handleReturn(url, paymentType: .vault, completion: appSwitchCompletion)
         case .unknownPath:
             notifyFailure(with: BTPayPalError.appSwitchReturnURLPathInvalid, completion: appSwitchCompletion)
         }

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -42,6 +42,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 12. Missing BA Token for App Switch
     case missingBAToken
 
+    /// 13. Missing PayPal Request
+    case missingPayPalRequest
+
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
     }
@@ -74,6 +77,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 11
         case .missingBAToken:
             return 12
+        case .missingPayPalRequest:
+            return 13
         }
     }
 
@@ -105,6 +110,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "UIApplication failed to perform app switch to PayPal."
         case .missingBAToken:
             return "Missing BA Token for PayPal App Switch."
+        case .missingPayPalRequest:
+            return "The PayPal Request was missing or invalid."
         }
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -424,8 +424,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let paypalAccount = lastPostParameters["paypal_account"] as! [String: Any]
         XCTAssertEqual(paypalAccount["intent"] as? String, "sale")
 
-        let options = paypalAccount["options"] as! [String:
-                                                        Any]
+        let options = paypalAccount["options"] as! [String: Any]
         XCTAssertFalse(options["validate"] as! Bool)
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -416,16 +416,29 @@ class BTPayPalClient_Tests: XCTestCase {
         payPalClient.payPalRequest = payPalRequest
 
         let returnURL = URL(string: "bar://onetouch/v1/success?token=hermes_token")!
-        payPalClient.handleReturn(returnURL, paymentType: .checkout) { _, _ in }
+        payPalClient.handleReturn(returnURL, paymentType: payPalRequest.paymentType) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.lastPOSTPath, "/v1/payment_methods/paypal_accounts")
 
         let lastPostParameters = mockAPIClient.lastPOSTParameters!
-        let paypalAccount = lastPostParameters["paypal_account"] as! [String:Any]
+        let paypalAccount = lastPostParameters["paypal_account"] as! [String: Any]
         XCTAssertEqual(paypalAccount["intent"] as? String, "sale")
 
-        let options = paypalAccount["options"] as! [String:Any]
+        let options = paypalAccount["options"] as! [String:
+                                                        Any]
         XCTAssertFalse(options["validate"] as! Bool)
+    }
+
+    func testHandleBrowserSwitchReturn_whenBrowserSwitchSucceeds_intentShouldBeNilForVaultRequests() {
+        let payPalRequest = BTPayPalVaultRequest()
+        let returnURL = URL(string: "bar://onetouch/v1/success?ec-token=ec_token")!
+        payPalClient.handleReturn(returnURL, paymentType: payPalRequest.paymentType) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.lastPOSTPath, "/v1/payment_methods/paypal_accounts")
+
+        let lastPostParameters = mockAPIClient.lastPOSTParameters!
+        let paypalAccount = lastPostParameters["paypal_account"] as! [String: Any]
+        XCTAssertNil(paypalAccount["intent"])
     }
 
     func testHandleBrowserSwitchReturn_whenBrowserSwitchSucceeds_merchantAccountIdIsSet() {


### PR DESCRIPTION
### Summary of changes

- Fix bug where we were hardcoding the `paymentType` to `vault` when returning from `webAuthenticationSession.start` -this caused us to not pass the correct parameters to the Gateway as this block was never executed for the Checkout flow: https://github.com/braintree/braintree_ios/blob/7b81129478fb3302b2ffacdbb4ade80e561faef7/Sources/BraintreePayPal/BTPayPalClient.swift#L225-L230

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
