### PR TITLE
Move `timeInterval` Default Value

### DIFF
--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -20,11 +20,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     // MARK: - Private Properties
     
     private let events = BTAnalyticsEventsStorage()
-    
-    /// Amount of time, in seconds, between batch API requests sent to FPTI
-    private static let timeInterval = 15
-    
-    private let timer = RepeatingTimer(timeInterval: timeInterval)
+    private let timer = RepeatingTimer()
 
     private weak var apiClient: BTAPIClient?
             

--- a/Sources/BraintreeCore/Analytics/RepeatingTimer.swift
+++ b/Sources/BraintreeCore/Analytics/RepeatingTimer.swift
@@ -33,7 +33,8 @@ final class RepeatingTimer {
     
     // MARK: - Initializer
     
-    init(timeInterval: Int) {
+    /// exposed for testing shorter time intervals
+    init(timeInterval: Int = 15) {
         self.timeInterval = timeInterval
     }
         


### PR DESCRIPTION
### Summary of changes

- Move `timeInterval` default value into `RepeatingTimer` init - `BTAnalyticsService` should not need to know about our timer's default

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
