### PR TITLE
Cleanup App Switch

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		BED00CAE28A5419900D74AEC /* BTBinData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAD28A5419900D74AEC /* BTBinData.swift */; };
 		BED00CB028A579D700D74AEC /* BTClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CAF28A579D700D74AEC /* BTClientToken.swift */; };
 		BED00CB228A57AD400D74AEC /* BTClientTokenError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */; };
+		BED3A2C62C5D74B20034D9A6 /* LinkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED3A2C52C5D74AC0034D9A6 /* LinkType.swift */; };
 		BED7493628579BAC0074C818 /* BTURLUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED7493528579BAC0074C818 /* BTURLUtils.swift */; };
 		BEDA91A028EDDE64007441D9 /* FakeAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDA919F28EDDE64007441D9 /* FakeAnalyticsService.swift */; };
 		BEDB820229B109EE00075AF3 /* BTApplePayAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB820129B109EE00075AF3 /* BTApplePayAnalytics.swift */; };
@@ -1066,6 +1067,7 @@
 		BED00CAD28A5419900D74AEC /* BTBinData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBinData.swift; sourceTree = "<group>"; };
 		BED00CAF28A579D700D74AEC /* BTClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientToken.swift; sourceTree = "<group>"; };
 		BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTClientTokenError.swift; sourceTree = "<group>"; };
+		BED3A2C52C5D74AC0034D9A6 /* LinkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkType.swift; sourceTree = "<group>"; };
 		BED7493528579BAC0074C818 /* BTURLUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTURLUtils.swift; sourceTree = "<group>"; };
 		BEDA919F28EDDE64007441D9 /* FakeAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAnalyticsService.swift; sourceTree = "<group>"; };
 		BEDB820129B109EE00075AF3 /* BTApplePayAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayAnalytics.swift; sourceTree = "<group>"; };
@@ -1599,6 +1601,7 @@
 				BEE2E4E5290080BD00C03FDD /* BTAnalyticsServiceError.swift */,
 				BEF388C02BE52CD2000965C8 /* BTCoreAnalytics.swift */,
 				800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */,
+				BED3A2C52C5D74AC0034D9A6 /* LinkType.swift */,
 				457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */,
 			);
 			path = Analytics;
@@ -3312,6 +3315,7 @@
 				BE63A3A7288F3026001936DA /* BTPostalAddress.swift in Sources */,
 				BE2F98D028A2BCCD008EF189 /* BTConfiguration.swift in Sources */,
 				804DC45D2B2D08FF00F17A15 /* BTConfigurationRequest.swift in Sources */,
+				BED3A2C62C5D74B20034D9A6 /* LinkType.swift in Sources */,
 				BED00CB228A57AD400D74AEC /* BTClientTokenError.swift in Sources */,
 				BE24C67328E73E810067B11A /* BTAPIClientHTTPType.swift in Sources */,
 				457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */,

--- a/Sources/BraintreeCore/Analytics/LinkType.swift
+++ b/Sources/BraintreeCore/Analytics/LinkType.swift
@@ -1,5 +1,6 @@
 /// Used to describe the link type for analytics
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
 public enum LinkType: String {
     case universal
     case deeplink

--- a/Sources/BraintreeCore/Analytics/LinkType.swift
+++ b/Sources/BraintreeCore/Analytics/LinkType.swift
@@ -1,0 +1,6 @@
+/// Used to describe the link type for analytics
+/// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+public enum LinkType: String {
+    case universal = "universal"
+    case deeplink = "deeplink"
+}

--- a/Sources/BraintreeCore/Analytics/LinkType.swift
+++ b/Sources/BraintreeCore/Analytics/LinkType.swift
@@ -1,6 +1,6 @@
 /// Used to describe the link type for analytics
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 public enum LinkType: String {
-    case universal = "universal"
-    case deeplink = "deeplink"
+    case universal
+    case deeplink
 }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -310,7 +310,7 @@ import Foundation
         errorDescription: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
-        linkType: String? = nil,
+        linkType: LinkType? = nil,
         payPalContextID: String? = nil
     ) {
         analyticsService.sendAnalyticsEvent(
@@ -320,7 +320,7 @@ import Foundation
                 eventName: eventName,
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
-                linkType: linkType,
+                linkType: linkType?.rawValue,
                 payPalContextID: payPalContextID
             )
         )

--- a/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
+++ b/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
@@ -45,9 +45,8 @@ struct BTPayPalApprovalURLParser {
         return nil
     }
 
-    // TODO: do we need this
-    init?(body: BTJSON, linkType: LinkType?) {
-        if linkType == .universal, let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
+    init?(body: BTJSON) {
+        if let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
             redirectType = .payPalApp(url: payPalAppRedirectURL)
             url = payPalAppRedirectURL
         } else if let approvalURL = body["paymentResource"]["redirectUrl"].asURL() ??

--- a/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
+++ b/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
@@ -45,8 +45,9 @@ struct BTPayPalApprovalURLParser {
         return nil
     }
 
-    init?(body: BTJSON, linkType: String?) {
-        if linkType == "universal", let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
+    // TODO: do we need this
+    init?(body: BTJSON, linkType: LinkType?) {
+        if linkType == .universal, let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
             redirectType = .payPalApp(url: payPalAppRedirectURL)
             url = payPalAppRedirectURL
         } else if let approvalURL = body["paymentResource"]["redirectUrl"].asURL() ??

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -120,7 +120,7 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil) -> [String: Any] {
+    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
         var baseParameters = super.parameters(with: configuration)
         var checkoutParameters: [String: Any] = [
             "intent": intent.stringValue,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -62,7 +62,7 @@ import BraintreeDataCollector
     private var isConfigFromCache: Bool?
 
     /// Used for sending the type of flow, universal vs deeplink to FPTI
-    private var linkType: String? = nil
+    private var linkType: LinkType? = nil
 
     // MARK: - Initializer
 
@@ -308,7 +308,7 @@ import BraintreeDataCollector
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? "universal" : "deeplink"
+        linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? .universal : .deeplink
 
         apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeStarted, isVaultRequest: isVaultRequest, linkType: linkType)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -347,7 +347,7 @@ import BraintreeDataCollector
                     return
                 }
                 
-                guard let body, let approvalURL = BTPayPalApprovalURLParser(body: body, linkType: self.linkType) else {
+                guard let body, let approvalURL = BTPayPalApprovalURLParser(body: body) else {
                     self.notifyFailure(with: BTPayPalError.invalidURL("Missing approval URL in gateway response."), completion: completion)
                     return
                 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -332,7 +332,11 @@ import BraintreeDataCollector
             self.payPalRequest = request
             self.apiClient.post(
                 request.hermesPath,
-                parameters: request.parameters(with: configuration, universalLink: self.universalLink)
+                parameters: request.parameters(
+                    with: configuration,
+                    universalLink: self.universalLink,
+                    isPayPalAppInstalled: self.application.isPayPalAppInstalled()
+                )
             ) { body, response, error in
                 if let error = error as? NSError {
                     guard let jsonResponseBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON else {

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -37,9 +37,6 @@ import BraintreeDataCollector
     /// This allows us to set and return a completion in our methods that otherwise cannot require a completion.
     var appSwitchCompletion: (BTPayPalAccountNonce?, Error?) -> Void = { _, _ in }
 
-    /// Exposed for testing to check if the PayPal app is installed
-    var payPalAppInstalled: Bool = false
-
     /// True if `tokenize()` was called with a Vault request object type
     var isVaultRequest: Bool = false
 
@@ -311,8 +308,7 @@ import BraintreeDataCollector
         request: BTPayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
-        payPalAppInstalled = application.isPayPalAppInstalled()
-        linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true && payPalAppInstalled ? "universal" : "deeplink"
+        linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? "universal" : "deeplink"
 
         apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeStarted, isVaultRequest: isVaultRequest, linkType: linkType)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
@@ -331,10 +327,6 @@ import BraintreeDataCollector
             guard json["paypalEnabled"].isTrue else {
                 self.notifyFailure(with: BTPayPalError.disabled, completion: completion)
                 return
-            }
-
-            if !self.payPalAppInstalled {
-                (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch = false
             }
 
             self.payPalRequest = request

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -135,7 +135,7 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public func parameters(with configuration: BTConfiguration, universalLink: URL? = nil) -> [String: Any] {
+    public func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
         var experienceProfile: [String: Any] = [:]
 
         experienceProfile["no_shipping"] = !isShippingAddressRequired

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -42,7 +42,7 @@ struct BTPayPalReturnURL {
         url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success"))
     }
 
-    static func isValidURLAction(url: URL, linkType: String?) -> Bool {
+    static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {
         guard let host = url.host, let scheme = url.scheme, !scheme.isEmpty else {
             return false
         }
@@ -59,7 +59,7 @@ struct BTPayPalReturnURL {
 
         /// If we are using the deeplink/ASWeb based PayPal flow we want to check that the host and path matches
         /// the static callbackURLHostAndPath. For the universal link flow we do not care about this check.
-        if hostAndPath != BTPayPalRequest.callbackURLHostAndPath && linkType == "deeplink" {
+        if hostAndPath != BTPayPalRequest.callbackURLHostAndPath && linkType == .deeplink {
             return false
         }
 

--- a/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
@@ -27,7 +27,7 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil) -> [String: Any] {
+    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
         let baseParameters = super.parameters(with: configuration)
         var vaultParameters: [String: Any] = ["offer_paypal_credit": offerCredit]
 

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -19,6 +19,8 @@ import BraintreeCore
     /// - Warning: This property is currently in beta and may change or be removed in future releases.
     var enablePayPalAppSwitch: Bool = false
 
+    private var application: URLOpener = UIApplication.shared
+
     // MARK: - Initializers
 
     /// Initializes a PayPal Vault request for the PayPal App Switch flow
@@ -34,7 +36,7 @@ import BraintreeCore
         offerCredit: Bool = false
     ) {
         self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail)
-        self.enablePayPalAppSwitch = enablePayPalAppSwitch
+        self.enablePayPalAppSwitch = !application.isPayPalAppInstalled() ? false : enablePayPalAppSwitch
     }
 
     /// Initializes a PayPal Vault request

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -56,13 +56,14 @@ import BraintreeCore
             baseParameters["payer_email"] = userAuthenticationEmail
         }
         
-        if enablePayPalAppSwitch, application.isPayPalAppInstalled(), let universalLink {
+        if let universalLink, enablePayPalAppSwitch, application.isPayPalAppInstalled() {
             let appSwitchParameters: [String: Any] = [
                 "launch_paypal_app": enablePayPalAppSwitch,
                 "os_version": UIDevice.current.systemVersion,
                 "os_type": UIDevice.current.systemName,
                 "merchant_app_return_url": universalLink.absoluteString
             ]
+            
             return baseParameters.merging(appSwitchParameters) { $1 }
         }
 

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -19,7 +19,8 @@ import BraintreeCore
     /// - Warning: This property is currently in beta and may change or be removed in future releases.
     var enablePayPalAppSwitch: Bool = false
 
-    private var application: URLOpener = UIApplication.shared
+    /// exposed for mocking not installed tests
+    var application: URLOpener = UIApplication.shared
 
     // MARK: - Initializers
 

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -19,7 +19,7 @@ import BraintreeCore
     /// - Warning: This property is currently in beta and may change or be removed in future releases.
     var enablePayPalAppSwitch: Bool = false
 
-    /// exposed for mocking not installed tests
+    /// exposed for mocking in tests
     var application: URLOpener = UIApplication.shared
 
     // MARK: - Initializers
@@ -37,7 +37,7 @@ import BraintreeCore
         offerCredit: Bool = false
     ) {
         self.init(offerCredit: offerCredit, userAuthenticationEmail: userAuthenticationEmail)
-        self.enablePayPalAppSwitch = !application.isPayPalAppInstalled() ? false : enablePayPalAppSwitch
+        self.enablePayPalAppSwitch = enablePayPalAppSwitch
     }
 
     /// Initializes a PayPal Vault request
@@ -56,7 +56,7 @@ import BraintreeCore
             baseParameters["payer_email"] = userAuthenticationEmail
         }
         
-        if enablePayPalAppSwitch, let universalLink {
+        if enablePayPalAppSwitch, application.isPayPalAppInstalled(), let universalLink {
             let appSwitchParameters: [String: Any] = [
                 "launch_paypal_app": enablePayPalAppSwitch,
                 "os_version": UIDevice.current.systemVersion,

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -19,9 +19,6 @@ import BraintreeCore
     /// - Warning: This property is currently in beta and may change or be removed in future releases.
     var enablePayPalAppSwitch: Bool = false
 
-    /// exposed for mocking in tests
-    var application: URLOpener = UIApplication.shared
-
     // MARK: - Initializers
 
     /// Initializes a PayPal Vault request for the PayPal App Switch flow
@@ -49,14 +46,14 @@ import BraintreeCore
         super.init(offerCredit: offerCredit)
     }
 
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil) -> [String: Any] {
+    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
         var baseParameters = super.parameters(with: configuration)
 
         if let userAuthenticationEmail {
             baseParameters["payer_email"] = userAuthenticationEmail
         }
         
-        if let universalLink, enablePayPalAppSwitch, application.isPayPalAppInstalled() {
+        if let universalLink, enablePayPalAppSwitch, isPayPalAppInstalled {
             let appSwitchParameters: [String: Any] = [
                 "launch_paypal_app": enablePayPalAppSwitch,
                 "os_version": UIDevice.current.systemVersion,

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -42,7 +42,7 @@ import BraintreeCore
     private var payPalContextID: String? = nil
 
     /// Used for sending the type of flow, universal vs deeplink to FPTI
-    private var linkType: String? = nil
+    private var linkType: LinkType? = nil
 
     // MARK: - Initializer
 
@@ -64,7 +64,7 @@ import BraintreeCore
     ///   If the user cancels out of the flow, the error code will be `.canceled`.
     @objc(tokenizeWithVenmoRequest:completion:)
     public func tokenize(_ request: BTVenmoRequest, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        linkType = request.fallbackToWeb ? "universal" : "deeplink"
+        linkType = request.fallbackToWeb ? .universal : .deeplink
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault, linkType: linkType)
         let returnURLScheme = BTAppContextSwitcher.sharedInstance.returnURLScheme
 

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -25,7 +25,7 @@ final class FPTIBatchData_Tests: XCTestCase {
             eventName: "fake-event-1", 
             isConfigFromCache: false,
             isVaultRequest: false,
-            linkType: .universal,
+            linkType: LinkType.universal.rawValue,
             payPalContextID: "fake-order-id",
             requestStartTime: 456,
             startTime: 999888777666

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -25,7 +25,7 @@ final class FPTIBatchData_Tests: XCTestCase {
             eventName: "fake-event-1", 
             isConfigFromCache: false,
             isVaultRequest: false,
-            linkType: "universal",
+            linkType: .universal,
             payPalContextID: "fake-order-id",
             requestStartTime: 456,
             startTime: 999888777666

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -239,8 +239,6 @@ class BTPayPalClient_Tests: XCTestCase {
             enablePayPalAppSwitch: true
         )
 
-        vaultRequest.application.payPalAppInstalled = true
-
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
                 "paypalAppApprovalUrl": "https://www.paypal.com?ba_token=BA-Random-Value"
@@ -932,6 +930,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenPayPalInAppURL_returnsTrueAndSendsAnalytics() {
         let fakeApplication = FakeApplication()
+        fakeApplication.cannedCanOpenURL = true
         payPalClient.application = fakeApplication
 
         let vaultRequest = BTPayPalVaultRequest(
@@ -939,7 +938,7 @@ class BTPayPalClient_Tests: XCTestCase {
             enablePayPalAppSwitch: true
         )
 
-        vaultRequest.application.payPalAppInstalled = true
+        vaultRequest.application = fakeApplication
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -232,13 +232,14 @@ class BTPayPalClient_Tests: XCTestCase {
     func testTokenize_whenPayPalAppApprovalURLContainsPayPalContextID_sendsPayPalContextIDAndLinkTypeInAnalytics() {
         let fakeApplication = FakeApplication()
         payPalClient.application = fakeApplication
-        payPalClient.payPalAppInstalled = true
         payPalClient.webAuthenticationSession = MockWebAuthenticationSession()
 
         let vaultRequest = BTPayPalVaultRequest(
             userAuthenticationEmail: "fake@gmail.com",
             enablePayPalAppSwitch: true
         )
+
+        vaultRequest.application.payPalAppInstalled = true
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
@@ -252,7 +253,7 @@ class BTPayPalClient_Tests: XCTestCase {
         payPalClient.handleReturnURL(returnURL)
 
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "BA-Random-Value")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "universal")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .universal)
         XCTAssertNotNil(payPalClient.clientMetadataID)
     }
 
@@ -282,7 +283,7 @@ class BTPayPalClient_Tests: XCTestCase {
         payPalClient.tokenize(request) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "BA-Random-Value")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "deeplink")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .deeplink)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:handle-return:started"))
     }
 
@@ -301,7 +302,7 @@ class BTPayPalClient_Tests: XCTestCase {
         payPalClient.tokenize(request) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "A_FAKE_BA_TOKEN")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "deeplink")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .deeplink)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:handle-return:started"))
     }
 
@@ -932,12 +933,13 @@ class BTPayPalClient_Tests: XCTestCase {
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenPayPalInAppURL_returnsTrueAndSendsAnalytics() {
         let fakeApplication = FakeApplication()
         payPalClient.application = fakeApplication
-        payPalClient.payPalAppInstalled = true
 
         let vaultRequest = BTPayPalVaultRequest(
             userAuthenticationEmail: "fake@gmail.com",
             enablePayPalAppSwitch: true
         )
+
+        vaultRequest.application.payPalAppInstalled = true
 
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -938,8 +938,6 @@ class BTPayPalClient_Tests: XCTestCase {
             enablePayPalAppSwitch: true
         )
 
-        vaultRequest.application = fakeApplication
-
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
                 "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -77,11 +77,7 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
             enablePayPalAppSwitch: true
         )
 
-        let fakeApplication = FakeApplication()
-        fakeApplication.cannedCanOpenURL = true
-        request.application = fakeApplication
-
-        let parameters = request.parameters(with: configuration, universalLink: URL(string: "some-url")!)
+        let parameters = request.parameters(with: configuration, universalLink: URL(string: "some-url")!, isPayPalAppInstalled: true)
 
         XCTAssertEqual(parameters["launch_paypal_app"] as? Bool, true)
         XCTAssertTrue((parameters["os_version"] as! String).matches("\\d+\\.\\d+"))

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import BraintreeCore
 @testable import BraintreePayPal
+@testable import BraintreeTestShared
 
 class BTPayPalVaultRequest_Tests: XCTestCase {
 
@@ -75,6 +76,10 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
             userAuthenticationEmail: "sally@gmail.com",
             enablePayPalAppSwitch: true
         )
+
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedCanOpenURL = true
+        request.application = fakeApplication
 
         let parameters = request.parameters(with: configuration, universalLink: URL(string: "some-url")!)
 

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -13,7 +13,7 @@ public class MockAPIClient: BTAPIClient {
 
     public var postedAnalyticsEvents : [String] = []
     public var postedPayPalContextID: String? = nil
-    public var postedLinkType: String? = nil
+    public var postedLinkType: LinkType? = nil
     public var postedIsVaultRequest = false
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
@@ -94,7 +94,7 @@ public class MockAPIClient: BTAPIClient {
         errorDescription: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
-        linkType: String? = nil,
+        linkType: LinkType? = nil,
         payPalContextID: String? = nil
     ) {
         postedPayPalContextID = payPalContextID

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -584,7 +584,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "some-resource-id")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "deeplink")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .deeplink)
     }
 
     func testTokenizeVenmoAccount_fallbackToWebTrue_sendsSuccessAnalyticsEvent() {
@@ -625,7 +625,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "some-resource-id")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "universal")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .universal)
     }
 
     func testTokenizeVenmoAccount_vaultTrue_sendsFailureAnalyticsEvent() {
@@ -651,7 +651,7 @@ class BTVenmoClient_Tests: XCTestCase {
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeFailed)
         XCTAssertEqual(mockAPIClient.postedPayPalContextID, "some-resource-id")
-        XCTAssertEqual(mockAPIClient.postedLinkType, "deeplink")
+        XCTAssertEqual(mockAPIClient.postedLinkType, .deeplink)
     }
 
     func testTokenizeVenmoAccount_whenAppSwitchCanceled_callsBackWithCancelError() {


### PR DESCRIPTION
### Summary of changes

- Move `LinkType` to enum
- Remove logic to pass `linkType` into Approval URL parser
- Move app installed check into Vault Request

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
