### PR TITLE
Add Optional merchantAccountID to PayPalVaultEditRequest

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Options for the PayPal edit funding instrument flow
 /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-public class BTPayPalVaultEditRequest {
+public struct BTPayPalVaultEditRequest {
 
     private let editPayPalVaultID: String
     private let merchantAccountID: String?
@@ -11,7 +11,7 @@ public class BTPayPalVaultEditRequest {
     /// Initializes a PayPal Edit Request for the edit funding instrument flow
     /// - Parameters:
     ///   - editPayPalVaultID: Required: The `edit_paypal_vault_id` returned from the server side request
-    ///   merchantAccountIdD: optional ID of the merchant account; if one is not provided the default will be used
+    ///   merchantAccountID: optional ID of the merchant account; if one is not provided the default will be used
     /// - Warning: This feature is currently in beta and may change or be removed in future releases.
     public init(editPayPalVaultID: String, merchantAccountID: String? = nil) {
         self.editPayPalVaultID = editPayPalVaultID

--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -5,7 +5,7 @@ import Foundation
 public class BTPayPalVaultEditRequest {
 
     private let editPayPalVaultID: String
-    public var merchantAccountID: String?
+    private let merchantAccountID: String?
 
     //   TODO: specify endpoint for merchant to retrieve the token
     /// Initializes a PayPal Edit Request for the edit funding instrument flow

--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -5,13 +5,16 @@ import Foundation
 public class BTPayPalVaultEditRequest {
 
     private let editPayPalVaultID: String
+    public var merchantAccountID: String?
 
     //   TODO: specify endpoint for merchant to retrieve the token
     /// Initializes a PayPal Edit Request for the edit funding instrument flow
     /// - Parameters:
     ///   - editPayPalVaultID: Required: The `edit_paypal_vault_id` returned from the server side request
+    ///   merchantAccountIdD: optional ID of the merchant account; if one is not provided the default will be used
     /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-    public init(editPayPalVaultID: String) {
+    public init(editPayPalVaultID: String, merchantAccountID: String? = nil) {
         self.editPayPalVaultID = editPayPalVaultID
+        self.merchantAccountID = merchantAccountID
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add optional merchantAccountID and docstrings to PayPalVaultEditRequest

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
