### PR TITLE
Move payPalInstalled and venmoInstalled to batch_params

### DIFF
--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -29,8 +29,6 @@ struct FPTIBatchData: Codable {
     /// Encapsulates a single event by it's name and timestamp.
     struct Event: Codable {
 
-        static var application: URLOpener = UIApplication.shared
-
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         ///
         /// `nil` if a persistent connection is used.
@@ -51,14 +49,13 @@ struct FPTIBatchData: Codable {
         /// Used for linking events from the client to server side request
         /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow
         let payPalContextID: String?
-        let payPalInstalled: Bool = application.isPayPalAppInstalled()
+
         /// UTC millisecond timestamp when a networking task started requesting a resource. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         let requestStartTime: Int?
         /// UTC millisecond timestamp when a networking task initiated.
         let startTime: Int?
         let timestamp = String(Date().utcTimestampMilliseconds)
         let tenantName: String = "Braintree"
-        let venmoInstalled: Bool = application.isVenmoAppInstalled()
         
         init(
             connectionStartTime: Int? = nil,
@@ -97,20 +94,20 @@ struct FPTIBatchData: Codable {
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case payPalContextID = "paypal_context_id"
-            case payPalInstalled = "paypal_installed"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"
             case startTime = "start_time"
             case endTime = "end_time"
             case endpoint = "endpoint"
-            case venmoInstalled = "venmo_installed"
         }
     }
     
     /// The FPTI tags/ metadata applicable to all events in the batch upload.
     struct Metadata: Codable {
-            
+          
+        static var application: URLOpener = UIApplication.shared
+
         let appID: String = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] as? String ?? "N/A"
 
         let appName: String = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? "N/A"
@@ -164,11 +161,15 @@ struct FPTIBatchData: Codable {
 
         let merchantID: String?
 
+        let payPalInstalled: Bool = application.isPayPalAppInstalled()
+
         let platform = "iOS"
 
         let sessionID: String
 
         let tokenizationKey: String?
+
+        let venmoInstalled: Bool = application.isVenmoAppInstalled()
 
         enum CodingKeys: String, CodingKey {
             case appID = "app_id"
@@ -182,6 +183,7 @@ struct FPTIBatchData: Codable {
             case eventSource = "event_source"
             case environment = "merchant_sdk_env"
             case packageManager = "ios_package_manager"
+            case payPalInstalled = "paypal_installed"
             case integrationType = "api_integration_type"
             case isSimulator = "is_simulator"
             case merchantAppVersion = "mapv"
@@ -189,6 +191,7 @@ struct FPTIBatchData: Codable {
             case platform = "platform"
             case sessionID = "session_id"
             case tokenizationKey = "tokenization_key"
+            case venmoInstalled = "venmo_installed"
         }
     }
 }

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -146,6 +146,9 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
                 headers: headers
             )
 
+            if path == "v1/tracking/batch/events" {
+                
+            }
             self.session.dataTask(with: request) { [weak self] data, response, error in
                 guard let self else {
                     completion?(nil, nil, BTHTTPError.deallocated("BTHTTP"))

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -146,9 +146,6 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
                 headers: headers
             )
 
-            if path == "v1/tracking/batch/events" {
-                
-            }
             self.session.dataTask(with: request) { [weak self] data, response, error in
                 guard let self else {
                     completion?(nil, nil, BTHTTPError.deallocated("BTHTTP"))

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -89,6 +89,8 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(batchParams["platform"] as? String, "iOS")
         XCTAssertEqual(batchParams["session_id"] as? String, "fake-session")
         XCTAssertEqual(batchParams["tokenization_key"] as! String, "fake-auth")
+        XCTAssertEqual(batchParams["paypal_installed"] as! Bool, false)
+        XCTAssertEqual(batchParams["venmo_installed"] as! Bool, false)
 
         // Verify event-level parameters
         XCTAssertNotNil(eventParams[0]["t"] as? String)


### PR DESCRIPTION
### Summary of changes

- Move venmo_installed and paypal_installed FPTI metadata params to `batch_prams` from `event_params`

on device (less events here since I didn't go through actual Apple Pay on device, but both sets matched up number of events = these fields):
![Screenshot 2024-08-13 at 12 13 40 PM](https://github.com/user-attachments/assets/6bcd0e59-bb58-4a9a-a40d-619bee1f97ff)

on simulator 
![Screenshot 2024-08-13 at 12 06 40 PM](https://github.com/user-attachments/assets/723b1f44-d7f5-4feb-8735-b345cf935fb0)


### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @jwarmkessel 
