### PR TITLE
Send `isVaultRequest` for App Switch Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPal
+  * Send `isVaultRequest` for App Switch events to PayPal's analytics service (FPTI)
+
 ## 6.23.3 (2024-08-12)
 * BraintreeCore
   * Fix bug where some analytics wouldn't send if `BTAPIClient` instantiated on button click

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -379,6 +379,7 @@ import BraintreeDataCollector
     private func launchPayPalApp(with payPalAppRedirectURL: URL, baToken: String, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.appSwitchStarted,
+            isVaultRequest: isVaultRequest,
             linkType: linkType,
             payPalContextID: payPalContextID
         )
@@ -404,6 +405,7 @@ import BraintreeDataCollector
         if success {
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.appSwitchSucceeded,
+                isVaultRequest: isVaultRequest,
                 linkType: linkType,
                 payPalContextID: payPalContextID
             )
@@ -412,6 +414,7 @@ import BraintreeDataCollector
         } else {
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.appSwitchFailed,
+                isVaultRequest: isVaultRequest,
                 linkType: linkType,
                 payPalContextID: payPalContextID
             )


### PR DESCRIPTION
### Summary of changes

- Send `isVaultRequest` for app switch events to FPTI
    - Verified that all events are now sending this bool to FPTI

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
