### PR TITLE
Add SwiftLint to `BraintreeCard`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@
 included:
   - Sources/BraintreeAmericanExpress
   - Sources/BraintreeApplePay
+  - Sources/BraintreeCard
   - Sources/BraintreeCore
 
 excluded:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -106,4 +106,7 @@ trailing_whitespace:
   ignores_empty_lines: true
 
 vertical_whitespace:
-  max_empty_lines: 2 
+  max_empty_lines: 2
+
+cyclomatic_complexity:
+  ignores_case_statements: true

--- a/Sources/BraintreeCard/BTAuthenticationInsight.swift
+++ b/Sources/BraintreeCard/BTAuthenticationInsight.swift
@@ -17,8 +17,8 @@ import BraintreeCore
     // MARK: - Initializer
 
     init(json: BTJSON) {
-        if let customerAuthenticationRegulationEnvironment = json["customerAuthenticationRegulationEnvironment"].asString() {
-            self.regulationEnvironment = customerAuthenticationRegulationEnvironment
+        if let customerAuthRegulationEnvironment = json["customerAuthenticationRegulationEnvironment"].asString() {
+            self.regulationEnvironment = customerAuthRegulationEnvironment
         } else if let regulationEnvironment = json["regulationEnvironment"].asString() {
             self.regulationEnvironment = regulationEnvironment
         }

--- a/Sources/BraintreeCard/BTCard.swift
+++ b/Sources/BraintreeCard/BTCard.swift
@@ -81,159 +81,21 @@ import Foundation
     // MARK: - Internal Methods
 
     func parameters() -> [String: Any] {
-        var parameters: [String: Any] = [:]
-
-        if let number {
-            parameters["number"] = number
-        }
-
-        if let expirationMonth {
-            parameters["expiration_month"] = expirationMonth
-        }
-
-        if let expirationYear {
-            parameters["expiration_year"] = expirationYear
-        }
-
-        if let cardholderName {
-            parameters["cardholder_name"] = cardholderName
-        }
-
-        if let cvv {
-            parameters["cvv"] = cvv
-        }
-
-        var billingAddressDictionary: [String: String] = [:]
-
-        if let firstName {
-            billingAddressDictionary["first_name"] = firstName
-        }
-
-        if let lastName {
-            billingAddressDictionary["last_name"] = lastName
-        }
-
-        if let company {
-            billingAddressDictionary["company"] = company
-        }
-
-        if let postalCode {
-            billingAddressDictionary["postal_code"] = postalCode
-        }
-
-        if let streetAddress {
-            billingAddressDictionary["street_address"] = streetAddress
-        }
-
-        if let extendedAddress {
-            billingAddressDictionary["extended_address"] = extendedAddress
-        }
-
-        if let locality {
-            billingAddressDictionary["locality"] = locality
-        }
-
-        if let region {
-            billingAddressDictionary["region"] = region
-        }
-
-        if let countryName {
-            billingAddressDictionary["country_name"] = countryName
-        }
-
-        if let countryCodeAlpha2 {
-            billingAddressDictionary["country_code_alpha2"] = countryCodeAlpha2
-        }
-
-        if let countryCodeAlpha3 {
-            billingAddressDictionary["country_code_alpha3"] = countryCodeAlpha3
-        }
-
-        if let countryCodeNumeric {
-            billingAddressDictionary["country_code_numeric"] = countryCodeNumeric
-        }
+        var cardDictionary: [String: Any] = buildCardDictionary(isGraphQL: false)
+        let billingAddressDictionary: [String: String] = buildBillingAddressDictionary(isGraphQL: false)
 
         if !billingAddressDictionary.isEmpty {
-            parameters["billing_address"] = billingAddressDictionary
+            cardDictionary["billing_address"] = billingAddressDictionary
         }
 
         let options: [String: Bool] = ["validate": shouldValidate]
-        parameters["options"] = options
-        return parameters
+        cardDictionary["options"] = options
+        return cardDictionary
     }
 
     func graphQLParameters() -> [String: Any] {
-        var cardDictionary: [String: Any] = [:]
-
-        if let number {
-            cardDictionary["number"] = number
-        }
-
-        if let expirationMonth {
-            cardDictionary["expirationMonth"] = expirationMonth
-        }
-
-        if let expirationYear {
-            cardDictionary["expirationYear"] = expirationYear
-        }
-
-        if let cvv {
-            cardDictionary["cvv"] = cvv
-        }
-
-        if let cardholderName {
-            cardDictionary["cardholderName"] = cardholderName
-        }
-
-        var billingAddressDictionary: [String: String] = [:]
-
-        if let firstName {
-            billingAddressDictionary["firstName"] = firstName
-        }
-
-        if let lastName {
-            billingAddressDictionary["lastName"] = lastName
-        }
-
-        if let company {
-            billingAddressDictionary["company"] = company
-        }
-
-        if let postalCode {
-            billingAddressDictionary["postalCode"] = postalCode
-        }
-
-        if let streetAddress {
-            billingAddressDictionary["streetAddress"] = streetAddress
-        }
-
-        if let extendedAddress {
-            billingAddressDictionary["extendedAddress"] = extendedAddress
-        }
-
-        if let locality {
-            billingAddressDictionary["locality"] = locality
-        }
-
-        if let region {
-            billingAddressDictionary["region"] = region
-        }
-
-        if let countryName {
-            billingAddressDictionary["countryName"] = countryName
-        }
-
-        if let countryCodeAlpha2 {
-            billingAddressDictionary["countryCodeAlpha2"] = countryCodeAlpha2
-        }
-
-        if let countryCodeAlpha3 {
-            billingAddressDictionary["countryCode"] = countryCodeAlpha3
-        }
-
-        if let countryCodeNumeric {
-            billingAddressDictionary["countryCodeNumeric"] = countryCodeNumeric
-        }
+        var cardDictionary: [String: Any] = buildCardDictionary(isGraphQL: true)
+        let billingAddressDictionary: [String: String] = buildBillingAddressDictionary(isGraphQL: true)
 
         if !billingAddressDictionary.isEmpty {
             cardDictionary["billingAddress"] = billingAddressDictionary
@@ -244,7 +106,11 @@ import Foundation
         var variables: [String: Any] = ["input": inputDictionary]
 
         if authenticationInsightRequested {
-            variables["authenticationInsightInput"] = merchantAccountID != nil ? ["merchantAccountId": merchantAccountID] : [:] as [String?: Any]?
+            if let merchantAccountID {
+                variables["authenticationInsightInput"] = ["merchantAccountId": merchantAccountID]
+            } else {
+                variables["authenticationInsightInput"] = [:]
+            }
         }
 
         return [
@@ -256,6 +122,88 @@ import Foundation
 
     // MARK: - Private Methods
 
+    private func buildCardDictionary(isGraphQL: Bool) -> [String: Any] {
+        var cardDictionary: [String: Any] = [:]
+
+        if let number {
+            cardDictionary["number"] = number
+        }
+
+        if let expirationMonth {
+            cardDictionary[isGraphQL ? "expirationMonth" : "expiration_month"] = expirationMonth
+        }
+
+        if let expirationYear {
+            cardDictionary[isGraphQL ? "expirationYear" : "expiration_year"] = expirationYear
+        }
+
+        if let cvv {
+            cardDictionary["cvv"] = cvv
+        }
+
+        if let cardholderName {
+            cardDictionary[isGraphQL ? "cardholderName" : "cardholder_name"] = cardholderName
+        }
+
+        return cardDictionary
+    }
+
+    // swiftlint:disable cyclomatic_complexity
+    private func buildBillingAddressDictionary(isGraphQL: Bool) -> [String: String] {
+        var billingAddressDictionary: [String: String] = [:]
+
+        if let firstName {
+            billingAddressDictionary[isGraphQL ? "firstName" : "first_name"] = firstName
+        }
+
+        if let lastName {
+            billingAddressDictionary[isGraphQL ? "lastName" : "last_name"] = lastName
+        }
+
+        if let company {
+            billingAddressDictionary["company"] = company
+        }
+
+        if let postalCode {
+            billingAddressDictionary[isGraphQL ? "postalCode" : "postal_code"] = postalCode
+        }
+
+        if let streetAddress {
+            billingAddressDictionary[isGraphQL ? "streetAddress" : "street_address"] = streetAddress
+        }
+
+        if let extendedAddress {
+            billingAddressDictionary[isGraphQL ? "extendedAddress" : "extended_address"] = extendedAddress
+        }
+
+        if let locality {
+            billingAddressDictionary["locality"] = locality
+        }
+
+        if let region {
+            billingAddressDictionary["region"] = region
+        }
+
+        if let countryName {
+            billingAddressDictionary[isGraphQL ? "countryName" : "country_name"] = countryName
+        }
+
+        if let countryCodeAlpha2 {
+            billingAddressDictionary[isGraphQL ? "countryCodeAlpha2" : "country_code_alpha2"] = countryCodeAlpha2
+        }
+
+        if let countryCodeAlpha3 {
+            billingAddressDictionary[isGraphQL ? "countryCode" : "country_code_alpha3"] = countryCodeAlpha3
+        }
+
+        if let countryCodeNumeric {
+            billingAddressDictionary[isGraphQL ? "countryCodeNumeric" : "country_code_numeric"] = countryCodeNumeric
+        }
+
+        return billingAddressDictionary
+    }
+    // swiftlint:enable cyclomatic_complexity
+
     private func cardTokenizationGraphQLMutation() -> String {
         var mutation = "mutation TokenizeCreditCard($input: TokenizeCreditCardInput!"
 
@@ -263,6 +211,7 @@ import Foundation
             mutation.append(", $authenticationInsightInput: AuthenticationInsightInput!")
         }
 
+        // swiftlint:disable indentation_width
         mutation.append(
             """
             ) {
@@ -306,6 +255,7 @@ import Foundation
             }
             """
         )
+        // swiftlint:enable indentation_width
 
         return mutation.replacingOccurrences(of: "\n", with: "")
     }

--- a/Sources/BraintreeCard/BTCardClient.swift
+++ b/Sources/BraintreeCard/BTCardClient.swift
@@ -34,7 +34,7 @@ import BraintreeCore
     public func tokenize(_ card: BTCard, completion: @escaping (BTCardNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(BTCardAnalytics.cardTokenizeStarted)
 
-        apiClient.fetchOrReturnRemoteConfiguration() { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
                 self.notifyFailure(with: error, completion: completion)
                 return
@@ -73,7 +73,7 @@ import BraintreeCore
                         return
                     }
 
-                    let cardNonce: BTCardNonce = BTCardNonce(graphQLJSON: cardJSON)
+                    let cardNonce = BTCardNonce(graphQLJSON: cardJSON)
 
                     self.notifySuccess(with: cardNonce, completion: completion)
                     return
@@ -101,7 +101,7 @@ import BraintreeCore
                         return
                     }
 
-                    let cardNonce: BTCardNonce = BTCardNonce(json: cardJSON)
+                    let cardNonce = BTCardNonce(json: cardJSON)
 
                     self.notifySuccess(with: cardNonce, completion: completion)
                     return

--- a/Sources/BraintreeCard/BTCardError.swift
+++ b/Sources/BraintreeCard/BTCardError.swift
@@ -37,6 +37,7 @@ public enum BTCardError: Error, CustomNSError, LocalizedError, Equatable {
         }
     }
 
+    // swiftlint:disable line_length
     public var errorUserInfo: [String: Any] {
         switch self {
         case .unknown:
@@ -51,6 +52,7 @@ public enum BTCardError: Error, CustomNSError, LocalizedError, Equatable {
             return [NSLocalizedDescriptionKey: "Failed to fetch Braintree configuration."]
         }
     }
+    // swiftlint:enable line_length
 
     // MARK: - Equatable Conformance
 

--- a/Sources/BraintreeCard/BTCardNonce.swift
+++ b/Sources/BraintreeCard/BTCardNonce.swift
@@ -80,7 +80,7 @@ import BraintreeCore
     @_documentation(visibility: private)
     @objc(initWithJSON:)
     public convenience init(json cardJSON: BTJSON?) {
-        var authenticationInsightJSON: BTJSON? = nil
+        var authenticationInsightJSON: BTJSON?
 
         if cardJSON?["authenticationInsight"].asDictionary() != nil {
             authenticationInsightJSON = cardJSON?["authenticationInsight"]
@@ -111,9 +111,9 @@ import BraintreeCore
             lastFour = lastFourString
         }
 
-        let lastTwo: String = String(lastFour.count == 4 ? lastFour.suffix(2) : "")
+        let lastTwo = String(lastFour.count == 4 ? lastFour.suffix(2) : "")
 
-        var authenticationInsightJSON: BTJSON? = nil
+        var authenticationInsightJSON: BTJSON?
 
         if json?["authenticationInsight"].asDictionary() != nil {
             authenticationInsightJSON = json?["authenticationInsight"]

--- a/Sources/BraintreeCard/BTCardRequest.swift
+++ b/Sources/BraintreeCard/BTCardRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Contains information about a card to tokenize
 // TODO: - NEXT_MAJOR_VERSION remove this class
+/// Contains information about a card to tokenize
 @available(*, deprecated, message: "Use BTCard directly instead")
 @objcMembers public class BTCardRequest: NSObject {
 


### PR DESCRIPTION
### Summary of changes

- Add `BraintreeCard` module to .swiftlint.yml
Address all swiftlint violations in `BraintreeCard` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
