### PR TITLE
Add `RiskCorrelationID` to `BTPayPalVaultEditRequest`

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -13,6 +13,7 @@ public struct BTPayPalVaultEditRequest {
     /// - Parameters:
     ///   - editPayPalVaultID: Required: The `edit_paypal_vault_id` returned from the server side request
     ///   merchantAccountID: optional ID of the merchant account; if one is not provided the default will be used
+    ///   riskCorrelationID: optional ID passed in by merchant to track errors
     /// - Warning: This feature is currently in beta and may change or be removed in future releases.
     public init(editPayPalVaultID: String, merchantAccountID: String? = nil, riskCorrelationID: String? = nil) {
         self.editPayPalVaultID = editPayPalVaultID

--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -6,6 +6,7 @@ public struct BTPayPalVaultEditRequest {
 
     private let editPayPalVaultID: String
     private let merchantAccountID: String?
+    private let riskCorrelationID: String?
 
     //   TODO: specify endpoint for merchant to retrieve the token
     /// Initializes a PayPal Edit Request for the edit funding instrument flow
@@ -13,8 +14,9 @@ public struct BTPayPalVaultEditRequest {
     ///   - editPayPalVaultID: Required: The `edit_paypal_vault_id` returned from the server side request
     ///   merchantAccountID: optional ID of the merchant account; if one is not provided the default will be used
     /// - Warning: This feature is currently in beta and may change or be removed in future releases.
-    public init(editPayPalVaultID: String, merchantAccountID: String? = nil) {
+    public init(editPayPalVaultID: String, merchantAccountID: String? = nil, riskCorrelationID: String? = nil) {
         self.editPayPalVaultID = editPayPalVaultID
         self.merchantAccountID = merchantAccountID
+        self.riskCorrelationID = riskCorrelationID
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add `RiskCorrelationID` to `BTPayPalVaultEditRequest`
- Add docStrings for `RiskCorrelationID`

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @jwarmkessel 
