### PR TITLE
Add SwiftLint to `BraintreeDataCollector`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ included:
   - Sources/BraintreeApplePay
   - Sources/BraintreeCard
   - Sources/BraintreeCore
+  - Sources/BraintreeDataCollector
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -37,7 +37,7 @@ import BraintreeCore
     ///  calling it when the customer initiates checkout is also fine.
     ///  Use the return value on your server, e.g. with `Transaction.sale`.
     ///  - Parameter completion:  A completion block that returns either a device data string that should be passed into server-side calls, such as `Transaction.sale`, or an error with the failure reason.
-    @objc public func collectDeviceData(_ completion: @escaping (String? , Error?) -> Void) {
+    @objc public func collectDeviceData(_ completion: @escaping (String?, Error?) -> Void) {
         fetchConfiguration { configuration, error in
             guard let configuration = configuration else {
                 completion(nil, error)
@@ -103,7 +103,12 @@ import BraintreeCore
         generateClientMetadataID("", disableBeacon: false, configuration: configuration, data: nil)
     }
     
-    func generateClientMetadataID(_ clientMetadataID: String?, disableBeacon: Bool, configuration: BTConfiguration?, data: [String : String]?) -> String {
+    func generateClientMetadataID(
+        _ clientMetadataID: String?,
+        disableBeacon: Bool,
+        configuration: BTConfiguration?,
+        data: [String: String]?
+    ) -> String {
         if configuration != nil {
             config = configuration
         } else {
@@ -142,7 +147,7 @@ import BraintreeCore
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         if status == errSecSuccess,
-            let existingItem = item as? [String : Any],
+            let existingItem = item as? [String: Any],
             let data = existingItem[kSecValueData as String] as? Data,
             let identifier = String(data: data, encoding: String.Encoding.utf8) {
             return identifier

--- a/Sources/BraintreeDataCollector/BTDataCollectorEnvironment.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollectorEnvironment.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-enum BTDataCollectorEnvironment: String {
-    case development
-    case qa
-    case sandbox
-    case production
-}


### PR DESCRIPTION
### Summary of changes

- Add `BraintreeDataCollector` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreeDataCollector` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
