### PR TITLE
Update `BTPayPalVaultEditResult` to Return Only `riskCorrelationID`

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalVaultEditResult.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditResult.swift
@@ -11,26 +11,5 @@ public struct BTPayPalVaultEditResult {
     // MARK: - Public Properties
 
     /// This ID is used to link subsequent retry attempts if payment is declined
-    public let clientMetadataID: String
-
-    /// ID of the payer
-    public let payerID: String?
-
-    /// email address of the payer
-    public let email: String?
-
-    /// first name of the payer
-    public let firstName: String?
-
-    /// last name of the payer
-    public let lastName: String?
-
-    /// phone number of the payer
-    public let phone: String?
-
-    /// shipping address of the payer
-    public let shippingAddress: BTPostalAddress?
-
-    /// description of the funding source
-    public let fundingSourceDescription: String?
+    public let riskCorrelationID: String
 }


### PR DESCRIPTION
### Summary of changes

- Update `BTPayPalVaultEditResult` to only return `riskCorrelationID`

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @jwarmkessel 
