### PR TITLE
Add SwiftLint to `BraintreePayPal`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ included:
   - Sources/BraintreeCore
   - Sources/BraintreeDataCollector
   - Sources/BraintreeLocalPayment
+  - Sources/BraintreePayPal
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreePayPal/BTJSON+PayPal.swift
+++ b/Sources/BraintreePayPal/BTJSON+PayPal.swift
@@ -5,12 +5,14 @@ import BraintreeCore
 extension BTJSON {
 
     func asPayPalCreditFinancingAmount() -> BTPayPalCreditFinancingAmount? {
-        guard self.isObject,
-              let currency = self["currency"].asString(),
-              let value = self["value"].asString() else {
-                  return nil
-              }
-        
+        guard
+            self.isObject,
+            let currency = self["currency"].asString(),
+            let value = self["value"].asString()
+        else {
+            return nil
+        }
+
         return BTPayPalCreditFinancingAmount(currency: currency, value: value)
     }
     

--- a/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
+++ b/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
@@ -42,8 +42,8 @@ import BraintreeCore
         let details = json["details"]
         let payerInfo = details["payerInfo"]
 
-        self.email = payerInfo["email"].asString() ?? details["email"].asString()        
-        self.firstName = payerInfo["firstName"].asString()  
+        self.email = payerInfo["email"].asString() ?? details["email"].asString()
+        self.firstName = payerInfo["firstName"].asString()
         self.lastName = payerInfo["lastName"].asString()
         self.phone = payerInfo["phone"].asString()
         self.billingAddress = payerInfo["billingAddress"].asAddress()

--- a/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
+++ b/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
@@ -26,7 +26,7 @@ struct BTPayPalApprovalURLParser {
             .queryItems?
             .compactMap { $0 }
 
-        if let ecToken = queryItems?.filter({ $0.name == "token" }).first?.value, !ecToken.isEmpty {
+        if let ecToken = queryItems?.first(where: { $0.name == "token" })?.value, !ecToken.isEmpty {
             return ecToken
         }
 
@@ -38,7 +38,7 @@ struct BTPayPalApprovalURLParser {
             .queryItems?
             .compactMap { $0 }
 
-        if let baToken = queryItems?.filter({ $0.name == "ba_token" }).first?.value, !baToken.isEmpty {
+        if let baToken = queryItems?.first(where: { $0.name == "ba_token" })?.value, !baToken.isEmpty {
             return baToken
         }
 

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -120,7 +120,11 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
+    public override func parameters(
+        with configuration: BTConfiguration,
+        universalLink: URL? = nil,
+        isPayPalAppInstalled: Bool = false
+    ) -> [String: Any] {
         var baseParameters = super.parameters(with: configuration)
         var checkoutParameters: [String: Any] = [
             "intent": intent.stringValue,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -9,6 +9,7 @@ import BraintreeCore
 import BraintreeDataCollector
 #endif
 
+// swiftlint:disable type_body_length file_length
 @objc public class BTPayPalClient: BTWebAuthenticationSessionClient {
     
     // MARK: - Internal Properties
@@ -21,14 +22,14 @@ import BraintreeDataCollector
     var application: URLOpener = UIApplication.shared
 
     /// Exposed for testing the approvalURL construction
-    var approvalURL: URL? = nil
+    var approvalURL: URL?
 
     /// Exposed for testing the clientMetadataID associated with this request.
     /// Used in POST body for FPTI analytics & `/paypal_account` fetch.
-    var clientMetadataID: String? = nil
+    var clientMetadataID: String?
     
     /// Exposed for testing the intent associated with this request
-    var payPalRequest: BTPayPalRequest? = nil
+    var payPalRequest: BTPayPalRequest?
 
     /// Exposed for testing, the ASWebAuthenticationSession instance used for the PayPal flow
     var webAuthenticationSession: BTWebAuthenticationSession
@@ -44,7 +45,7 @@ import BraintreeDataCollector
 
     /// This static instance of `BTPayPalClient` is used during the app switch process.
     /// We require a static reference of the client to call `handleReturnURL` and return to the app.
-    static var payPalClient: BTPayPalClient? = nil
+    static var payPalClient: BTPayPalClient?
 
     // MARK: - Private Properties
 
@@ -56,13 +57,13 @@ import BraintreeDataCollector
 
     /// Used for linking events from the client to server side request
     /// In the PayPal flow this will be either an EC token or a Billing Agreement token
-    private var payPalContextID: String? = nil
+    private var payPalContextID: String?
     
     /// Used for analytics purposes, to determine if brower-presentation event is associated with a locally cached, or remotely fetched `BTConfiguration`
     private var isConfigFromCache: Bool?
 
     /// Used for sending the type of flow, universal vs deeplink to FPTI
-    private var linkType: LinkType? = nil
+    private var linkType: LinkType?
 
     // MARK: - Initializer
 
@@ -224,7 +225,7 @@ import BraintreeDataCollector
 
         if paymentType == .checkout {
             account["options"] = ["validate": false]
-            if let request  = payPalRequest as? BTPayPalCheckoutRequest {
+            if let request = payPalRequest as? BTPayPalCheckoutRequest {
                 account["intent"] = request.intent.stringValue
             }
         }
@@ -248,14 +249,16 @@ import BraintreeDataCollector
             "sessionId": metadata.sessionID
         ]
         
-        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: parameters) { body, response, error in
+        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: parameters) { body, _, error in
             if let error {
                 self.notifyFailure(with: error, completion: completion)
                 return
             }
 
-            guard let payPalAccount = body?["paypalAccounts"].asArray()?.first,
-                  let tokenizedAccount = BTPayPalAccountNonce(json: payPalAccount) else {
+            guard
+                let payPalAccount = body?["paypalAccounts"].asArray()?.first,
+                let tokenizedAccount = BTPayPalAccountNonce(json: payPalAccount)
+            else {
                 self.notifyFailure(with: BTPayPalError.failedToCreateNonce, completion: completion)
                 return
             }
@@ -337,7 +340,7 @@ import BraintreeDataCollector
                     universalLink: self.universalLink,
                     isPayPalAppInstalled: self.application.isPayPalAppInstalled()
                 )
-            ) { body, response, error in
+            ) { body, _, error in
                 if let error = error as? NSError {
                     guard let jsonResponseBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON else {
                         self.notifyFailure(with: error, completion: completion)
@@ -376,7 +379,11 @@ import BraintreeDataCollector
         }
     }
 
-    private func launchPayPalApp(with payPalAppRedirectURL: URL, baToken: String, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
+    private func launchPayPalApp(
+        with payPalAppRedirectURL: URL,
+        baToken: String,
+        completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
+    ) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.appSwitchStarted,
             isVaultRequest: isVaultRequest,
@@ -533,6 +540,7 @@ import BraintreeDataCollector
 }
 
 extension BTPayPalClient: BTAppContextSwitchClient {
+
     /// :nodoc:
     @_documentation(visibility: private)
     @objc public static func handleReturnURL(_ url: URL) {

--- a/Sources/BraintreePayPal/BTPayPalCreditFinancing.swift
+++ b/Sources/BraintreePayPal/BTPayPalCreditFinancing.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Contains information about a PayPal credit financing option
 @objcMembers public class BTPayPalCreditFinancing: NSObject {
+    
     /// Indicates whether the card amount is editable after payer's acceptance on PayPal side.
     public let cardAmountImmutable: Bool
     

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -99,7 +99,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
         case .invalidURLAction:
             return "The URL action did not contain a valid URL."
         case .failedToCreateNonce:
+            // swiftlint:disable line_length
             return "Unable to create BTPayPalAccountNonce. Either body did not contain paypalAccounts array or contents could not be parsed."
+            // swiftlint:enable line_length
         case .webSessionError(let error):
             return "ASWebAuthenticationSession failed with \(error.localizedDescription)"
         case .deallocated:

--- a/Sources/BraintreePayPal/BTPayPalLineItem.swift
+++ b/Sources/BraintreePayPal/BTPayPalLineItem.swift
@@ -9,6 +9,7 @@ import Foundation
     case credit
 }
 
+// swiftlint:disable identifier_name
 /// Use this option to specify  the UPC type of the line item.
 @objc public enum BTPayPalLineItemUPCType: Int {
 
@@ -35,7 +36,8 @@ import Foundation
     
     /// Upc Type 5
     case UPC_5
-    
+    // swiftlint:enable identifier_name
+
     var stringValue: String? {
         switch self {
         case .none:
@@ -88,10 +90,10 @@ import Foundation
     public let productCode: String? = nil
     
     /// Optional: The URL to product image information.
-    public var imageURL: URL? = nil
+    public var imageURL: URL?
 
     /// Optional: UPC code for the item.
-    public var upcCode: String? = nil
+    public var upcCode: String?
 
     /// Optional: UPC type for the item.
     public var upcType: BTPayPalLineItemUPCType = .none
@@ -124,15 +126,15 @@ import Foundation
             "kind": kind == .debit ? "debit" : "credit"
         ]
 
-        if let unitTaxAmount, unitTaxAmount != "" {
+        if let unitTaxAmount, !unitTaxAmount.isEmpty {
             requestParameters["unit_tax_amount"] = unitAmount
         }
 
-        if let itemDescription, itemDescription != "" {
+        if let itemDescription, !itemDescription.isEmpty {
             requestParameters["description"] = itemDescription
         }
 
-        if let productCode, productCode != "" {
+        if let productCode, !productCode.isEmpty {
             requestParameters["product_code"] = productCode
         }
 
@@ -144,7 +146,7 @@ import Foundation
             requestParameters["image_url"] = imageURL.absoluteString
         }
 
-        if let upcCode, upcCode != "" {
+        if let upcCode, !upcCode.isEmpty {
             requestParameters["upc_code"] = upcCode
         }
         

--- a/Sources/BraintreePayPal/BTPayPalLocaleCode.swift
+++ b/Sources/BraintreePayPal/BTPayPalLocaleCode.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftlint:disable identifier_name
 ///  A locale code to use for a transaction.
 @objc public enum BTPayPalLocaleCode: Int {
     case none
@@ -30,7 +31,8 @@ import Foundation
     case zh_HK
     case zh_TW
     case zh_XC
-    
+    // swiftlint:enable identifier_name
+
     var stringValue: String? {
         switch self {
         case .none:

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -135,7 +135,11 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
+    public func parameters(
+        with configuration: BTConfiguration,
+        universalLink: URL? = nil,
+        isPayPalAppInstalled: Bool = false
+    ) -> [String: Any] {
         var experienceProfile: [String: Any] = [:]
 
         experienceProfile["no_shipping"] = !isShippingAddressRequired
@@ -161,7 +165,7 @@ import BraintreeCore
             parameters["correlation_id"] = riskCorrelationID
         }
 
-        if let lineItems, lineItems.count > 0 {
+        if let lineItems, !lineItems.isEmpty {
             let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
             parameters["line_items"] = lineItemsArray
         }

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -53,7 +53,7 @@ struct BTPayPalReturnURL {
             .dropLast(1) // remove the action (`success`, `cancel`, etc)
             .joined(separator: "/")
 
-        if hostAndPath.count > 0 {
+        if !hostAndPath.isEmpty {
             hostAndPath.append("/")
         }
 
@@ -63,11 +63,13 @@ struct BTPayPalReturnURL {
             return false
         }
 
-        guard let action = action(from: url),
-              let query = url.query,
-              query.count > 0,
-              action.count >= 0,
-              ["success", "cancel", "authenticate"].contains(action) else {
+        guard
+            let action = action(from: url),
+            let query = url.query,
+            !query.isEmpty,
+            !action.isEmpty,
+            ["success", "cancel", "authenticate"].contains(action)
+        else {
             return false
         }
 

--- a/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
@@ -27,7 +27,11 @@ import BraintreeCore
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This method is not covered by semantic versioning.
     @_documentation(visibility: private)
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
+    public override func parameters(
+        with configuration: BTConfiguration,
+        universalLink: URL? = nil,
+        isPayPalAppInstalled: Bool = false
+    ) -> [String: Any] {
         let baseParameters = super.parameters(with: configuration)
         var vaultParameters: [String: Any] = ["offer_paypal_credit": offerCredit]
 

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -46,7 +46,11 @@ import BraintreeCore
         super.init(offerCredit: offerCredit)
     }
 
-    public override func parameters(with configuration: BTConfiguration, universalLink: URL? = nil, isPayPalAppInstalled: Bool = false) -> [String: Any] {
+    public override func parameters(
+        with configuration: BTConfiguration,
+        universalLink: URL? = nil,
+        isPayPalAppInstalled: Bool = false
+    ) -> [String: Any] {
         var baseParameters = super.parameters(with: configuration)
 
         if let userAuthenticationEmail {


### PR DESCRIPTION
### Summary of changes

- Add `BraintreePayPal` module to `.swiftlint.yml`
-  Address all swiftlint violations in `BraintreePayPal` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
