### PR TITLE
Add SwiftLint to `BraintreePayPalMessaging`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ included:
   - Sources/BraintreeCore
   - Sources/BraintreeDataCollector
   - Sources/BraintreeLocalPayment
+  - Sources/BraintreePayPalMessaging
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingLogoType.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingLogoType.swift
@@ -30,4 +30,3 @@ public enum BTPayPalMessagingLogoType {
         }
     }
 }
-

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingOfferType.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingOfferType.swift
@@ -5,29 +5,28 @@ import PayPalMessages
 /// - Warning: This module is in beta. It's public API may change or be removed in future releases.
 public enum BTPayPalMessagingOfferType {
 
-   /// Pay Later short term installment
-   case payLaterShortTerm
+    /// Pay Later short term installment
+    case payLaterShortTerm
 
-   /// Pay Later long term installments
-   case payLaterLongTerm
+    /// Pay Later long term installments
+    case payLaterLongTerm
 
-   /// Pay Later deferred payment
-   case payLaterPayInOne
+    /// Pay Later deferred payment
+    case payLaterPayInOne
 
-   /// PayPal Credit No Interest
-   case payPalCreditNoInterest
+    /// PayPal Credit No Interest
+    case payPalCreditNoInterest
 
-   var offerTypeRawValue: PayPalMessageOfferType {
-       switch self {
-       case .payLaterShortTerm:
-           return .payLaterShortTerm
-       case .payLaterLongTerm:
-           return .payLaterLongTerm
-       case .payLaterPayInOne:
-           return .payLaterPayIn1
-       case .payPalCreditNoInterest:
-           return .payPalCreditNoInterest
-       }
-   }
+    var offerTypeRawValue: PayPalMessageOfferType {
+        switch self {
+        case .payLaterShortTerm:
+            return .payLaterShortTerm
+        case .payLaterLongTerm:
+            return .payLaterLongTerm
+        case .payLaterPayInOne:
+            return .payLaterPayIn1
+        case .payPalCreditNoInterest:
+            return .payPalCreditNoInterest
+        }
+    }
 }
-

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingPageType.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingPageType.swift
@@ -40,4 +40,3 @@ public enum BTPayPalMessagingPageType {
         }
     }
 }
-

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingRequest.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingRequest.swift
@@ -41,4 +41,3 @@ public struct BTPayPalMessagingRequest {
         self.color = color
     }
 }
-

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -117,14 +117,18 @@ public extension BTPayPalMessagingView {
         private let apiClient: BTAPIClient
         private let delegate: BTPayPalMessagingDelegate?
 
-        private var request: BTPayPalMessagingRequest = BTPayPalMessagingRequest()
+        private var request = BTPayPalMessagingRequest()
         
         ///  Initializes a `BTPayPalMessagingView`.
         /// - Parameters:
         ///   - apiClient: The Braintree API client
         ///   - request: an optional `BTPayPalMessagingRequest`
         ///   - delegate: an optional `BTPayPalMessagingDelegate`
-        public init(apiClient: BTAPIClient, request: BTPayPalMessagingRequest = BTPayPalMessagingRequest(), delegate: BTPayPalMessagingDelegate? = nil) {
+        public init(
+            apiClient: BTAPIClient,
+            request: BTPayPalMessagingRequest = BTPayPalMessagingRequest(),
+            delegate: BTPayPalMessagingDelegate? = nil
+        ) {
             self.apiClient = apiClient
             self.request = request
             self.delegate = delegate


### PR DESCRIPTION
### Summary of changes

- Add `BraintreePayPalMessaging` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreePayPalMessaging` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
