### PR TITLE
Add SwiftLint to `BraintreePayPalNativeCheckout`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ included:
   - Sources/BraintreeCore
   - Sources/BraintreeDataCollector
   - Sources/BraintreeLocalPayment
+  - Sources/BraintreePayPalNativeCheckout
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutAccountNonce.swift
@@ -61,7 +61,7 @@ import PayPalCheckout
         payerID = payerInfo["payerId"].asString() ?? buyerData?.userId
 
         let shippingAddressJSON = details["payerInfo"]["shippingAddress"].asAddress()
-        let accountAddressJSON =  details["payerInfo"]["accountAddress"].asAddress()
+        let accountAddressJSON = details["payerInfo"]["accountAddress"].asAddress()
         shippingAddress = shippingAddressJSON ?? accountAddressJSON
 
         let billingAddressJSON = details["payerInfo"]["billingAddress"].asAddress()

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutClient.swift
@@ -17,11 +17,11 @@ import PayPalCheckout
     private let apiClient: BTAPIClient
     
     /// Used in POST body for FPTI analytics.
-    private var clientMetadataID: String? = nil
+    private var clientMetadataID: String?
 
     /// Used for linking events from the client to server side request
     /// In the PayPal Native Checkout flow this will be an Order ID
-    private var payPalContextID: String? = nil
+    private var payPalContextID: String?
 
     private let nativeCheckoutProvider: BTPayPalNativeCheckoutStartable
 

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProtocol.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProtocol.swift
@@ -5,6 +5,7 @@ protocol BTPayPalNativeCheckoutProtocol {
 
     static var showsExitAlert: Bool { get set }
 
+    // swiftlint:disable function_parameter_count
     static func start(
         presentingViewController: UIViewController?,
         createOrder: CheckoutConfig.CreateOrderCallback?,
@@ -13,6 +14,7 @@ protocol BTPayPalNativeCheckoutProtocol {
         onCancel: CheckoutConfig.CancelCallback?,
         onError: CheckoutConfig.ErrorCallback?
     )
+    // swiftlint:enable function_parameter_count
 
     static func set(config: CheckoutConfig)
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProvider.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutProvider.swift
@@ -17,6 +17,7 @@ class BTPayPalNativeCheckoutProvider: BTPayPalNativeCheckoutStartable {
         self.checkout = mxo
     }
 
+    // swiftlint:disable function_parameter_count
     func start(
         request: BTPayPalRequest,
         order: BTPayPalNativeOrder,
@@ -66,4 +67,5 @@ class BTPayPalNativeCheckoutProvider: BTPayPalNativeCheckoutStartable {
 
         NotificationCenter.default.post(name: Notification.Name("brain_tree_source_event"), object: nil)
     }
+    // swiftlint:enable function_parameter_count
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutStartable.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeCheckoutStartable.swift
@@ -12,6 +12,7 @@ protocol BTPayPalNativeCheckoutStartable {
     typealias StartableErrorCallback = (BTPayPalNativeCheckoutError) -> Void
     typealias StartableCancelCallback = () -> Void
 
+    // swiftlint:disable function_parameter_count
     func start(
         request: BTPayPalRequest,
         order: BTPayPalNativeOrder,
@@ -20,4 +21,5 @@ protocol BTPayPalNativeCheckoutStartable {
         onStartableCancel: @escaping StartableCancelCallback,
         onStartableError: @escaping StartableErrorCallback
     )
+    // swiftlint:enable function_parameter_count
 }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeHermesResponse.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeHermesResponse.swift
@@ -18,7 +18,7 @@ struct BTPayPalNativeHermesResponse {
 
         let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems?
-            .first(where: { $0.name == "token" || $0.name == "ba_token" })?
+            .first { $0.name == "token" || $0.name == "ba_token" }?
             .value
 
         guard let orderID = token else { return nil }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeOrderCreationClient.swift
@@ -9,6 +9,7 @@ import BraintreePayPal
 import PayPalCheckout
 
 struct BTPayPalNativeOrder: Equatable {
+
     let payPalClientID: String
     let environment: PayPalCheckout.Environment
     let orderID: String
@@ -17,7 +18,7 @@ struct BTPayPalNativeOrder: Equatable {
 @available(*, deprecated, message: "BraintreePayPalNativeCheckout Module is deprecated, use BraintreePayPal Module instead")
 class BTPayPalNativeOrderCreationClient {
 
-    var payPalContextID: String? = nil
+    var payPalContextID: String?
 
     private let apiClient: BTAPIClient
 
@@ -62,7 +63,7 @@ class BTPayPalNativeOrderCreationClient {
             self.apiClient.post(
                 request.hermesPath,
                 parameters: request.parameters(with: config)
-            ) { json, response, error in
+            ) { json, _, error in
                 guard let hermesResponse = BTPayPalNativeHermesResponse(json: json), error == nil else {
                     let underlyingError = error ?? BTPayPalNativeCheckoutError.invalidJSONResponse
                     completion(.failure(.orderCreationFailed(underlyingError)))

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationClient.swift
@@ -21,17 +21,16 @@ class BTPayPalNativeTokenizationClient {
         request: BTPayPalRequest,
         returnURL: String?,
         buyerData: User? = nil,
-        completion: @escaping (Result<BTPayPalNativeCheckoutAccountNonce, BTPayPalNativeCheckoutError>) -> Void)
-    {
-
+        completion: @escaping (Result<BTPayPalNativeCheckoutAccountNonce, BTPayPalNativeCheckoutError>) -> Void
+    ) {
         guard let returnURL else {
-          completion(.failure(.missingReturnURL))
-          return
+            completion(.failure(.missingReturnURL))
+            return
         }
-        
+
         let tokenizationRequest = BTPayPalNativeTokenizationRequest(
-          request: request,
-          correlationID: request.riskCorrelationID ?? State.correlationIDs.riskCorrelationID ?? ""
+            request: request,
+            correlationID: request.riskCorrelationID ?? State.correlationIDs.riskCorrelationID ?? ""
         )
 
         apiClient.post(
@@ -48,7 +47,7 @@ class BTPayPalNativeTokenizationClient {
                 completion(.failure(.parsingTokenizationResultFailed))
                 return
             }
-            
+
             completion(.success(accountNonce))
         }
     }

--- a/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
+++ b/Sources/BraintreePayPalNativeCheckout/BTPayPalNativeTokenizationRequest.swift
@@ -21,7 +21,7 @@ class BTPayPalNativeTokenizationRequest {
 
     // The return URL is vended from the Native Checkout SDK and is consumed
     // by the Braintree Gateway to consume payment details
-    func parameters(returnURL: String?) -> [String : Any] {
+    func parameters(returnURL: String?) -> [String: Any] {
         let clientDictionary: [String: String] = [
             "platform": "iOS",
             "product_name": "PayPal",
@@ -29,15 +29,15 @@ class BTPayPalNativeTokenizationRequest {
         ]
 
         let responseDictionary: [String: String?] = ["webURL": returnURL ?? ""]
-        var account: [String : Any] = [
+        var account: [String: Any] = [
             "client": clientDictionary,
             "response": responseDictionary,
             "response_type": "web",
-            "correlation_id": correlationID,
+            "correlation_id": correlationID
         ]
 
         if let checkoutRequest = request as? BTPayPalNativeCheckoutRequest {
-            account["options"] = ["validate" : false]
+            account["options"] = ["validate": false]
             account["intent"] = checkoutRequest.intent.stringValue
         }
 


### PR DESCRIPTION
### Summary of changes

- Add `BraintreePayPalNativeCheckout` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreePayPalNativeCheckout` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
