### PR TITLE
Add SwiftLint to `BraintreeSEPADirectDebit`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,6 +11,7 @@ included:
   - Sources/BraintreeDataCollector
   - Sources/BraintreeLocalPayment
   - Sources/BraintreePayPal
+  - Sources/BraintreeSEPADirectDebit
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
@@ -14,7 +14,7 @@ import BraintreeCore
     
     var webAuthenticationSession: BTWebAuthenticationSession
         
-    var sepaDirectDebitAPI: SEPADirectDebitAPI    
+    var sepaDirectDebitAPI: SEPADirectDebitAPI
 
     // MARK: - Initializers
 
@@ -24,7 +24,7 @@ import BraintreeCore
     public init(apiClient: BTAPIClient) {
         self.apiClient = apiClient
         self.sepaDirectDebitAPI = SEPADirectDebitAPI(apiClient: apiClient)
-        self.webAuthenticationSession =  BTWebAuthenticationSession()
+        self.webAuthenticationSession = BTWebAuthenticationSession()
 
         // We do not need to require the user authentication UIAlertViewController on SEPA since user log in is not required
         webAuthenticationSession.prefersEphemeralWebBrowserSession = true
@@ -46,7 +46,7 @@ import BraintreeCore
     @objc(tokenizeWithSEPADirectDebitRequest:completion:)
     public func tokenize(
         _ request: BTSEPADirectDebitRequest,
-        completion:  @escaping (BTSEPADirectDebitNonce?, Error?) -> Void
+        completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void
     ) {
         apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.tokenizeStarted)
         createMandate(request: request) { createMandateResult, error in
@@ -171,19 +171,22 @@ import BraintreeCore
         completion: @escaping (Bool, Error?) -> Void
     ) {
         if let url {
-            guard url.absoluteString.contains("sepa/success"),
-                  let queryParameter = self.getQueryStringParameter(url: url.absoluteString, param: "success"),
-                  queryParameter.contains("true") else {
-                self.apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeFailed)
-                self.apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.tokenizeFailed)
+            guard
+                url.absoluteString.contains("sepa/success"),
+                let queryParameter = self.getQueryStringParameter(url: url.absoluteString, param: "success"),
+                queryParameter.contains("true")
+            else {
+                apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeFailed)
+                apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.tokenizeFailed)
                 completion(false, BTSEPADirectDebitError.resultURLInvalid)
                 return
             }
-            self.apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeSucceeded)
+
+            apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeSucceeded)
             completion(true, nil)
         } else {
-            self.apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeFailed)
-            self.apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.tokenizeFailed)
+            apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeFailed)
+            apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.tokenizeFailed)
             completion(false, error)
             return
         }

--- a/Sources/BraintreeSEPADirectDebit/CreateMandateResult.swift
+++ b/Sources/BraintreeSEPADirectDebit/CreateMandateResult.swift
@@ -28,10 +28,11 @@ struct CreateMandateResult {
     let mandateType: String?
     
     init(json: BTJSON) {
-        self.approvalURL = json["message"]["body"]["sepaDebitAccount"]["approvalUrl"].asString() ?? CreateMandateResult.mandateAlreadyApprovedURLString
-        self.ibanLastFour = json["message"]["body"]["sepaDebitAccount"]["last4"].asString()
-        self.customerID = json["message"]["body"]["sepaDebitAccount"]["merchantOrPartnerCustomerId"].asString()
-        self.bankReferenceToken = json["message"]["body"]["sepaDebitAccount"]["bankReferenceToken"].asString()
-        self.mandateType = json["message"]["body"]["sepaDebitAccount"]["mandateType"].asString()
+        let sepaDebitAccount = json["message"]["body"]["sepaDebitAccount"]
+        self.approvalURL = sepaDebitAccount["approvalUrl"].asString() ?? CreateMandateResult.mandateAlreadyApprovedURLString
+        self.ibanLastFour = sepaDebitAccount["last4"].asString()
+        self.customerID = sepaDebitAccount["merchantOrPartnerCustomerId"].asString()
+        self.bankReferenceToken = sepaDebitAccount["bankReferenceToken"].asString()
+        self.mandateType = sepaDebitAccount["mandateType"].asString()
     }
 }

--- a/Sources/BraintreeSEPADirectDebit/SEPADebitAccountsRequest.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADebitAccountsRequest.swift
@@ -16,12 +16,14 @@ struct SEPADebitAccountsRequest: Encodable {
         let bankReferenceToken: String?
         let mandateType: String?
 
+        // swiftlint:disable nesting
         enum CodingKeys: String, CodingKey {
             case last4 = "last_4"
             case merchantOrPartnerCustomerID = "merchant_or_partner_customer_id"
             case bankReferenceToken = "bank_reference_token"
             case mandateType = "mandate_type"
         }
+        // swiftlint:enable nesting
     }
 
     init(createMandateResult: CreateMandateResult) {

--- a/Sources/BraintreeSEPADirectDebit/SEPADebitRequest.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADebitRequest.swift
@@ -4,6 +4,7 @@ import Foundation
 import BraintreeCore
 #endif
 
+// swiftlint:disable nesting
 /// The POST body for `v1/sepa_debit`
 struct SEPADebitRequest: Encodable {
 
@@ -56,6 +57,7 @@ struct SEPADebitRequest: Encodable {
                 case countryCodeAlpha2 = "country_code"
             }
         }
+        // swiftlint:enable nesting
 
         init(sepaDirectDebitRequest: BTSEPADirectDebitRequest) {
             self.merchantOrPartnerCustomerID = sepaDirectDebitRequest.customerID

--- a/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
+++ b/Sources/BraintreeSEPADirectDebit/SEPADirectDebitAPI.swift
@@ -18,7 +18,7 @@ class SEPADirectDebitAPI {
         completion: @escaping (CreateMandateResult?, Error?) -> Void
     ) {
         let sepaDebitRequest = SEPADebitRequest(sepaDirectDebitRequest: sepaDirectDebitRequest)
-        apiClient.post("v1/sepa_debit", parameters: sepaDebitRequest) { body, response, error in
+        apiClient.post("v1/sepa_debit", parameters: sepaDebitRequest) { body, _, error in
             if let error = error {
                 completion(nil, error)
                 return
@@ -36,7 +36,7 @@ class SEPADirectDebitAPI {
 
     func tokenize(createMandateResult: CreateMandateResult, completion: @escaping (BTSEPADirectDebitNonce?, Error?) -> Void) {
         let sepaDebitAccountsRequest = SEPADebitAccountsRequest(createMandateResult: createMandateResult)
-        apiClient.post("v1/payment_methods/sepa_debit_accounts", parameters: sepaDebitAccountsRequest) { body, response, error in
+        apiClient.post("v1/payment_methods/sepa_debit_accounts", parameters: sepaDebitAccountsRequest) { body, _, error in
             if let error = error {
                 completion(nil, error)
                 return


### PR DESCRIPTION
### Summary of changes

- Add `BraintreeSEPADirectDebit` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreeSEPADirectDebit` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 