### PR TITLE
Add SwiftLint to `BraintreeThreeDSecure`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,7 @@ included:
   - Sources/BraintreeLocalPayment
   - Sources/BraintreePayPal
   - Sources/BraintreePayPalMessaging
+  - Sources/BraintreeThreeDSecure
 
 excluded:
   - Sources/BraintreeCore/BTAPIPinnedCertificates.swift

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAdditionalInformation.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAdditionalInformation.swift
@@ -251,7 +251,7 @@ import Foundation
             "recurringEnd": recurringEnd,
             "recurringFrequency": recurringFrequency,
             "sdkMaxTimeout": sdkMaxTimeout,
-            "workPhoneNumber": workPhoneNumber,
+            "workPhoneNumber": workPhoneNumber
         ]
 
         let finalShippingAddress = shippingAddress?.asParameters(withPrefix: "shipping")

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
@@ -4,7 +4,7 @@ import Foundation
 import BraintreeCore
 #endif
 
-class BTThreeDSecureAuthenticateJWT {
+enum BTThreeDSecureAuthenticateJWT {
 
     static func authenticate(
         jwt cardinalJWT: String,
@@ -42,11 +42,11 @@ class BTThreeDSecureAuthenticateJWT {
                 return
             }
 
-            let threeDSecureResult: BTThreeDSecureResult = BTThreeDSecureResult(json: body)
+            let threeDSecureResult = BTThreeDSecureResult(json: body)
 
             if threeDSecureResult.tokenizedCard != nil && threeDSecureResult.errorMessage == nil {
                 apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.jwtAuthSucceeded)
-            } else {                
+            } else {
                 apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.jwtAuthFailed)
                 // If authentication wasn't successful, add the BTCardNonce from the lookup result to the authentication result
                 // so that merchants can transact with the lookup nonce if desired.

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -5,6 +5,7 @@ import CardinalMobile
 import BraintreeCore
 #endif
 
+// swiftlint:disable type_body_length file_length
 @objcMembers public class BTThreeDSecureClient: NSObject {
 
     // MARK: - Internal Properties
@@ -66,7 +67,8 @@ import BraintreeCore
             }
 
             if request.threeDSecureRequestDelegate == nil {
-                let error = BTThreeDSecureError.configuration("Configuration Error: threeDSecureRequestDelegate can not be nil when versionRequested is 2.")
+                let message = "Configuration Error: threeDSecureRequestDelegate can not be nil when versionRequested is 2."
+                let error = BTThreeDSecureError.configuration(message)
                 notifyFailure(with: error, completion: completion)
                 return
             }
@@ -179,7 +181,10 @@ import BraintreeCore
         self.merchantCompletion = completion
         
         guard let dataResponse = lookupResponse.data(using: .utf8) else {
-            merchantCompletion(nil, BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "Lookup response cannot be converted to Data type."]))
+            merchantCompletion(
+                nil,
+                BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "Lookup response cannot be converted to Data type."])
+            )
             return
         }
 
@@ -340,42 +345,7 @@ import BraintreeCore
                 return
             }
 
-            let customer: [String: String] = [:]
-
-            var requestParameters: [String: Any?] = [
-                "amount": request.amount,
-                "customer": customer,
-                "requestedThreeDSecureVersion": "2",
-                "dfReferenceId": request.dfReferenceID,
-                "accountType": request.accountType.stringValue,
-                "challengeRequested": request.challengeRequested,
-                "exemptionRequested": request.exemptionRequested,
-                "requestedExemptionType": request.requestedExemptionType.stringValue,
-                "dataOnlyRequested": request.dataOnlyRequested
-            ]
-
-            if let customFields = request.customFields {
-                requestParameters["customFields"] = customFields
-            }
-
-            if request._cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
-                requestParameters["cardAdd"] = true
-            } else if request._cardAddChallenge == .notRequested {
-                requestParameters["cardAdd"] = false
-            }
-
-            var additionalInformation: [String: String?] = [
-                "mobilePhoneNumber": request.mobilePhoneNumber,
-                "email": request.email,
-                "shippingMethod": request.shippingMethod.stringValue
-            ]
-
-            additionalInformation = additionalInformation.merging(request.billingAddress?.asParameters(withPrefix: "billing") ?? [:]) { $1 }
-            additionalInformation = additionalInformation.merging(request.additionalInformation?.asParameters() ?? [:]) { $1 }
-
-            requestParameters["additionalInfo"] = additionalInformation
-            requestParameters = requestParameters.compactMapValues { $0 }
-
+            let requestParameters = self.buildRequestDictionary(with: request)
             guard let urlSafeNonce = request.nonce?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
                 self.apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.lookupFailed)
                 self.notifyFailure(
@@ -387,14 +357,14 @@ import BraintreeCore
 
             self.apiClient.post(
                 "v1/payment_methods/\(urlSafeNonce)/three_d_secure/lookup",
-                parameters: requestParameters as [String: Any] 
+                parameters: requestParameters as [String: Any]
             ) { body, _, error in
                 if let error = error as NSError? {
                     // Provide more context for card validation error when status code 422
                     if error.domain == BTCoreConstants.httpErrorDomain,
-                       error as? BTHTTPError == .clientError([:]),
-                       let urlResponseError = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse,
-                       urlResponseError.statusCode == 422 {
+                        error as? BTHTTPError == .clientError([:]),
+                        let urlResponseError = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse,
+                        urlResponseError.statusCode == 422 {
                         var userInfo: [String: Any] = error.userInfo
                         let errorBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON
 
@@ -433,6 +403,46 @@ import BraintreeCore
                 return
             }
         }
+    }
+
+    private func buildRequestDictionary(with request: BTThreeDSecureRequest) -> [String: Any?] {
+        let customer: [String: String] = [:]
+
+        var requestParameters: [String: Any?] = [
+            "amount": request.amount,
+            "customer": customer,
+            "requestedThreeDSecureVersion": "2",
+            "dfReferenceId": request.dfReferenceID,
+            "accountType": request.accountType.stringValue,
+            "challengeRequested": request.challengeRequested,
+            "exemptionRequested": request.exemptionRequested,
+            "requestedExemptionType": request.requestedExemptionType.stringValue,
+            "dataOnlyRequested": request.dataOnlyRequested
+        ]
+
+        if let customFields = request.customFields {
+            requestParameters["customFields"] = customFields
+        }
+
+        if request._cardAddChallenge == .requested || request.cardAddChallengeRequested == true {
+            requestParameters["cardAdd"] = true
+        } else if request._cardAddChallenge == .notRequested {
+            requestParameters["cardAdd"] = false
+        }
+
+        var additionalInformation: [String: String?] = [
+            "mobilePhoneNumber": request.mobilePhoneNumber,
+            "email": request.email,
+            "shippingMethod": request.shippingMethod.stringValue
+        ]
+
+        additionalInformation = additionalInformation.merging(request.billingAddress?.asParameters(withPrefix: "billing") ?? [:]) { $1 }
+        additionalInformation = additionalInformation.merging(request.additionalInformation?.asParameters() ?? [:]) { $1 }
+
+        requestParameters["additionalInfo"] = additionalInformation
+        requestParameters = requestParameters.compactMapValues { $0 }
+
+        return requestParameters
     }
 
     // MARK: - Analytics Helper Methods

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureLookup.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureLookup.swift
@@ -13,8 +13,10 @@ import BraintreeCore
     /// The "PAReq" or "Payment Authentication Request" is the encoded request message used to initiate authentication.
     public var paReq: String?
 
+    // swiftlint:disable identifier_name
     /// The unique 3DS identifier assigned by Braintree to track the 3DS call as it progresses.
     public var md: String?
+    // swiftlint:enable identifier_name
 
     ///  The URL which the customer will be redirected to for a 3DS Interface.
     ///  In 3DS 2, the presence of an acsURL indicates there is a challenge as it would otherwise frictionlessly complete without an acsURL.

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecurePostalAddress.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecurePostalAddress.swift
@@ -70,7 +70,7 @@ import Foundation
     // MARK: Private Methods
 
     private func prepend(_ prefix: String?, toKey key: String) -> String {
-        if prefix != "", let prefix {
+        if let prefix, !prefix.isEmpty {
             // Uppercase the first character in the key
             let firstLetter = key.prefix(1).capitalized
             let remainingLetters = key.dropFirst()

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -13,7 +13,7 @@ import BraintreeCore
     public var nonce: String?
     
     /// Object where each key is the name of a custom field which has been configured in the Control Panel. In the Control Panel you can configure 3D Secure Rules which trigger on certain values.
-    public var customFields: [String: String]? = nil
+    public var customFields: [String: String]?
 
     /// The amount for the transaction
     public var amount: NSDecimalNumber? = 0
@@ -23,7 +23,7 @@ import BraintreeCore
     public var accountType: BTThreeDSecureAccountType = .unspecified
 
     /// Optional. The billing address used for verification
-    public var billingAddress: BTThreeDSecurePostalAddress? = nil
+    public var billingAddress: BTThreeDSecurePostalAddress?
 
     /// Optional. The mobile phone number used for verification
     /// - Note: Only numbers. Remove dashes, parentheses and other characters
@@ -67,10 +67,12 @@ import BraintreeCore
         set { _cardAddChallenge = newValue }
     }
 
+    // swiftlint:disable identifier_name
     /// Internal property for `cardAddChallenge`. Created to avoid deprecation warnings upon accessing
     /// `cardAddChallenge` directly within our SDK. Use this value internally instead.
     var _cardAddChallenge: BTThreeDSecureCardAddChallenge = .unspecified
-    
+    // swiftlint:enable identifier_name
+
     /// Optional.  An authentication created using this flag should only be used for vaulting operations (creation of customers' credit cards or payment methods) and not for creating transactions.
     /// If set to `true`, a card-add challenge will be requested from the issuer.
     /// If set to `false`, a card-add challenge will not be requested. 
@@ -97,5 +99,5 @@ import BraintreeCore
     // MARK: - Internal Properties
     
     /// The dfReferenceID for the session. Exposed for testing.
-    var dfReferenceID: String? = nil
+    var dfReferenceID: String?
 }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
@@ -12,7 +12,7 @@ class BTThreeDSecureV2Provider {
     let cardinalSession: CardinalSessionTestable
     let apiClient: BTAPIClient
 
-    var lookupResult: BTThreeDSecureResult? = nil
+    var lookupResult: BTThreeDSecureResult?
     var completionHandler: (BTThreeDSecureResult?, Error?) -> Void = { _, _ in }
 
     // MARK: - Initializer
@@ -27,7 +27,7 @@ class BTThreeDSecureV2Provider {
         self.apiClient = apiClient
         self.cardinalSession = cardinalSession
 
-        let cardinalConfiguration: CardinalSessionConfiguration = CardinalSessionConfiguration()
+        let cardinalConfiguration = CardinalSessionConfiguration()
 
         if let v2UICustomization = request.v2UICustomization {
             cardinalConfiguration.uiCustomization = v2UICustomization.cardinalValue
@@ -102,11 +102,13 @@ class BTThreeDSecureV2Provider {
 
 extension BTThreeDSecureV2Provider: CardinalValidationDelegate {
 
+    // swiftlint:disable implicitly_unwrapped_optional
     public func cardinalSession(
         cardinalSession session: CardinalSession!,
         stepUpValidated validateResponse: CardinalResponse!,
         serverJWT: String!
     ) {
+        // swiftlint:enable implicitly_unwrapped_optional
         switch validateResponse.actionCode {
         case .success, .noAction, .failure:
             if validateResponse.actionCode == .failure {

--- a/Sources/BraintreeThreeDSecure/V2UICustomization/BTThreeDSecureV2UICustomization.swift
+++ b/Sources/BraintreeThreeDSecure/V2UICustomization/BTThreeDSecureV2UICustomization.swift
@@ -51,7 +51,7 @@ import CardinalMobile
 
     // MARK: - Internal Properties
 
-    let cardinalValue: UiCustomization = UiCustomization()
+    let cardinalValue = UiCustomization()
 
     // MARK: - Public Methods
 


### PR DESCRIPTION
### Summary of changes

- Add `BraintreeThreeDSecure` module to `.swiftlint.yml`
- Address all swiftlint violations in `BraintreeThreeDSecure` - will enable 1 module at a time to make PRs easier to reason about, additionally this allow us to progressively enable Swiftlint across the SDK while ensure code changes in modules where it's enable are compliant

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 