### PR TITLE
[QL] Make Amount Optional in `BTPayPalBillingPricing`

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -148,9 +148,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
                 interval: .month,
                 intervalCount: 1,
                 numberOfExecutions: 1,
+                isTrial: true,
                 sequence: 1,
                 startDate: "2024-08-01",
-                isTrial: true,
                 pricing: billingPricing
             )
             

--- a/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingCycle.swift
+++ b/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingCycle.swift
@@ -27,21 +27,21 @@ public struct BTPayPalBillingCycle {
     
     /// Initialize a `BTPayPalBillingCycle` object.
     /// - Parameters:
-    ///   - interval: The number of intervals after which a subscriber is charged or billed.
-    ///   - intervalCount: The number of times this billing cycle gets executed. For example, if the `intervalCount` is DAY with an `intervalCount` of 2, the subscription is billed once every two days. Maximum values {DAY -> 365}, {WEEK, 52}, {MONTH, 12}, {YEAR, 1}.
-    ///   - numberOfExecutions: The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between 1 and 999). Regular billing cycles can be executed infinite times (value of 0) or a finite number of times (value between 1 and 999).
-    ///   - sequence: The sequence of the billing cycle. Used to identify unique billing cycles. For example, sequence 1 could be a 3 month trial period, and sequence 2 could be a longer term full rater cycle. Max value 100. All billing cycles should have unique sequence values.
-    ///   - startDate: The date and time when the billing cycle starts, in Internet date and time format `YYYY-MM-DD`. If not provided the billing cycle starts at the time of checkout. If provided and the merchant wants the billing cycle to start at the time of checkout, provide the current time. Otherwise the `startDate` can be in future.
-    ///   - isTrial: The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.
-    ///   - pricing: The active pricing scheme for this billing cycle. Required if `trial` is false. Optional if `trial` is true.
+    ///   - interval: Required: The number of intervals after which a subscriber is charged or billed.
+    ///   - intervalCount: Required: The number of times this billing cycle gets executed. For example, if the `intervalCount` is DAY with an `intervalCount` of 2, the subscription is billed once every two days. Maximum values {DAY -> 365}, {WEEK, 52}, {MONTH, 12}, {YEAR, 1}.
+    ///   - numberOfExecutions: Required: The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between 1 and 999). Regular billing cycles can be executed infinite times (value of 0) or a finite number of times (value between 1 and 999).
+    ///   - isTrial: Required: The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.
+    ///   - sequence: Optional: The sequence of the billing cycle. Used to identify unique billing cycles. For example, sequence 1 could be a 3 month trial period, and sequence 2 could be a longer term full rater cycle. Max value 100. All billing cycles should have unique sequence values.
+    ///   - startDate: Optional: The date and time when the billing cycle starts, in Internet date and time format `YYYY-MM-DD`. If not provided the billing cycle starts at the time of checkout. If provided and the merchant wants the billing cycle to start at the time of checkout, provide the current time. Otherwise the `startDate` can be in future.
+    ///   - pricing: Optional: The active pricing scheme for this billing cycle. Required if `trial` is false. Optional if `trial` is true.
     public init(
         interval: BillingInterval,
         intervalCount: Int,
         numberOfExecutions: Int,
-        sequence: Int?,
-        startDate: String?,
         isTrial: Bool,
-        pricing: BTPayPalBillingPricing?
+        sequence: Int? = nil,
+        startDate: String? = nil,
+        pricing: BTPayPalBillingPricing? = nil
     ) {
         self.interval = interval
         self.intervalCount = intervalCount

--- a/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingPricing.swift
+++ b/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingPricing.swift
@@ -15,17 +15,17 @@ public struct BTPayPalBillingPricing {
     // MARK: - Private Properties
     
     private let pricingModel: PricingModel
-    private let amount: String
+    private let amount: String?
     private let reloadThresholdAmount: String?
     
     // MARK: - Initializer
     
-    /// Initialilize a `BTPayPalBillingPricing` object.
+    /// Initialize a `BTPayPalBillingPricing` object.
     /// - Parameters:
-    ///   - pricingModel: The pricing model associated with the billing agreement.
-    ///   - amount: Price. The amount to charge for the subscription, recurring, UCOF or installments.
-    ///   - reloadThresholdAmount: The reload trigger threshold condition amount when the customer is charged.
-    public init(pricingModel: PricingModel, amount: String, reloadThresholdAmount: String?) {
+    ///   - pricingModel: Required: The pricing model associated with the billing agreement.
+    ///   - amount: Optional: Price. The amount to charge for the subscription, recurring, UCOF or installments.
+    ///   - reloadThresholdAmount: Optional: The reload trigger threshold condition amount when the customer is charged.
+    public init(pricingModel: PricingModel, amount: String? = nil, reloadThresholdAmount: String? = nil) {
         self.pricingModel = pricingModel
         self.amount = amount
         self.reloadThresholdAmount = reloadThresholdAmount
@@ -35,10 +35,13 @@ public struct BTPayPalBillingPricing {
     
     func parameters() -> [String: Any] {
         var parameters: [String: Any] = [
-            "pricing_model": pricingModel.rawValue,
-            "price": amount
+            "pricing_model": pricingModel.rawValue
         ]
-        
+
+        if let amount {
+            parameters["price"] = amount
+        }
+
         if let reloadThresholdAmount {
             parameters["reload_threshold_amount"] = reloadThresholdAmount
         }

--- a/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalRecurringBillingDetails.swift
+++ b/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalRecurringBillingDetails.swift
@@ -20,27 +20,27 @@ public struct BTPayPalRecurringBillingDetails {
     
     /// Initialize a `BTPayPalRecurringBillingDetails` object.
     /// - Parameters:
-    ///   - billingCycles: An array of billing cycles for trial billing and regular billing. A plan can have at most two trial cycles and only one regular cycle. Exceeding 3 items in this array results in an error.
-    ///   - currencyISOCode: The three-character ISO-4217 currency code that identifies the currency.
-    ///   - totalAmount: The total amount associated with the billing cycle at the time of checkout.
-    ///   - productName: The name of the plan to display at checkout.
-    ///   - productDescription: Product description to display at the checkout.
-    ///   - productQuantity: Quantity associated with the product.
-    ///   - oneTimeFeeAmount: Price and currency for any one-time charges due at plan signup.
-    ///   - shippingAmount: The shipping amount for the billing cycle at the time of checkout.
-    ///   - productAmount: The item price for the product associated with the billing cycle at the time of checkout.
-    ///   - taxAmount: The taxes for the billing cycle at the time of checkout.
+    ///   - billingCycles: Required: An array of billing cycles for trial billing and regular billing. A plan can have at most two trial cycles and only one regular cycle. Exceeding 3 items in this array results in an error.
+    ///   - currencyISOCode: Required: The three-character ISO-4217 currency code that identifies the currency.
+    ///   - totalAmount: Required: The total amount associated with the billing cycle at the time of checkout.
+    ///   - productName: Optional: The name of the plan to display at checkout.
+    ///   - productDescription: Optional: Product description to display at the checkout.
+    ///   - productQuantity: Optional: Quantity associated with the product.
+    ///   - oneTimeFeeAmount: Optional: Price and currency for any one-time charges due at plan signup.
+    ///   - shippingAmount: Optional: The shipping amount for the billing cycle at the time of checkout.
+    ///   - productAmount: Optional: The item price for the product associated with the billing cycle at the time of checkout.
+    ///   - taxAmount: Optional: The taxes for the billing cycle at the time of checkout.
     public init(
         billingCycles: [BTPayPalBillingCycle],
         currencyISOCode: String,
         totalAmount: String,
-        productName: String?,
-        productDescription: String?,
-        productQuantity: Int?,
-        oneTimeFeeAmount: String?,
-        shippingAmount: String?,
-        productAmount: String?,
-        taxAmount: String?
+        productName: String? = nil,
+        productDescription: String? = nil,
+        productQuantity: Int? = nil,
+        oneTimeFeeAmount: String? = nil,
+        shippingAmount: String? = nil,
+        productAmount: String? = nil,
+        taxAmount: String? = nil
     ) {
         self.billingCycles = billingCycles
         self.currencyISOCode = currencyISOCode

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -96,9 +96,9 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
             interval: .month,
             intervalCount: 13,
             numberOfExecutions: 12,
+            isTrial: false,
             sequence: 9,
             startDate: "test-date",
-            isTrial: false,
             pricing: billingPricing
         )
         


### PR DESCRIPTION
### Summary of changes

- End to end testing revealed that there are cases where amount is not required for RBA metadata in the `BTPayPalBillingPricing` - updated and tested that this can be omitted without error
- Added default nil values for optional properties in init so merchants do not need to pass them as nil
- Updated docstrings

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
