### PR TITLE
Add Additional Parameters To ShopperInsights Button Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased
 * BraintreePayPal
   * Send `isVaultRequest` for App Switch events to PayPal's analytics service (FPTI)
+* BraintreeShopperInsights (BETA)
+  * For analytics, send `experiment` as a parameter to `getRecommendedPaymentMethods` method
+  * For analytics, send `experiment` and `paymentMethodsDisplayed` analytic metrics to FPTI via the button presented methods
 
 ## 6.23.3 (2024-08-12)
 * BraintreeCore

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -85,7 +85,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         )
         Task {
             do {
-                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request)
+                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request, experiment: nil)
                 progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nEligible in PayPal Network: \(result.isEligibleInPayPalNetwork)")
                 payPalVaultButton.isEnabled = result.isPayPalRecommended
                 venmoButton.isEnabled = result.isVenmoRecommended

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -67,14 +67,21 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         stackView.distribution = .fillEqually
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        shopperInsightsClient.sendPayPalPresentedEvent()
-        shopperInsightsClient.sendVenmoPresentedEvent()
-        
         return stackView
     }
     
     @objc func shopperInsightsButtonTapped(_ button: UIButton) {
         self.progressBlock("Fetching shopper insights...")
+        
+        let sampleExperimentDetails =
+            """
+            [
+                { "experimentName" : "Shopper Insights Allocation" },
+                { "experimentID" : "a1b2c3" },
+                { "experimentGroup" : "Control" }
+            ]
+            """
+        shopperInsightsClient.experiment = sampleExperimentDetails
         
         let request = BTShopperInsightsRequest(
             email: emailView.textField.text ?? "",
@@ -85,7 +92,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         )
         Task {
             do {
-                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request, experiment: nil)
+                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request)
                 progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nEligible in PayPal Network: \(result.isEligibleInPayPalNetwork)")
                 payPalVaultButton.isEnabled = result.isPayPalRecommended
                 venmoButton.isEnabled = result.isVenmoRecommended
@@ -96,6 +103,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     }
     
     @objc func payPalVaultButtonTapped(_ button: UIButton) {
+        shopperInsightsClient.sendPayPalPresentedEvent(buttonRank: 0)
         progressBlock("Tapped PayPal Vault")
         shopperInsightsClient.sendPayPalSelectedEvent()
         
@@ -112,6 +120,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     }
     
     @objc func venmoButtonTapped(_ button: UIButton) {
+        shopperInsightsClient.sendVenmoPresentedEvent()
         progressBlock("Tapped Venmo")
         shopperInsightsClient.sendVenmoSelectedEvent()
         

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -82,7 +82,17 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         )
         Task {
             do {
-                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request)
+                let sampleExperiment =
+                        """
+                        [
+                          {
+                            "experimentName" : "payment ready conversion",
+                            "experimentID" : "a1b2c3" ,
+                            "treatmentName" : "control group 1",
+                          }
+                        ]
+                        """
+                let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request, experiment: sampleExperiment)
                 // swiftlint:disable:next line_length
                 progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nEligible in PayPal Network: \(result.isEligibleInPayPalNetwork)")
                 payPalVaultButton.isEnabled = result.isPayPalRecommended
@@ -94,7 +104,18 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     }
     
     @objc func payPalVaultButtonTapped(_ button: UIButton) {
-        shopperInsightsClient.sendPayPalPresentedEvent()
+        let sampleExperiment1 =
+                """
+                [
+                  {
+                    "experimentName" : "payment ready conversion experiment",
+                    "experimentID" : "a1b2c3" ,
+                    "treatmentName" : "treatment group 1",
+                  }
+                ]
+                """
+        let paymentMethods = ["Apple Pay", "Card", "PayPal"].joined(separator: ", ")
+        shopperInsightsClient.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods, experiment: sampleExperiment1)
         progressBlock("Tapped PayPal Vault")
         shopperInsightsClient.sendPayPalSelectedEvent()
         

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -73,16 +73,6 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     @objc func shopperInsightsButtonTapped(_ button: UIButton) {
         self.progressBlock("Fetching shopper insights...")
         
-        let sampleExperimentDetails =
-            """
-            [
-                { "experimentName" : "Shopper Insights Allocation" },
-                { "experimentID" : "a1b2c3" },
-                { "experimentGroup" : "Control" }
-            ]
-            """
-        shopperInsightsClient.experiment = sampleExperimentDetails
-        
         let request = BTShopperInsightsRequest(
             email: emailView.textField.text ?? "",
             phone: Phone(

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -102,7 +102,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     }
     
     @objc func payPalVaultButtonTapped(_ button: UIButton) {
-        let sampleExperiment1 =
+        let sampleExperiment =
             """
             [
                 { "experimentName" : "payment ready conversion experiment" },
@@ -111,7 +111,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
             ]
             """
         let paymentMethods = ["Apple Pay", "Card", "PayPal"]
-        shopperInsightsClient.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods, experiment: sampleExperiment1)
+        shopperInsightsClient.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods, experiment: sampleExperiment)
         progressBlock("Tapped PayPal Vault")
         shopperInsightsClient.sendPayPalSelectedEvent()
         

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -110,7 +110,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
                 { "treatmentName" : "treatment group 1" }
             ]
             """
-        let paymentMethods = ["Apple Pay", "Card", "PayPal"].joined(separator: ", ")
+        let paymentMethods = ["Apple Pay", "Card", "PayPal"]
         shopperInsightsClient.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods, experiment: sampleExperiment1)
         progressBlock("Tapped PayPal Vault")
         shopperInsightsClient.sendPayPalSelectedEvent()

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -83,15 +83,13 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
         Task {
             do {
                 let sampleExperiment =
-                        """
-                        [
-                          {
-                            "experimentName" : "payment ready conversion",
-                            "experimentID" : "a1b2c3" ,
-                            "treatmentName" : "control group 1",
-                          }
-                        ]
-                        """
+                    """
+                    [
+                        { "experimentName" : "payment ready conversion" },
+                        { "experimentID" : "a1b2c3" },
+                        { "treatmentName" : "control group 1" }
+                    ]
+                    """
                 let result = try await shopperInsightsClient.getRecommendedPaymentMethods(request: request, experiment: sampleExperiment)
                 // swiftlint:disable:next line_length
                 progressBlock("PayPal Recommended: \(result.isPayPalRecommended)\nVenmo Recommended: \(result.isVenmoRecommended)\nEligible in PayPal Network: \(result.isEligibleInPayPalNetwork)")
@@ -105,15 +103,13 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     
     @objc func payPalVaultButtonTapped(_ button: UIButton) {
         let sampleExperiment1 =
-                """
-                [
-                  {
-                    "experimentName" : "payment ready conversion experiment",
-                    "experimentID" : "a1b2c3" ,
-                    "treatmentName" : "treatment group 1",
-                  }
-                ]
-                """
+            """
+            [
+                { "experimentName" : "payment ready conversion experiment" },
+                { "experimentID" : "a1b2c3" },
+                { "treatmentName" : "treatment group 1" }
+            ]
+            """
         let paymentMethods = ["Apple Pay", "Card", "PayPal"].joined(separator: ", ")
         shopperInsightsClient.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods, experiment: sampleExperiment1)
         progressBlock("Tapped PayPal Vault")

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -93,7 +93,7 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     }
     
     @objc func payPalVaultButtonTapped(_ button: UIButton) {
-        shopperInsightsClient.sendPayPalPresentedEvent(buttonRank: 0)
+        shopperInsightsClient.sendPayPalPresentedEvent()
         progressBlock("Tapped PayPal Vault")
         shopperInsightsClient.sendPayPalSelectedEvent()
         

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -47,7 +47,7 @@ struct FPTIBatchData: Codable {
         let isVaultRequest: Bool?
         /// The type of link the SDK will be handling, currently deeplink or universal
         let linkType: String?
-        /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow..
+        /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow.
         let paymentMethodsDisplayed: String?
         /// Used for linking events from the client to server side request
         /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -31,7 +31,7 @@ struct FPTIBatchData: Codable {
 
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         /// The position of the button in the list of available payment methods, associated with the payments ready flow
-        let rank: Int?
+        let buttonRank: Int?
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
         let correlationID: String?
@@ -41,7 +41,7 @@ struct FPTIBatchData: Codable {
         let errorDescription: String?
         let eventName: String
         /// The experiment details associated with a shopper insights flow
-        let experiment: String?
+        let merchantExperiment: String?
         /// True if the `BTConfiguration` was retrieved from local cache after `tokenize()` call.
         /// False if the `BTConfiguration` was fetched remotely after `tokenize()` call.
         let isConfigFromCache: Bool?
@@ -61,14 +61,14 @@ struct FPTIBatchData: Codable {
         let tenantName: String = "Braintree"
         
         init(
-            rank: Int? = nil,
+            buttonRank: Int? = nil,
             connectionStartTime: Int? = nil,
             correlationID: String? = nil,
             endpoint: String? = nil,
             endTime: Int? = nil,
             errorDescription: String? = nil,
             eventName: String,
-            experiment: String? = nil,
+            merchantExperiment: String? = nil,
             isConfigFromCache: Bool? = nil,
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
@@ -82,12 +82,12 @@ struct FPTIBatchData: Codable {
             self.endTime = endTime
             self.errorDescription = errorDescription
             self.eventName = eventName
-            self.experiment = experiment
+            self.merchantExperiment = merchantExperiment
             self.isConfigFromCache = isConfigFromCache
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
             self.payPalContextID = payPalContextID
-            self.rank = rank
+            self.buttonRank = buttonRank
             self.requestStartTime = requestStartTime
             self.startTime = startTime
         }
@@ -97,12 +97,12 @@ struct FPTIBatchData: Codable {
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
             case eventName = "event_name"
-            case experiment = "experiment"
+            case merchantExperiment = "experiment"
             case isConfigFromCache = "config_cached"
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case payPalContextID = "paypal_context_id"
-            case rank = "rank"
+            case buttonRank = "rank"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -30,7 +30,8 @@ struct FPTIBatchData: Codable {
     struct Event: Codable {
 
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
-        ///
+        /// The position of the button in the list of available payment methods, associated with the payments ready flow
+        let buttonRank: Int?
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
         let correlationID: String?
@@ -39,6 +40,8 @@ struct FPTIBatchData: Codable {
         let endTime: Int?
         let errorDescription: String?
         let eventName: String
+        /// The experiment details associated with a shopper insights flow
+        let experiment: String?
         /// True if the `BTConfiguration` was retrieved from local cache after `tokenize()` call.
         /// False if the `BTConfiguration` was fetched remotely after `tokenize()` call.
         let isConfigFromCache: Bool?
@@ -58,12 +61,14 @@ struct FPTIBatchData: Codable {
         let tenantName: String = "Braintree"
         
         init(
+            buttonRank: Int? = nil,
             connectionStartTime: Int? = nil,
             correlationID: String? = nil,
             endpoint: String? = nil,
             endTime: Int? = nil,
             errorDescription: String? = nil,
             eventName: String,
+            experiment: String? = nil,
             isConfigFromCache: Bool? = nil,
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
@@ -71,12 +76,14 @@ struct FPTIBatchData: Codable {
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
+            self.buttonRank = buttonRank
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
             self.endTime = endTime
             self.errorDescription = errorDescription
             self.eventName = eventName
+            self.experiment = experiment
             self.isConfigFromCache = isConfigFromCache
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
@@ -86,10 +93,12 @@ struct FPTIBatchData: Codable {
         }
 
         enum CodingKeys: String, CodingKey {
+            case buttonRank = "button_rank"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
             case eventName = "event_name"
+            case experiment = "experiment"
             case isConfigFromCache = "config_cached"
             case isVaultRequest = "is_vault"
             case linkType = "link_type"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -30,8 +30,6 @@ struct FPTIBatchData: Codable {
     struct Event: Codable {
 
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
-        /// The position of the button in the list of available payment methods, associated with the payments ready flow
-        let buttonRank: Int?
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
         let correlationID: String?
@@ -49,6 +47,8 @@ struct FPTIBatchData: Codable {
         let isVaultRequest: Bool?
         /// The type of link the SDK will be handling, currently deeplink or universal
         let linkType: String?
+        /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow..
+        let paymentMethodsDisplayed: [String?]
         /// Used for linking events from the client to server side request
         /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow
         let payPalContextID: String?
@@ -61,7 +61,6 @@ struct FPTIBatchData: Codable {
         let tenantName: String = "Braintree"
         
         init(
-            buttonRank: Int? = nil,
             connectionStartTime: Int? = nil,
             correlationID: String? = nil,
             endpoint: String? = nil,
@@ -73,10 +72,10 @@ struct FPTIBatchData: Codable {
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
             payPalContextID: String? = nil,
+            paymentMethodsDisplayed: [String?] = [],
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
-            self.buttonRank = buttonRank
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
@@ -88,12 +87,12 @@ struct FPTIBatchData: Codable {
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
             self.payPalContextID = payPalContextID
+            self.paymentMethodsDisplayed = paymentMethodsDisplayed
             self.requestStartTime = requestStartTime
             self.startTime = startTime
         }
 
         enum CodingKeys: String, CodingKey {
-            case buttonRank = "rank"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
@@ -103,6 +102,7 @@ struct FPTIBatchData: Codable {
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case payPalContextID = "paypal_context_id"
+            case paymentMethodsDisplayed = "payment_methods_displayed"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -71,8 +71,8 @@ struct FPTIBatchData: Codable {
             isConfigFromCache: Bool? = nil,
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
-            payPalContextID: String? = nil,
             paymentMethodsDisplayed: [String?] = [],
+            payPalContextID: String? = nil,
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
@@ -86,8 +86,8 @@ struct FPTIBatchData: Codable {
             self.isConfigFromCache = isConfigFromCache
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
-            self.payPalContextID = payPalContextID
             self.paymentMethodsDisplayed = paymentMethodsDisplayed
+            self.payPalContextID = payPalContextID
             self.requestStartTime = requestStartTime
             self.startTime = startTime
         }
@@ -101,8 +101,8 @@ struct FPTIBatchData: Codable {
             case isConfigFromCache = "config_cached"
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
-            case payPalContextID = "paypal_context_id"
             case paymentMethodsDisplayed = "payment_methods_displayed"
+            case payPalContextID = "paypal_context_id"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -48,7 +48,7 @@ struct FPTIBatchData: Codable {
         /// The type of link the SDK will be handling, currently deeplink or universal
         let linkType: String?
         /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow..
-        let paymentMethodsDisplayed: [String?]
+        let paymentMethodsDisplayed: String?
         /// Used for linking events from the client to server side request
         /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow
         let payPalContextID: String?
@@ -71,7 +71,7 @@ struct FPTIBatchData: Codable {
             isConfigFromCache: Bool? = nil,
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
-            paymentMethodsDisplayed: [String?] = [],
+            paymentMethodsDisplayed: String? = nil,
             payPalContextID: String? = nil,
             requestStartTime: Int? = nil,
             startTime: Int? = nil

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -31,7 +31,7 @@ struct FPTIBatchData: Codable {
 
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         /// The position of the button in the list of available payment methods, associated with the payments ready flow
-        let buttonRank: Int?
+        let rank: Int?
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
         let correlationID: String?
@@ -61,7 +61,7 @@ struct FPTIBatchData: Codable {
         let tenantName: String = "Braintree"
         
         init(
-            buttonRank: Int? = nil,
+            rank: Int? = nil,
             connectionStartTime: Int? = nil,
             correlationID: String? = nil,
             endpoint: String? = nil,
@@ -76,7 +76,6 @@ struct FPTIBatchData: Codable {
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
-            self.buttonRank = buttonRank
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
@@ -88,12 +87,12 @@ struct FPTIBatchData: Codable {
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
             self.payPalContextID = payPalContextID
+            self.rank = rank
             self.requestStartTime = requestStartTime
             self.startTime = startTime
         }
 
         enum CodingKeys: String, CodingKey {
-            case buttonRank = "button_rank"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
@@ -103,6 +102,7 @@ struct FPTIBatchData: Codable {
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case payPalContextID = "paypal_context_id"
+            case rank = "rank"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -38,8 +38,6 @@ struct FPTIBatchData: Codable {
         let endTime: Int?
         let errorDescription: String?
         let eventName: String
-        /// The experiment details associated with a shopper insights flow
-        let merchantExperiment: String?
         /// True if the `BTConfiguration` was retrieved from local cache after `tokenize()` call.
         /// False if the `BTConfiguration` was fetched remotely after `tokenize()` call.
         let isConfigFromCache: Bool?
@@ -47,6 +45,8 @@ struct FPTIBatchData: Codable {
         let isVaultRequest: Bool?
         /// The type of link the SDK will be handling, currently deeplink or universal
         let linkType: String?
+        /// The experiment details associated with a shopper insights flow
+        let merchantExperiment: String?
         /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow.
         let paymentMethodsDisplayed: String?
         /// Used for linking events from the client to server side request
@@ -67,10 +67,10 @@ struct FPTIBatchData: Codable {
             endTime: Int? = nil,
             errorDescription: String? = nil,
             eventName: String,
-            merchantExperiment: String? = nil,
             isConfigFromCache: Bool? = nil,
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
+            merchantExperiment: String? = nil,
             paymentMethodsDisplayed: String? = nil,
             payPalContextID: String? = nil,
             requestStartTime: Int? = nil,
@@ -82,10 +82,10 @@ struct FPTIBatchData: Codable {
             self.endTime = endTime
             self.errorDescription = errorDescription
             self.eventName = eventName
-            self.merchantExperiment = merchantExperiment
             self.isConfigFromCache = isConfigFromCache
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
+            self.merchantExperiment = merchantExperiment
             self.paymentMethodsDisplayed = paymentMethodsDisplayed
             self.payPalContextID = payPalContextID
             self.requestStartTime = requestStartTime
@@ -97,10 +97,10 @@ struct FPTIBatchData: Codable {
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
             case eventName = "event_name"
-            case merchantExperiment = "experiment"
             case isConfigFromCache = "config_cached"
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
+            case merchantExperiment = "experiment"
             case paymentMethodsDisplayed = "payment_methods_displayed"
             case payPalContextID = "paypal_context_id"
             case requestStartTime = "request_start_time"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -76,6 +76,7 @@ struct FPTIBatchData: Codable {
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
+            self.buttonRank = buttonRank
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
@@ -87,12 +88,12 @@ struct FPTIBatchData: Codable {
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
             self.payPalContextID = payPalContextID
-            self.buttonRank = buttonRank
             self.requestStartTime = requestStartTime
             self.startTime = startTime
         }
 
         enum CodingKeys: String, CodingKey {
+            case buttonRank = "rank"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
@@ -102,7 +103,6 @@ struct FPTIBatchData: Codable {
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case payPalContextID = "paypal_context_id"
-            case buttonRank = "rank"
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -309,7 +309,7 @@ import Foundation
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
-        paymentMethodsDisplayed: [String?] = [],
+        paymentMethodsDisplayed: String? = nil,
         payPalContextID: String? = nil
     ) {
         analyticsService.sendAnalyticsEvent(

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -290,7 +290,6 @@ import Foundation
     ) async throws -> (BTJSON?, HTTPURLResponse?) {
         try await withCheckedThrowingContinuation { continuation in
             post(path, parameters: parameters, headers: headers, httpType: httpType) { json, httpResponse, error in
-                print("httpResponse: \(httpResponse)")
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
@@ -304,7 +303,7 @@ import Foundation
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(
         _ eventName: String,
-        buttonRank: Int? = nil,
+        rank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
         experiment: String? = nil,
@@ -315,7 +314,7 @@ import Foundation
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
-                buttonRank: buttonRank,
+                rank: rank,
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -317,10 +317,10 @@ import Foundation
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,
-                merchantExperiment: merchantExperiment,
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,
+                merchantExperiment: merchantExperiment,
                 paymentMethodsDisplayed: paymentMethodsDisplayed,
                 payPalContextID: payPalContextID
             )

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -309,8 +309,8 @@ import Foundation
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
-        payPalContextID: String? = nil,
-        paymentMethodsDisplayed: [String?] = []
+        paymentMethodsDisplayed: [String?] = [],
+        payPalContextID: String? = nil
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
@@ -321,8 +321,8 @@ import Foundation
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,
-                payPalContextID: payPalContextID,
-                paymentMethodsDisplayed: paymentMethodsDisplayed
+                paymentMethodsDisplayed: paymentMethodsDisplayed,
+                payPalContextID: payPalContextID
             )
         )
     }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -303,10 +303,10 @@ import Foundation
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(
         _ eventName: String,
-        rank: Int? = nil,
+        buttonRank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
-        experiment: String? = nil,
+        merchantExperiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
@@ -314,11 +314,11 @@ import Foundation
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
-                rank: rank,
+                buttonRank: buttonRank,
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,
-                experiment: experiment,
+                merchantExperiment: merchantExperiment,
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -290,6 +290,7 @@ import Foundation
     ) async throws -> (BTJSON?, HTTPURLResponse?) {
         try await withCheckedThrowingContinuation { continuation in
             post(path, parameters: parameters, headers: headers, httpType: httpType) { json, httpResponse, error in
+                print("httpResponse: \(httpResponse)")
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
@@ -303,8 +304,10 @@ import Foundation
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(
         _ eventName: String,
+        buttonRank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
+        experiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
@@ -312,9 +315,11 @@ import Foundation
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
+                buttonRank: buttonRank,
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,
+                experiment: experiment,
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -303,18 +303,17 @@ import Foundation
     @_documentation(visibility: private)
     public func sendAnalyticsEvent(
         _ eventName: String,
-        buttonRank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
         merchantExperiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
-        payPalContextID: String? = nil
+        payPalContextID: String? = nil,
+        paymentMethodsDisplayed: [String?] = []
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
-                buttonRank: buttonRank,
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,
@@ -322,7 +321,8 @@ import Foundation
                 isConfigFromCache: isConfigFromCache,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                paymentMethodsDisplayed: paymentMethodsDisplayed
             )
         )
     }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -84,7 +84,7 @@ public class BTShopperInsightsClient {
     /// - Parameters:
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
-    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
+    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: String? = nil, experiment: String? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
@@ -103,7 +103,7 @@ public class BTShopperInsightsClient {
     /// - Parameters:
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
-    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
+    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: String? = nil, experiment: String? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -88,7 +88,7 @@ public class BTShopperInsightsClient {
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed i.e. ['Apple Pay', 'PayPal']
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
-        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{$0}.joined(separator: ", ")
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{ $0 }.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
@@ -108,7 +108,7 @@ public class BTShopperInsightsClient {
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
-        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{$0}.joined(separator: ", ")
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{ $0 }.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -85,12 +85,12 @@ public class BTShopperInsightsClient {
 
     /// Call this method when the PayPal button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
-    /// - Parameter buttonRank: Optional:  The position of the button in the list of available payment methods.
-    public func sendPayPalPresentedEvent(buttonRank: Int? = nil) {
+    /// - Parameter paymentMethodsDisplayed: Optional:  The list of available payment methods.
+    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = []) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
-            buttonRank: buttonRank,
-            merchantExperiment: experiment
+            merchantExperiment: experiment,
+            paymentMethodsDisplayed: paymentMethodsDisplayed
         )
     }
     
@@ -102,12 +102,12 @@ public class BTShopperInsightsClient {
     
     /// Call this method when the Venmo button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
-    /// - Parameter buttonRank: Optional:  The position of the button in the list of available payment methods.
-    public func sendVenmoPresentedEvent(buttonRank: Int? = nil) {
+    /// - Parameter paymentMethodsDisplayed: Optional:  The list of available payment methods.
+    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = []) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
-            buttonRank: buttonRank,
-            merchantExperiment: experiment
+            merchantExperiment: experiment,
+            paymentMethodsDisplayed: paymentMethodsDisplayed
         )
     }
     

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -33,7 +33,10 @@ public class BTShopperInsightsClient {
     /// - Warning: This feature is in beta. Its public API may change or be removed in future releases.
     ///         PayPal recommendation is only available for US, AU, FR, DE, ITA, NED, ESP, Switzerland and UK merchants.
     ///         Venmo recommendation is only available for US merchants.
-    public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest, experiment: String? = nil) async throws -> BTShopperInsightsResult {
+    public func getRecommendedPaymentMethods(
+        request: BTShopperInsightsRequest,
+        experiment: String? = nil
+    ) async throws -> BTShopperInsightsResult {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsStarted,
             merchantExperiment: experiment

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -88,7 +88,7 @@ public class BTShopperInsightsClient {
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed i.e. ['Apple Pay', 'PayPal']
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
-        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{ $0 }.joined(separator: ", ")
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap { $0 }.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
@@ -108,7 +108,7 @@ public class BTShopperInsightsClient {
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
-        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{ $0 }.joined(separator: ", ")
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap { $0 }.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -87,11 +87,12 @@ public class BTShopperInsightsClient {
     /// - Parameters:
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed i.e. ['Apple Pay', 'PayPal']
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
-    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: String? = nil, experiment: String? = nil) {
+    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{$0}.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
-            paymentMethodsDisplayed: paymentMethodsDisplayed
+            paymentMethodsDisplayed: paymentMethodsDisplayedString
         )
     }
     
@@ -106,11 +107,12 @@ public class BTShopperInsightsClient {
     /// - Parameters:
     ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
-    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: String? = nil, experiment: String? = nil) {
+    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
+        let paymentMethodsDisplayedString = paymentMethodsDisplayed.compactMap{$0}.joined(separator: ", ")
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,
-            paymentMethodsDisplayed: paymentMethodsDisplayed
+            paymentMethodsDisplayed: paymentMethodsDisplayedString
         )
     }
     

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -52,8 +52,6 @@ public class BTShopperInsightsClient {
                 headers: ["PayPal-Client-Metadata-Id": apiClient.metadata.sessionID],
                 httpType: .payPalAPI
             )
-            
-            print("session id: \(apiClient.metadata.sessionID)")
 
             // swiftlint:disable empty_count
             guard
@@ -80,10 +78,10 @@ public class BTShopperInsightsClient {
 
     /// Call this method when the PayPal button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
-    public func sendPayPalPresentedEvent(experiment: String? = nil, buttonRank: Int? = nil) {
+    public func sendPayPalPresentedEvent(experiment: String? = nil, rank: Int? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
-            buttonRank: buttonRank,
+            rank: rank,
             experiment: experiment
         )
     }
@@ -96,10 +94,10 @@ public class BTShopperInsightsClient {
     
     /// Call this method when the Venmo button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience
-    public func sendVenmoPresentedEvent(experiment: String? = nil,buttonRank: Int? = nil) {
+    public func sendVenmoPresentedEvent(experiment: String? = nil, rank: Int? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
-            buttonRank: buttonRank,
+            rank: rank,
             experiment: experiment
         )
     }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -82,7 +82,7 @@ public class BTShopperInsightsClient {
     /// Call this method when the PayPal button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
     /// - Parameters:
-    ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
+    ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed i.e. ['Apple Pay', 'PayPal']
     ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     public func sendPayPalPresentedEvent(paymentMethodsDisplayed: String? = nil, experiment: String? = nil) {
         apiClient.sendAnalyticsEvent(

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -14,9 +14,6 @@ public class BTShopperInsightsClient {
     /// Defaults to `UIApplication.shared`, but exposed for unit tests to mock calls to `canOpenURL`.
     var application: URLOpener = UIApplication.shared
     
-    /// A `JSONObject` passed in as a string indicating details of the merchant experiment.
-    var experiment: String?
-    
     // MARK: - Private Properties
     
     private let apiClient: BTAPIClient
@@ -30,14 +27,13 @@ public class BTShopperInsightsClient {
     
     /// This method confirms if the customer is a user of PayPal services using their email and phone number.
     /// - Parameters:
-    ///   - request: Required:  A `BTShopperInsightsRequest` containing the buyer's user information
+    ///   - request: Required:  A `BTShopperInsightsRequest` containing the buyer's user information.
+    ///   - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
     /// - Returns: A `BTShopperInsightsResult` instance
     /// - Warning: This feature is in beta. Its public API may change or be removed in future releases.
     ///         PayPal recommendation is only available for US, AU, FR, DE, ITA, NED, ESP, Switzerland and UK merchants.
     ///         Venmo recommendation is only available for US merchants.
     public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest, experiment: String? = nil) async throws -> BTShopperInsightsResult {
-        self.experiment = experiment
-        
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsStarted,
             merchantExperiment: experiment
@@ -85,8 +81,10 @@ public class BTShopperInsightsClient {
 
     /// Call this method when the PayPal button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
-    /// - Parameter paymentMethodsDisplayed: Optional:  The list of available payment methods.
-    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = []) {
+    /// - Parameters:
+    ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
+    ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
+    public func sendPayPalPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
@@ -102,8 +100,10 @@ public class BTShopperInsightsClient {
     
     /// Call this method when the Venmo button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
-    /// - Parameter paymentMethodsDisplayed: Optional:  The list of available payment methods.
-    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = []) {
+    /// - Parameters:
+    ///    - paymentMethodsDisplayed: Optional:  The list of available payment methods, rendered in the same order in which they are displayed.
+    ///    - experiment: Optional:  A `JSONObject` passed in as a string containing details of the merchant experiment.
+    public func sendVenmoPresentedEvent(paymentMethodsDisplayed: [String?] = [], experiment: String? = nil) {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -9,15 +9,13 @@ import BraintreeCore
 /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
 public class BTShopperInsightsClient {
     
-    // MARK: - Public Properties
-
-    /// A `JSONObject` passed in as a string indicating details of the merchant experiment.
-    public var experiment: String?
-    
     // MARK: - Internal Properties
     
     /// Defaults to `UIApplication.shared`, but exposed for unit tests to mock calls to `canOpenURL`.
     var application: URLOpener = UIApplication.shared
+    
+    /// A `JSONObject` passed in as a string indicating details of the merchant experiment.
+    var experiment: String?
     
     // MARK: - Private Properties
     
@@ -37,7 +35,9 @@ public class BTShopperInsightsClient {
     /// - Warning: This feature is in beta. Its public API may change or be removed in future releases.
     ///         PayPal recommendation is only available for US, AU, FR, DE, ITA, NED, ESP, Switzerland and UK merchants.
     ///         Venmo recommendation is only available for US merchants.
-    public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest) async throws -> BTShopperInsightsResult {
+    public func getRecommendedPaymentMethods(request: BTShopperInsightsRequest, experiment: String? = nil) async throws -> BTShopperInsightsResult {
+        self.experiment = experiment
+        
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsStarted,
             merchantExperiment: experiment

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -21,9 +21,11 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     let sampleExperiment =
             """
             [
-                { "experimentName" : "Shopper Insights Experiment" },
-                { "experimentID" : "a1b2c3" },
-                { "experimentGroup" : "Control Group 1" }
+              {
+                "experimentName" : "payment ready conversion",
+                "experimentID" : "a1b2c3" ,
+                "treatmentName" : "control group 1",
+              }
             ]
             """
     
@@ -204,9 +206,10 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
     }
     
-    func testSendPayPalPresentedEvent_whenButtonRankSet_sendsAnalytic() {
-        sut.sendPayPalPresentedEvent(buttonRank: 0)
-        XCTAssertEqual(mockAPIClient.postedButtonRank, 0)
+    func testSendPayPalPresentedEvent_whenPaymentMethodsDisplayedNotNil_sendsAnalytic() {
+        let paymentMethods = ["Apple Pay", "Card", "PayPal"]
+        sut.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods)
+        XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods)
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
     }
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -106,7 +106,6 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     
     func testGetRecommendedPaymentMethods_whenEligibleInPayPalNetworkTrueANDMerchantExperimentSet_returnsOnlyPayPalRecommended() async {
         do {
-            sut.experiment = sampleExperiment
             let mockPayPalRecommendedResponse = BTJSON(
                 value: [
                     "eligible_methods": [
@@ -120,7 +119,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
                 ]
             )
             mockAPIClient.cannedResponseBody = mockPayPalRecommendedResponse
-            let result = try await sut.getRecommendedPaymentMethods(request: request)
+            let result = try await sut.getRecommendedPaymentMethods(request: request, experiment: sampleExperiment)
             XCTAssertTrue(result.isPayPalRecommended)
             XCTAssertFalse(result.isVenmoRecommended)
             XCTAssertTrue(result.isEligibleInPayPalNetwork)

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -207,9 +207,9 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     }
     
     func testSendPayPalPresentedEvent_whenPaymentMethodsDisplayedNotNil_sendsAnalytic() {
-        let paymentMethods = ["Apple Pay", "Card", "PayPal"].joined(separator: ", ")
+        let paymentMethods = ["Apple Pay", "Card", "PayPal"]
         sut.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods)
-        XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods)
+        XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods.joined(separator: ","))
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
     }
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -209,7 +209,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     func testSendPayPalPresentedEvent_whenPaymentMethodsDisplayedNotNil_sendsAnalytic() {
         let paymentMethods = ["Apple Pay", "Card", "PayPal"]
         sut.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods)
-        XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods.joined(separator: ","))
+        XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods.joined(separator: ", "))
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
     }
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -207,7 +207,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     }
     
     func testSendPayPalPresentedEvent_whenPaymentMethodsDisplayedNotNil_sendsAnalytic() {
-        let paymentMethods = ["Apple Pay", "Card", "PayPal"]
+        let paymentMethods = ["Apple Pay", "Card", "PayPal"].joined(separator: ", ")
         sut.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods)
         XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods)
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -90,8 +90,10 @@ public class MockAPIClient: BTAPIClient {
 
     public override func sendAnalyticsEvent(
         _ name: String,
+        rank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
+        experiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -15,6 +15,8 @@ public class MockAPIClient: BTAPIClient {
     public var postedPayPalContextID: String? = nil
     public var postedLinkType: LinkType? = nil
     public var postedIsVaultRequest = false
+    public var postedMerchantExperiment: String? = nil
+    public var postedButtonRank: Int? = nil
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -90,10 +92,10 @@ public class MockAPIClient: BTAPIClient {
 
     public override func sendAnalyticsEvent(
         _ name: String,
-        rank: Int? = nil,
+        buttonRank rank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
-        experiment: String? = nil,
+        merchantExperiment experiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
@@ -102,6 +104,8 @@ public class MockAPIClient: BTAPIClient {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType
         postedIsVaultRequest = isVaultRequest ?? false
+        postedButtonRank = rank
+        postedMerchantExperiment = experiment
         postedAnalyticsEvents.append(name)
     }
 

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -16,7 +16,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedLinkType: LinkType? = nil
     public var postedIsVaultRequest = false
     public var postedMerchantExperiment: String? = nil
-    public var postedPaymentMethodsDisplayed: [String?] = []
+    public var postedPaymentMethodsDisplayed: String? = nil
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -98,8 +98,8 @@ public class MockAPIClient: BTAPIClient {
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
-        payPalContextID: String? = nil,
-        paymentMethodsDisplayed: [String?] = []
+        paymentMethodsDisplayed: String? = nil,
+        payPalContextID: String? = nil
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -16,7 +16,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedLinkType: LinkType? = nil
     public var postedIsVaultRequest = false
     public var postedMerchantExperiment: String? = nil
-    public var postedButtonRank: Int? = nil
+    public var postedPaymentMethodsDisplayed: [String?] = []
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -92,20 +92,20 @@ public class MockAPIClient: BTAPIClient {
 
     public override func sendAnalyticsEvent(
         _ name: String,
-        buttonRank rank: Int? = nil,
         correlationID: String? = nil,
         errorDescription: String? = nil,
         merchantExperiment experiment: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
-        payPalContextID: String? = nil
+        payPalContextID: String? = nil,
+        paymentMethodsDisplayed: [String?] = []
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType
         postedIsVaultRequest = isVaultRequest ?? false
-        postedButtonRank = rank
         postedMerchantExperiment = experiment
+        postedPaymentMethodsDisplayed = paymentMethodsDisplayed
         postedAnalyticsEvents.append(name)
     }
 


### PR DESCRIPTION
### Summary of changes

- Add additional analytic parameters to the `ShopperInsights` Button Presentment Analytics 
- Tested out various use cases and ensured appropriate logs were rendered in FPTI:
    - `paymentMethodsDisplayed = ["Apple Pay", "Card", "PayPal"] `and `experiment` set to sampleJSON 
    - `sessionID: FE9334072FBD47C7B81EFED6C314C9DF `

<img width="1716" alt="Screenshot 2024-09-23 at 11 41 04 AM" src="https://github.com/user-attachments/assets/09d5f011-e889-4402-8563-05f16ce244c2">


### Checklist

- [x] Added a changelog entry


### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
