### PR TITLE
[QL] Update `interval` and `intervalCount`

### DIFF
--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -182,7 +182,7 @@ class ContainmentViewController: UIViewController {
                 }
             }
 
-        //TODO Remove this once ModXO goes GA
+        // TODO: Remove this once ModXO goes GA
         case .newPayPalCheckoutTokenizationKey:
             updateStatus("Fetching modXO (origami) checkout token...")
             

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -144,10 +144,10 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             )
             
             let billingCycle = BTPayPalBillingCycle(
+                isTrial: true,
+                numberOfExecutions: 1,
                 interval: .month,
                 intervalCount: 1,
-                numberOfExecutions: 1,
-                isTrial: true,
                 sequence: 1,
                 startDate: "2024-08-01",
                 pricing: billingPricing

--- a/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingCycle.swift
+++ b/Sources/BraintreePayPal/RecurringBillingMetadata/BTPayPalBillingCycle.swift
@@ -15,40 +15,40 @@ public struct BTPayPalBillingCycle {
     
     // MARK: - Private Properties
     
-    private let interval: BillingInterval
-    private let intervalCount: Int
+    private let isTrial: Bool
     private let numberOfExecutions: Int
+    private let interval: BillingInterval?
+    private let intervalCount: Int?
     private let sequence: Int?
     private let startDate: String?
-    private let isTrial: Bool
     private let pricing: BTPayPalBillingPricing?
     
     // MARK: - Initializer
     
     /// Initialize a `BTPayPalBillingCycle` object.
     /// - Parameters:
-    ///   - interval: Required: The number of intervals after which a subscriber is charged or billed.
-    ///   - intervalCount: Required: The number of times this billing cycle gets executed. For example, if the `intervalCount` is DAY with an `intervalCount` of 2, the subscription is billed once every two days. Maximum values {DAY -> 365}, {WEEK, 52}, {MONTH, 12}, {YEAR, 1}.
-    ///   - numberOfExecutions: Required: The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between 1 and 999). Regular billing cycles can be executed infinite times (value of 0) or a finite number of times (value between 1 and 999).
     ///   - isTrial: Required: The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.
+    ///   - numberOfExecutions: Required: The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between 1 and 999). Regular billing cycles can be executed infinite times (value of 0) or a finite number of times (value between 1 and 999).
+    ///   - interval: Optional: The number of intervals after which a subscriber is charged or billed.
+    ///   - intervalCount: Optional: The number of times this billing cycle gets executed. For example, if the `intervalCount` is DAY with an `intervalCount` of 2, the subscription is billed once every two days. Maximum values {DAY -> 365}, {WEEK, 52}, {MONTH, 12}, {YEAR, 1}.
     ///   - sequence: Optional: The sequence of the billing cycle. Used to identify unique billing cycles. For example, sequence 1 could be a 3 month trial period, and sequence 2 could be a longer term full rater cycle. Max value 100. All billing cycles should have unique sequence values.
     ///   - startDate: Optional: The date and time when the billing cycle starts, in Internet date and time format `YYYY-MM-DD`. If not provided the billing cycle starts at the time of checkout. If provided and the merchant wants the billing cycle to start at the time of checkout, provide the current time. Otherwise the `startDate` can be in future.
     ///   - pricing: Optional: The active pricing scheme for this billing cycle. Required if `trial` is false. Optional if `trial` is true.
     public init(
-        interval: BillingInterval,
-        intervalCount: Int,
-        numberOfExecutions: Int,
         isTrial: Bool,
+        numberOfExecutions: Int,
+        interval: BillingInterval? = nil,
+        intervalCount: Int? = nil,
         sequence: Int? = nil,
         startDate: String? = nil,
         pricing: BTPayPalBillingPricing? = nil
     ) {
+        self.isTrial = isTrial
+        self.numberOfExecutions = numberOfExecutions
         self.interval = interval
         self.intervalCount = intervalCount
-        self.numberOfExecutions = numberOfExecutions
         self.sequence = sequence
         self.startDate = startDate
-        self.isTrial = isTrial
         self.pricing = pricing
     }
     
@@ -56,12 +56,18 @@ public struct BTPayPalBillingCycle {
     
     func parameters() -> [String: Any] {
         var parameters: [String: Any] = [
-            "billing_frequency": intervalCount,
-            "billing_frequency_unit": interval.rawValue,
             "number_of_executions": numberOfExecutions,
             "trial": isTrial
         ]
-        
+
+        if let interval {
+            parameters["billing_frequency_unit"] = interval.rawValue
+        }
+
+        if let intervalCount {
+            parameters["billing_frequency"] = intervalCount
+        }
+
         if let sequence {
             parameters["sequence"] = sequence
         }

--- a/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalVaultRequest_Tests.swift
@@ -93,10 +93,10 @@ class BTPayPalVaultRequest_Tests: XCTestCase {
         )
         
         let billingCycle = BTPayPalBillingCycle(
+            isTrial: false,
+            numberOfExecutions: 12,
             interval: .month,
             intervalCount: 13,
-            numberOfExecutions: 12,
-            isTrial: false,
             sequence: 9,
             startDate: "test-date",
             pricing: billingPricing


### PR DESCRIPTION
### Summary of changes

- End to end testing revealed that there are cases where `billing_frequency` and `billing_frequency_unit` are not required for `unscheduled` cases for RBA metadata - updated and tested that these fields can be omitted without error when the `recurringBillingPlanType` is `.unscheduled` and the `pricingModel` is `.autoReload` per the test case
- Updated docstrings

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais