### PR TITLE
[QL] Add New `BTPayPalError.invalidAuthorization`

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -192,7 +192,7 @@ import BraintreeDataCollector
     /// - Parameters:
     ///   - request: A `BTPayPalVaultEditRequest`
     ///   - completion: This completion will be invoked exactly once when the edit flow is complete or an error occurs.
-    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases. Additionally, this feature is currently only supported with client token authorization.
     public func edit(
         _ request: BTPayPalVaultEditRequest,
         completion: @escaping (BTPayPalVaultEditResult?, Error?) -> Void
@@ -208,7 +208,7 @@ import BraintreeDataCollector
     /// - Parameter request: A `BTPayPalVaultEditRequest`
     /// - Returns: A `BTPayPalVaultEditResult` if successful
     /// - Throws: An `Error` describing the failure
-    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases. Additionally, this feature is currently only supported with client token authorization.
     public func edit(_ request: BTPayPalVaultEditRequest) async throws -> BTPayPalVaultEditResult {
         try await withCheckedThrowingContinuation { continuation in
             edit(request) { result, error in
@@ -229,7 +229,7 @@ import BraintreeDataCollector
     /// - Parameters:
     ///   - request: A `BTPayPalVaultErrorHandlingEditRequest`
     ///   - completion: This completion will be invoked exactly once when the edit flow is complete or an error occurs.
-    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases. Additionally, this feature is currently only supported with client token authorization.
     public func edit(
         _ request: BTPayPalVaultErrorHandlingEditRequest,
         completion: @escaping (BTPayPalVaultEditResult?, Error?) -> Void
@@ -245,7 +245,7 @@ import BraintreeDataCollector
     /// - Parameter request: A `BTPayPalVaultErrorHandlingEditRequest`
     /// - Returns: A `BTPayPalVaultEditResult` if successful
     /// - Throws: An `Error` describing the failure
-    /// - Warning: This feature is currently in beta and may change or be removed in future releases.
+    /// - Warning: This feature is currently in beta and may change or be removed in future releases. Additionally, this feature is currently only supported with client token authorization.
     public func edit(_ request: BTPayPalVaultErrorHandlingEditRequest) async throws -> BTPayPalVaultEditResult {
         try await withCheckedThrowingContinuation { continuation in
             edit(request) { result, error in
@@ -469,6 +469,11 @@ import BraintreeDataCollector
 
     private func edit(request: BTPayPalVaultEditRequest, completion: @escaping (BTPayPalVaultEditResult?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(BTPayPalAnalytics.editFIStarted)
+
+        if apiClient.authorization.type != .clientToken {
+            notifyEditFIFailure(with: BTPayPalError.invalidAuthorization, completion: completion)
+            return
+        }
 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -45,7 +45,7 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 13. Missing PayPal Request
     case missingPayPalRequest
 
-    /// 14. Invalid authorization type
+    /// 14. Invalid Authorization Type
     case invalidAuthorization
 
     public static var errorDomain: String {

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -45,6 +45,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 13. Missing PayPal Request
     case missingPayPalRequest
 
+    /// 14. Invalid authorization type
+    case invalidAuthorization
+
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
     }
@@ -79,6 +82,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 12
         case .missingPayPalRequest:
             return 13
+        case .invalidAuthorization:
+            return 14
         }
     }
 
@@ -114,6 +119,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "Missing BA Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
+        case .invalidAuthorization:
+            return "Invalid authorization. This feature can only be used with a client token."
         }
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -8,6 +8,10 @@ class BTPayPalClient_Tests: XCTestCase {
     var payPalClient: BTPayPalClient!
     var mockWebAuthenticationSession: MockWebAuthenticationSession!
 
+    let clientToken = TestClientTokenFactory.validClientToken
+    var clientTokenMockAPIClient: MockAPIClient!
+    var clientTokenPayPalClient: BTPayPalClient!
+
     override func setUp() {
         super.setUp()
 
@@ -20,8 +24,20 @@ class BTPayPalClient_Tests: XCTestCase {
             "paymentResource": ["redirectUrl": "http://fakeURL.com"]
         ])
         payPalClient = BTPayPalClient(apiClient: mockAPIClient, universalLink: URL(string: "https://www.paypal.com")!)
+
+        clientTokenMockAPIClient = MockAPIClient(authorization: clientToken)
+        clientTokenMockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
+            "paypalEnabled": true,
+            "paypal": ["environment": "offline"]
+        ] as [String: Any])
+        clientTokenMockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paymentResource": ["redirectUrl": "http://fakeURL.com"]
+        ])
+        clientTokenPayPalClient = BTPayPalClient(apiClient: clientTokenMockAPIClient)
+
         mockWebAuthenticationSession = MockWebAuthenticationSession()
         payPalClient.webAuthenticationSession = mockWebAuthenticationSession
+        clientTokenPayPalClient.webAuthenticationSession = mockWebAuthenticationSession
     }
 
     func testTokenizePayPalAccount_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
@@ -137,7 +153,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://onetouch/v1/success")
         let expectation = expectation(description: "Edit vault completion")
-        payPalClient.edit(editRequest) { result, error in
+        clientTokenPayPalClient.edit(editRequest) { result, error in
             XCTAssertNil(error)
             XCTAssertNotNil(result?.riskCorrelationID)
             expectation.fulfill()
@@ -145,7 +161,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
         let returnURL = URL(string: "https://onetouch/v1/success?ba_token=BA-777")!
         payPalClient.handleReturnURL(returnURL)
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:edit:succeeded"))
+        XCTAssertTrue(clientTokenMockAPIClient.postedAnalyticsEvents.contains("paypal:edit:succeeded"))
         waitForExpectations(timeout: 2)
     }
 
@@ -160,7 +176,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://onetouch/v1/cancel")
         let expectation = expectation(description: "Edit vault completion")
-        payPalClient.edit(editRequest) { result, error in
+        clientTokenPayPalClient.edit(editRequest) { result, error in
             XCTAssertNotNil(error)
             XCTAssertNil(result)
             expectation.fulfill()
@@ -168,17 +184,17 @@ class BTPayPalClient_Tests: XCTestCase {
 
         let returnURL = URL(string: "https://onetouch/v1/cancel?ba_token=BA-777")!
         payPalClient.handleReturnURL(returnURL)
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:edit:browser-login:canceled"))
+        XCTAssertTrue(clientTokenMockAPIClient.postedAnalyticsEvents.contains("paypal:edit:browser-login:canceled"))
         waitForExpectations(timeout: 2)
     }
 
     func testEdit_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {
-        mockAPIClient.cannedConfigurationResponseBody = nil
+        clientTokenMockAPIClient.cannedConfigurationResponseBody = nil
 
         let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
         let expectation = expectation(description: "Edit Vault fails with error")
 
-        payPalClient.edit(editRequest) { editResult, error in
+        clientTokenPayPalClient.edit(editRequest) { editResult, error in
             guard let error = error as NSError? else { XCTFail(); return }
             XCTAssertNil(editResult)
             XCTAssertEqual(error.domain, BTPayPalError.errorDomain)
@@ -187,19 +203,19 @@ class BTPayPalClient_Tests: XCTestCase {
             expectation.fulfill()
         }
 
-        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:edit:failed"))
+        XCTAssertTrue(clientTokenMockAPIClient.postedAnalyticsEvents.contains("paypal:edit:failed"))
         self.waitForExpectations(timeout: 1)
     }
 
     func testEdit_whenPayPalNotEnabledInConfiguration_callsBackWithError() {
-        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
+        clientTokenMockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": false
         ])
 
         let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
         let expectation = expectation(description: "Edit Vault fails with error")
 
-        payPalClient.edit(editRequest) { result, error in
+        clientTokenPayPalClient.edit(editRequest) { result, error in
             guard let error = error as NSError? else { XCTFail(); return }
             XCTAssertNil(result)
             XCTAssertEqual(error.domain, BTPayPalError.errorDomain)
@@ -212,7 +228,7 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testEdit_withTokenizationKey_returnsError() {
-        var apiClient = BTAPIClient(authorization: "sandbox_merchant_1234567890abc")!
+        let apiClient = BTAPIClient(authorization: "sandbox_merchant_1234567890abc")!
         let payPalClient = BTPayPalClient(apiClient: apiClient)
         let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
 
@@ -228,10 +244,10 @@ class BTPayPalClient_Tests: XCTestCase {
     func testEditFI_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
         let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
 
-        payPalClient.edit(editRequest) { _, _ in }
+        clientTokenPayPalClient.edit(editRequest) { _, _ in }
 
-        XCTAssertEqual("v1/paypal_hermes/generate_edit_fi_url", mockAPIClient.lastPOSTPath)
-        guard let lastPostParameters = mockAPIClient.lastPOSTParameters else { XCTFail(); return }
+        XCTAssertEqual("v1/paypal_hermes/generate_edit_fi_url", clientTokenMockAPIClient.lastPOSTPath)
+        guard let lastPostParameters = clientTokenMockAPIClient.lastPOSTParameters else { XCTFail(); return }
 
         XCTAssertEqual(lastPostParameters["edit_paypal_vault_id"] as? String, "test-ID")
 
@@ -259,11 +275,12 @@ class BTPayPalClient_Tests: XCTestCase {
             ]
         )
 
-        mockAPIClient.cannedResponseError = stubError
+        clientTokenMockAPIClient.cannedResponseError = stubError
 
         let dummyRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
         let expectation = expectation(description: "Edit FI fails with error")
-        payPalClient.edit(dummyRequest) { _, error in
+
+        clientTokenPayPalClient.edit(dummyRequest) { _, error in
             guard let error = error as NSError? else { XCTFail(); return }
             XCTAssertNotNil(error)
             XCTAssertEqual(error.domain, BTPayPalError.errorDomain)
@@ -452,7 +469,7 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testEditVault_whenAllApprovalURLsInvalid_returnsError() {
-        mockAPIClient.cannedResponseBody = BTJSON(value: [
+        clientTokenMockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
                 "approvalUrl": "",
                 "paypalAppApprovalUrl": ""
@@ -462,7 +479,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let request = BTPayPalVaultEditRequest(editPayPalVaultID: "test-id")
         let expectation = expectation(description: "Returns error")
 
-        payPalClient.edit(request) { editResult, error in
+        clientTokenPayPalClient.edit(request) { editResult, error in
             guard let error = error as NSError? else { XCTFail(); return }
             XCTAssertNil(editResult)
             XCTAssertEqual(error.domain, BTPayPalError.errorDomain)
@@ -475,7 +492,7 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testEditPayPalAccount_whenApprovalUrlIsNotHTTP_returnsError() {
-        mockAPIClient.cannedResponseBody = BTJSON(value: [
+        clientTokenMockAPIClient.cannedResponseBody = BTJSON(value: [
             "paymentResource": [
                 "redirectUrl": "file://some-url.com"
             ]
@@ -484,7 +501,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let request = BTPayPalVaultEditRequest(editPayPalVaultID: "testID")
         let expectation = expectation(description: "Returns error")
 
-        payPalClient.edit(request) { editResult, error in
+        clientTokenPayPalClient.edit(request) { editResult, error in
             XCTAssertNil(editResult)
             XCTAssertEqual((error! as NSError).domain, BTPayPalError.errorDomain)
             XCTAssertEqual((error! as NSError).code, BTPayPalError.asWebAuthenticationSessionURLInvalid("").errorCode)
@@ -496,7 +513,7 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testEditPayPalAccount_whenAllApprovalURLsInvalid_returnsError() {
-        mockAPIClient.cannedResponseBody = BTJSON(value: [
+        clientTokenMockAPIClient.cannedResponseBody = BTJSON(value: [
             "agreementSetup": [
                 "approvalUrl": "",
                 "paypalAppApprovalUrl": ""
@@ -506,7 +523,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let request = BTPayPalVaultEditRequest(editPayPalVaultID: "testID")
         let expectation = expectation(description: "Returns error")
 
-        payPalClient.edit(request) { editResult, error in
+        clientTokenPayPalClient.edit(request) { editResult, error in
             guard let error = error as NSError? else { XCTFail(); return }
             XCTAssertNil(editResult)
             XCTAssertEqual(error.domain, BTPayPalError.errorDomain)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -211,6 +211,20 @@ class BTPayPalClient_Tests: XCTestCase {
         self.waitForExpectations(timeout: 1)
     }
 
+    func testEdit_withTokenizationKey_returnsError() {
+        var apiClient = BTAPIClient(authorization: "sandbox_merchant_1234567890abc")!
+        let payPalClient = BTPayPalClient(apiClient: apiClient)
+        let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
+
+        payPalClient.edit(editRequest) { result, error in
+            XCTAssertNil(result)
+
+            guard let error = error as NSError? else { XCTFail(); return }
+            XCTAssertEqual(error.code, 14)
+            XCTAssertEqual(error.localizedDescription, "Invalid authorization. This feature can only be used with a client token.")
+        }
+    }
+
     func testEditFI_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
         let editRequest = BTPayPalVaultEditRequest(editPayPalVaultID: "test-ID")
 


### PR DESCRIPTION
### Summary of changes

- Add new `BTPayPalError.invalidAuthorization` and check authorization type in `edit` method
- Add warnings that authorization can only be client token with this feature
- Add unit test for new error

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
