### PR TITLE
Remove the dismiss keyboard gesture from PayPalMessagingViewController

### DIFF
--- a/Demo/Application/Base/BaseViewController.swift
+++ b/Demo/Application/Base/BaseViewController.swift
@@ -5,7 +5,8 @@ class BaseViewController: UIViewController {
 
     var progressBlock: ((String?) -> Void) = { _ in }
     var completionBlock: ((BTPaymentMethodNonce?) -> Void) = { _ in }
-
+    lazy var tapToDismissKeyboard = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    
     init(authorization: String) {
         super.init(nibName: nil, bundle: nil)
     }
@@ -15,7 +16,6 @@ class BaseViewController: UIViewController {
     }
 
     override func viewDidLoad() {
-        let tapToDismissKeyboard = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapToDismissKeyboard)
         super.viewDidLoad()
     }

--- a/Demo/Application/Features/PayPalMessagingViewController.swift
+++ b/Demo/Application/Features/PayPalMessagingViewController.swift
@@ -14,11 +14,12 @@ class PayPalMessagingViewController: PaymentButtonBaseViewController {
     )
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+        view.removeGestureRecognizer(super.tapToDismissKeyboard)
+
         title = "PayPal Messaging"
-        
         payPalMessagingView.delegate = self
         payPalMessagingView.start(request)
-        super.viewDidLoad()
     }
 
     private func setupView() {


### PR DESCRIPTION
### Summary of changes

- Remove the gesture implemented in the `BaseViewController` to avoid interference with the gesture in the `PayPalMessagingViewController`. This ensures that the `PayPalMessagingViewController` receives the gesture and launches the `PayPalMessageView`.

https://github.com/user-attachments/assets/229141d0-8f8e-44d2-92e0-a6f3031ad51b

### Checklist

- [ ] Added a changelog entry

### Authors

- @richherrera 
