### PR TITLE
[OPEN DEV] Move Workflows to GitHub Actions v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -24,7 +24,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Xcode 15.0.1
         run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
       - name: Install SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -26,7 +26,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
### Summary of changes

- Move all GitHub actions workflows to v4 - the main improvement in v4 should be performance speed as noted in the [GitHub blog here](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#whats-improved-in-v4)
- We were getting the following warning with continuing to use an old version, which v4 should also resolve:
    <img width="1242" alt="Screenshot 2024-10-04 at 1 03 02 PM" src="https://github.com/user-attachments/assets/4db6cb41-a0e0-4f78-95f4-ab02a1bffa36">
- It doesn't look like there should be any breaking changes in the release portion, but a bit hard to say since we were on v2 (while the rest of our workflows were on v3) - we will just need to be slightly aware of this next release

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
