### PR TITLE
Add Shipping Callback URL to BTPayPalRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreePayPal
+  * Add `shippingCallbackURL` to `BTPayPalRequest`
+
 ## 6.23.4 (2024-09-24)
 * BraintreePayPal
   * Send `isVaultRequest` for App Switch events to PayPal's analytics service (FPTI)

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -88,6 +88,9 @@ import BraintreeCore
 
     /// Optional: A risk correlation ID created with Set Transaction Context on your server.
     public var riskCorrelationID: String?
+    
+    /// Optional: Server side shipping callback URL to be notified when a customer updates their shipping address or options. A callback request will be sent to the merchant server at this URL.
+    public var shippingCallbackURL: URL?
 
     /// :nodoc: Exposed publicly for use by PayPal Native Checkout module. This property is not covered by semantic versioning.
     @_documentation(visibility: private)
@@ -115,7 +118,8 @@ import BraintreeCore
         merchantAccountID: String? = nil,
         lineItems: [BTPayPalLineItem]? = nil,
         billingAgreementDescription: String? = nil,
-        riskCorrelationId: String? = nil
+        riskCorrelationId: String? = nil,
+        shippingCallbackURL: URL? = nil
     ) {
         self.hermesPath = hermesPath
         self.paymentType = paymentType
@@ -129,6 +133,7 @@ import BraintreeCore
         self.lineItems = lineItems
         self.billingAgreementDescription = billingAgreementDescription
         self.riskCorrelationID = riskCorrelationId
+        self.shippingCallbackURL = shippingCallbackURL
     }
 
     // MARK: Public Methods
@@ -170,6 +175,10 @@ import BraintreeCore
             parameters["line_items"] = lineItemsArray
         }
 
+        if let shippingCallbackURL {
+            parameters["shipping_callback_url"] = shippingCallbackURL.absoluteString
+        }
+        
         parameters["return_url"] = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)success"
         parameters["cancel_url"] = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)cancel"
         parameters["experience_profile"] = experienceProfile

--- a/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalRequest_Tests.swift
@@ -105,4 +105,20 @@ class BTPayPalRequest_Tests: XCTestCase {
         XCTAssertEqual(request.userAuthenticationEmail, "fake@gmail.com")
         XCTAssertTrue(request.enablePayPalAppSwitch)
     }
+    
+    func testParameters_whenShippingCallbackURLNotSet_returnsParameters() {
+        let request = BTPayPalRequest(hermesPath: "hermes-test-path", paymentType: .checkout)
+        
+        XCTAssertNil(request.shippingCallbackURL)
+        let parameters = request.parameters(with: configuration)
+        XCTAssertNil(parameters["shipping_callback_url"])
+    }
+    
+    func testParameters_whitShippingCallbackURL_returnsParametersWithShippingCallbackURL() {
+        let request = BTPayPalRequest(hermesPath: "hermes-test-path", paymentType: .checkout, shippingCallbackURL: URL(string: "www.some-url.com"))
+        
+        XCTAssertNotNil(request.shippingCallbackURL)
+        let parameters = request.parameters(with: configuration)
+        XCTAssertNotNil(parameters["shipping_callback_url"])
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Add a new property to the `BTPayPalRequest` and pass it to support server-side shipping callbacks

### Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage

### Authors

- @richherrera 
