### PR TITLE
Fixup - only batch analytics events with same sessionID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Fix analytics bug where sessionID value in analytics payload was inaccurate; send separate FPTI POST requests per unique sessionID
+
 ## 6.23.4 (2024-09-24)
 * BraintreePayPal
   * Send `isVaultRequest` for App Switch events to PayPal's analytics service (FPTI)

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsEventsStorage.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsEventsStorage.swift
@@ -1,27 +1,32 @@
 import Foundation
 
-/// Used to store and access our array of events in a thread-safe manner
+/// Used to store and access our dictionary of events in a thread-safe manner
 actor BTAnalyticsEventsStorage {
 
-    private var events: [FPTIBatchData.Event]
+    // A list of analytic events, keyed by sessionID
+    private var events: [String: [FPTIBatchData.Event]]
 
     var isEmpty: Bool {
         events.isEmpty
     }
 
-    var allValues: [FPTIBatchData.Event] {
+    var allValues: [String: [FPTIBatchData.Event]] {
         events
     }
 
     init() {
-        self.events = []
+        self.events = [:]
     }
 
-    func append(_ event: FPTIBatchData.Event) {
-        events.append(event)
+    func append(_ event: FPTIBatchData.Event, sessionID: String) {
+        if let existingEventPerSession = events[sessionID] {
+            events[sessionID] = existingEventPerSession + [event]
+        } else {
+            events[sessionID] = [event]
+        }
     }
-
-    func removeAll() {
-        events.removeAll()
+    
+    func removeFor(sessionID: String) {
+        events.removeValue(forKey: sessionID)
     }
 }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsEventsStorage.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsEventsStorage.swift
@@ -19,11 +19,7 @@ actor BTAnalyticsEventsStorage {
     }
 
     func append(_ event: FPTIBatchData.Event, sessionID: String) {
-        if let existingEventPerSession = events[sessionID] {
-            events[sessionID] = existingEventPerSession + [event]
-        } else {
-            events[sessionID] = [event]
-        }
+        events[sessionID] = (events[sessionID] ?? []) + [event]
     }
     
     func removeFor(sessionID: String) {

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -163,9 +163,6 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
                 headers: headers
             )
 
-            if request.url?.path.contains("tracking") != nil {
-                request.debug()
-            }
             self.session.dataTask(with: request) { [weak self] data, response, error in
                 guard let self else {
                     completion?(nil, nil, BTHTTPError.deallocated("BTHTTP"))
@@ -489,15 +486,5 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
         let queryDiscardHolder = query.replacingOccurrences(of: #"^[^\(]*"#, with: "", options: .regularExpression)
         let finalQuery = query.replacingOccurrences(of: queryDiscardHolder, with: "")
         return finalQuery
-    }
-}
-
-extension URLRequest {
-    func debug() {
-        print("\(self.httpMethod!) \(self.url!)")
-//        print("Headers:")
-//        print(self.allHTTPHeaderFields!)
-        print("Body:")
-        print(String(data: self.httpBody ?? Data(), encoding: .utf8)!)
     }
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -52,6 +52,7 @@ public class BTShopperInsightsClient {
         )
 
         do {
+            print("👀SessionID: \(apiClient.metadata.sessionID)")
             let (json, _) = try await apiClient.post(
                 "/v2/payments/find-eligible-methods",
                 parameters: postParameters,

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -52,7 +52,6 @@ public class BTShopperInsightsClient {
         )
 
         do {
-            print("👀SessionID: \(apiClient.metadata.sessionID)")
             let (json, _) = try await apiClient.post(
                 "/v2/payments/find-eligible-methods",
                 parameters: postParameters,

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -113,10 +113,4 @@ final class BTAnalyticsService_Tests: XCTestCase {
         let eventParams = topLevelEvent?[0]["event_params"] as? [[String: Any]]
         return eventParams?[index]["event_name"] as? String
     }
-    
-    func parseSessionID(_ postParameters: [String: Any]?, at index: Int = 0) -> String? {
-        let topLevelEvent = postParameters?["events"] as? [[String: Any]]
-        let batchParams = topLevelEvent?[0]["batch_params"] as? [[String: Any]]
-        return batchParams?[index]["session_id"] as? String
-    }
 }

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -57,13 +57,11 @@ final class BTAnalyticsService_Tests: XCTestCase {
         // Send events associated with 1st sessionID
         stubAPIClient.metadata.sessionID = "session-id-1"
         await sut.performEventRequest(with: FPTIBatchData.Event(eventName: "event1"))
-        await sut.performEventRequest(with: FPTIBatchData.Event(eventName: "event2"))
         
         // Send events associated with 2nd sessionID
         stubAPIClient.metadata.sessionID = "session-id-2"
-        await sut.performEventRequest(with: FPTIBatchData.Event(eventName: "event3"))
         sut.shouldBypassTimerQueue = true
-        await sut.performEventRequest(with: FPTIBatchData.Event(eventName: "event4"))
+        await sut.performEventRequest(with: FPTIBatchData.Event(eventName: "event2"))
         
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 2)
     }

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -47,7 +47,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
         self.validateMetadataParameters(mockAnalyticsHTTP.lastRequestParameters)
     }
 
-    func testSendAnalyticsEvent_withMultipleSessionIDs_sendsMultiplePOSTs() async {
+    func testSendAnalyticsEvent_whenMultipleSessionIDs_sendsMultiplePOSTs() async {
         let stubAPIClient: MockAPIClient = stubbedAPIClientWithAnalyticsURL("test://do-not-send.url")
         let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
         let sut = BTAnalyticsService.shared


### PR DESCRIPTION
### Summary of Issue [LI-64570]
- There was a bug found with an LE merchant's ShopperInsights integration where the PaymentReady API team logs were tracking _more_ unique sessionIDs used to call their API from our SDK, than our SDK logs were tracking alone
    - The SDK sends our `session_id` to the PaymentReady API via[ this header](https://github.com/braintree/braintree_ios/blob/971196de71e88b1ccf2c35bf79ca7fc4c4c60b77/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift#L58)
    - Our analytics batch upload logic was including events across varying sessionIDs in a single batch payload. Since the `session_id` is at the `batch_params` level, the unique sessionIDs per API call were squashed/lost only logging the latest sessionID to be created/used.

### Changes
- This PR follows BT Android's model of doing a unique POST to `v1/tracking` per new sessionID
- Update `BTAnalyticsEventStorage` to track a list of events per `sessionID`

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 
