### PR TITLE
Add setupHTTPCredentials in fetchConfiguration

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -107,7 +107,13 @@ import Foundation
     }
     
     @MainActor func fetchConfiguration() async throws -> BTConfiguration {
-        try await configurationLoader.getConfig()
+        do {
+            let configuration = try await configurationLoader.getConfig()
+            setupHTTPCredentials(configuration)
+            return configuration
+        } catch {
+            throw error
+        }
     }
 
     /// Fetches a customer's vaulted payment method nonces.


### PR DESCRIPTION
### Summary of changes

- Make sure `setupHTTPCredentials` is called in `fetchConfiguration` used in `sendQueuedAnlayticsEvents`.

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
