### PR TITLE
Add App Switch Analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeVenmo
+  * Send `appSwitchUrl` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
+
 ## 6.24.0 (2024-10-15)
 * BraintreePayPal
   * Add `BTPayPalRecurringBillingDetails` and `BTPayPalRecurringBillingPlanType` opt-in request objects. Including these details will provide transparency to users on their billing schedule, dates, and amounts, as well as launch a modernized checkout UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeVenmo
-  * Send `appSwitchUrl` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
+  * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
 
 ## 6.24.0 (2024-10-15)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
-
 * BraintreePayPal
   * Add `BTPayPalRequest.userPhoneNumber` optional property
 * BraintreeVenmo

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -29,6 +29,7 @@ struct FPTIBatchData: Codable {
     /// Encapsulates a single event by it's name and timestamp.
     struct Event: Codable {
 
+        let appSwitchURL: URL?
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
@@ -61,6 +62,7 @@ struct FPTIBatchData: Codable {
         let tenantName: String = "Braintree"
         
         init(
+            appSwitchURL: URL? = nil,
             connectionStartTime: Int? = nil,
             correlationID: String? = nil,
             endpoint: String? = nil,
@@ -76,6 +78,7 @@ struct FPTIBatchData: Codable {
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
+            self.appSwitchURL = appSwitchURL
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
@@ -93,6 +96,7 @@ struct FPTIBatchData: Codable {
         }
 
         enum CodingKeys: String, CodingKey {
+            case appSwitchURL
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -96,7 +96,7 @@ struct FPTIBatchData: Codable {
         }
 
         enum CodingKeys: String, CodingKey {
-            case appSwitchURL
+            case appSwitchURL = "appSwitchUrl"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"
@@ -131,7 +131,7 @@ struct FPTIBatchData: Codable {
 
         let clientOS: String = UIDevice.current.systemName + " " + UIDevice.current.systemVersion
 
-        let component = "braintreeclientsdk"
+        let component = "venmo_10_16_braintreeclientsdk"
 
         let deviceManufacturer = "Apple"
 

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -131,7 +131,7 @@ struct FPTIBatchData: Codable {
 
         let clientOS: String = UIDevice.current.systemName + " " + UIDevice.current.systemVersion
 
-        let component = "venmo_10_16_braintreeclientsdk"
+        let component = "braintreeclientsdk"
 
         let deviceManufacturer = "Apple"
 

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -29,7 +29,7 @@ struct FPTIBatchData: Codable {
     /// Encapsulates a single event by it's name and timestamp.
     struct Event: Codable {
 
-        let appSwitchURL: URL?
+        let appSwitchURL: String?
         /// UTC millisecond timestamp when a networking task started establishing a TCP connection. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         /// `nil` if a persistent connection is used.
         let connectionStartTime: Int?
@@ -78,7 +78,7 @@ struct FPTIBatchData: Codable {
             requestStartTime: Int? = nil,
             startTime: Int? = nil
         ) {
-            self.appSwitchURL = appSwitchURL
+            self.appSwitchURL = appSwitchURL?.absoluteString
             self.connectionStartTime = connectionStartTime
             self.correlationID = correlationID
             self.endpoint = endpoint
@@ -96,7 +96,7 @@ struct FPTIBatchData: Codable {
         }
 
         enum CodingKeys: String, CodingKey {
-            case appSwitchURL = "appSwitchUrl"
+            case appSwitchURL = "url"
             case connectionStartTime = "connect_start_time"
             case correlationID = "correlation_id"
             case errorDescription = "error_desc"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -310,10 +310,12 @@ import Foundation
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
         paymentMethodsDisplayed: String? = nil,
-        payPalContextID: String? = nil
+        payPalContextID: String? = nil,
+        appSwitchURL: URL? = nil
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
+                appSwitchURL: appSwitchURL,
                 correlationID: correlationID,
                 errorDescription: errorDescription,
                 eventName: eventName,

--- a/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAnalytics.swift
@@ -9,8 +9,13 @@ enum BTVenmoAnalytics {
     static let tokenizeSucceeded = "venmo:tokenize:succeeded"
     static let appSwitchCanceled = "venmo:tokenize:app-switch:canceled"
     
-    // MARK: - Additional Detail Events
+    // MARK: - Additional Conversion events
+
+    static let handleReturnStarted = "venmo:tokenize:handle-return:started"
     
+    // MARK: - App Switch events
+    
+    static let appSwitchStarted = "venmo:tokenize:app-switch:started"
     static let appSwitchSucceeded = "venmo:tokenize:app-switch:succeeded"
     static let appSwitchFailed = "venmo:tokenize:app-switch:failed"
 }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -286,6 +286,7 @@ import BraintreeCore
 
     // MARK: - App Switch Methods
 
+    // swiftlint:disable:next function_body_length
     func handleOpen(_ url: URL) {
         apiClient.sendAnalyticsEvent(
             BTVenmoAnalytics.handleReturnStarted,

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -287,8 +287,12 @@ import BraintreeCore
     // MARK: - App Switch Methods
 
     func handleOpen(_ url: URL) {
-        // TODO: Add properties
-        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.handleReturnStarted)
+        apiClient.sendAnalyticsEvent(
+            BTVenmoAnalytics.handleReturnStarted,
+            isVaultRequest: shouldVault,
+            linkType: linkType,
+            payPalContextID: payPalContextID
+        )
         guard let cleanedURL = URL(string: url.absoluteString.replacingOccurrences(of: "#", with: "?")) else {
             notifyFailure(with: BTVenmoError.invalidReturnURL(url.absoluteString), completion: appSwitchCompletion)
             return
@@ -366,16 +370,21 @@ import BraintreeCore
     }
 
     func startVenmoFlow(with appSwitchURL: URL, shouldVault vault: Bool, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
-        // TODO: Add properties
-        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchStarted)
+        apiClient.sendAnalyticsEvent(
+            BTVenmoAnalytics.appSwitchStarted,
+            isVaultRequest: shouldVault,
+            linkType: linkType,
+            payPalContextID: payPalContextID
+        )
         application.open(appSwitchURL) { success in
-            self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
+            self.invokedOpenURLSuccessfully(success, shouldVault: vault, appSwitchURL: appSwitchURL, completion: completion)
         }
     }
 
     func invokedOpenURLSuccessfully(
         _ success: Bool,
         shouldVault vault: Bool,
+        appSwitchURL: URL,
         completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void
     ) {
         shouldVault = success && vault
@@ -385,7 +394,8 @@ import BraintreeCore
                 BTVenmoAnalytics.appSwitchSucceeded,
                 isVaultRequest: shouldVault,
                 linkType: linkType,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                appSwitchURL: appSwitchURL
             )
             BTVenmoClient.venmoClient = self
             self.appSwitchCompletion = completion
@@ -394,7 +404,8 @@ import BraintreeCore
                 BTVenmoAnalytics.appSwitchFailed,
                 isVaultRequest: shouldVault,
                 linkType: linkType,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                appSwitchURL: appSwitchURL
             )
             notifyFailure(with: BTVenmoError.appSwitchFailed, completion: completion)
         }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -287,6 +287,8 @@ import BraintreeCore
     // MARK: - App Switch Methods
 
     func handleOpen(_ url: URL) {
+        // TODO: Add properties
+        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.handleReturnStarted)
         guard let cleanedURL = URL(string: url.absoluteString.replacingOccurrences(of: "#", with: "?")) else {
             notifyFailure(with: BTVenmoError.invalidReturnURL(url.absoluteString), completion: appSwitchCompletion)
             return
@@ -364,6 +366,8 @@ import BraintreeCore
     }
 
     func startVenmoFlow(with appSwitchURL: URL, shouldVault vault: Bool, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
+        // TODO: Add properties
+        apiClient.sendAnalyticsEvent(BTVenmoAnalytics.appSwitchStarted)
         application.open(appSwitchURL) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, completion: completion)
         }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -17,7 +17,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedIsVaultRequest = false
     public var postedMerchantExperiment: String? = nil
     public var postedPaymentMethodsDisplayed: String? = nil
-    public var postedAppSwitchURL: [String: URL?] = [:]
+    public var postedAppSwitchURL: [String: String?] = [:]
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -108,7 +108,7 @@ public class MockAPIClient: BTAPIClient {
         postedIsVaultRequest = isVaultRequest ?? false
         postedMerchantExperiment = experiment
         postedPaymentMethodsDisplayed = paymentMethodsDisplayed
-        postedAppSwitchURL[name] = appSwitchURL
+        postedAppSwitchURL[name] = appSwitchURL?.absoluteString
         postedAnalyticsEvents.append(name)
     }
 

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -17,6 +17,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedIsVaultRequest = false
     public var postedMerchantExperiment: String? = nil
     public var postedPaymentMethodsDisplayed: String? = nil
+    public var postedAppSwitchURL: [String: URL?] = [:]
 
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -99,13 +100,15 @@ public class MockAPIClient: BTAPIClient {
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
         paymentMethodsDisplayed: String? = nil,
-        payPalContextID: String? = nil
+        payPalContextID: String? = nil,
+        appSwitchURL: URL? = nil
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType
         postedIsVaultRequest = isVaultRequest ?? false
         postedMerchantExperiment = experiment
         postedPaymentMethodsDisplayed = paymentMethodsDisplayed
+        postedAppSwitchURL[name] = appSwitchURL
         postedAnalyticsEvents.append(name)
     }
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -806,7 +806,7 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.invokedOpenURLSuccessfully(true, shouldVault: true, appSwitchURL: appSwitchURL) { _, _ in }
         
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, eventName)
-        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
     }
     
     func testInvokedOpenURLSuccessfully_whenFailure_sendsAppSwitchFailed_withAppSwitchURL() {
@@ -816,7 +816,7 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.invokedOpenURLSuccessfully(false, shouldVault: true, appSwitchURL: appSwitchURL) { _, _ in }
         
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first!, eventName)
-        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
     }
     
     // MARK: - BTAppContextSwitchClient

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -783,6 +783,42 @@ class BTVenmoClient_Tests: XCTestCase {
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
     
+    func testHandleOpen_sendsHandleReturnStartedEvent() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        let appSwitchURL = URL(string: "some-url")!
+        venmoClient.handleOpen(appSwitchURL)
+        
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.handleReturnStarted)
+    }
+    
+    func testStartVenmoFlow_sendsAppSwitchStartedEvent() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        let appSwitchURL = URL(string: "some-url")!
+        venmoClient.startVenmoFlow(with: appSwitchURL, shouldVault: false) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.appSwitchStarted)
+    }
+    
+    func testInvokedOpenURLSuccessfully_whenSuccess_sendsAppSwitchSucceeded_withAppSwitchURL() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        let eventName = BTVenmoAnalytics.appSwitchSucceeded
+        let appSwitchURL = URL(string: "some-url")!
+        venmoClient.invokedOpenURLSuccessfully(true, shouldVault: true, appSwitchURL: appSwitchURL) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, eventName)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL)
+    }
+    
+    func testInvokedOpenURLSuccessfully_whenFailure_sendsAppSwitchFailed_withAppSwitchURL() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+        let eventName = BTVenmoAnalytics.appSwitchFailed
+        let appSwitchURL = URL(string: "some-url")!
+        venmoClient.invokedOpenURLSuccessfully(false, shouldVault: true, appSwitchURL: appSwitchURL) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first!, eventName)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL)
+    }
+    
     // MARK: - BTAppContextSwitchClient
 
     func testIsiOSAppSwitchAvailable_whenApplicationCanOpenVenmoURL_returnsTrue() {


### PR DESCRIPTION
### Summary of changes

- Add the same events for the Venmo flow that were added for the PayPal app switch flow:
`venmo:tokenize:app-switch:started` and `venmo:tokenize:handle-return:started`
- Add `appSwitchUrl` in the `appSwitchSucceeded` and `appSwitchFailed` events.

<p>
  <img src=https://github.com/user-attachments/assets/caed3a92-8814-4c5d-b680-25342d79c6ae width="400" />
  <img src=https://github.com/user-attachments/assets/628659f8-e53d-4029-8dd3-fa1d2d5a0451 width="400" />
</p>

### Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage

### Authors

- @richherrera 
