### PR TITLE
Cleanup Venmo Demo UI

### DIFF
--- a/Demo/Application/Features/Helpers/Toggle.swift
+++ b/Demo/Application/Features/Helpers/Toggle.swift
@@ -6,7 +6,7 @@ class Toggle: UIView {
     private let title: String
     
     var isOn: Bool {
-        return toggle.isOn
+        toggle.isOn
     }
 
     init(title: String) {

--- a/Demo/Application/Features/Helpers/Toggle.swift
+++ b/Demo/Application/Features/Helpers/Toggle.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ToggleWithLabel: UIView {
+class Toggle: UIView {
 
     private let toggle = UISwitch()
     private let title: String
@@ -9,7 +9,7 @@ class ToggleWithLabel: UIView {
         return toggle.isOn
     }
 
-    init(_ title: String) {
+    init(title: String) {
         self.title = title
         super.init(frame: .zero)
         layoutUI()

--- a/Demo/Application/Features/Helpers/ToggleWithLabel.swift
+++ b/Demo/Application/Features/Helpers/ToggleWithLabel.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+class ToggleWithLabel: UIView {
+
+    private let toggle = UISwitch()
+    private let title: String
+    
+    var isOn: Bool {
+        return toggle.isOn
+    }
+
+    init(_ title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        layoutUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func layoutUI() {
+        let label = UILabel()
+        label.text = title
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+
+        let stackView = UIStackView(arrangedSubviews: [label, toggle])
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+}

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -52,32 +52,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         return textField
     }()
     
-    lazy var payLaterToggleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Offer Pay Later"
-        label.font = .preferredFont(forTextStyle: .footnote)
-        return label
-    }()
-    
-    let payLaterToggle = UISwitch()
 
-    lazy var newPayPalCheckoutToggleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "New PayPal Checkout Experience"
-        label.font = .preferredFont(forTextStyle: .footnote)
-        return label
-    }()
+    let payLaterToggle = Toggle(title: "Offer Pay Later")
     
-    let newPayPalCheckoutToggle = UISwitch()
+    let newPayPalCheckoutToggle = Toggle(title: "New PayPal Checkout Experience")
     
-    lazy var rbaDataToggleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Recurring Billing (RBA) Data"
-        label.font = .preferredFont(forTextStyle: .footnote)
-        return label
-    }()
-    
-    let rbaDataToggle = UISwitch()
+    let rbaDataToggle = Toggle(title: "Recurring Billing (RBA) Data")
 
     override func viewDidLoad() {
         super.heightConstraint = 350
@@ -90,12 +70,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let payPalAppSwitchButton = createButton(title: "PayPal App Switch", action: #selector(tappedPayPalAppSwitch))
 
         let oneTimeCheckoutStackView = buttonsStackView(label: "1-Time Checkout", views: [
-            UIStackView(arrangedSubviews: [payLaterToggleLabel, payLaterToggle]),
-            UIStackView(arrangedSubviews: [newPayPalCheckoutToggleLabel, newPayPalCheckoutToggle]),
+            payLaterToggle,
+            newPayPalCheckoutToggle,
             payPalCheckoutButton
         ])
         let vaultStackView = buttonsStackView(label: "Vault", views: [
-            UIStackView(arrangedSubviews: [rbaDataToggleLabel, rbaDataToggle]),
+            rbaDataToggle,
             payPalVaultButton,
             payPalAppSwitchButton
         ])

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -6,7 +6,6 @@ class VenmoViewController: PaymentButtonBaseViewController {
     // swiftlint:disable:next implicitly_unwrapped_optional
     var venmoClient: BTVenmoClient!
 
-    let ecdOptionsToggle = Toggle(title: "Add ECD Options")
     let webFallbackToggle = Toggle(title: "Enable Web Fallback")
     let vaultToggle = Toggle(title: "Vault")
     
@@ -19,7 +18,7 @@ class VenmoViewController: PaymentButtonBaseViewController {
     override func createPaymentButton() -> UIView {
         let venmoButton = createButton(title: "Venmo", action: #selector(tappedVenmo))
 
-        let stackView = UIStackView(arrangedSubviews: [ecdOptionsToggle, webFallbackToggle, vaultToggle, venmoButton])
+        let stackView = UIStackView(arrangedSubviews: [webFallbackToggle, vaultToggle, venmoButton])
         stackView.axis = .vertical
         stackView.spacing = 15
         stackView.alignment = .fill
@@ -33,20 +32,6 @@ class VenmoViewController: PaymentButtonBaseViewController {
         self.progressBlock("Tapped Venmo - initiating Venmo auth")
         
         let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
-
-        if ecdOptionsToggle.isOn {
-            venmoRequest.vault = true
-            venmoRequest.collectCustomerBillingAddress = true
-            venmoRequest.collectCustomerShippingAddress = true
-            venmoRequest.totalAmount = "30.00"
-            venmoRequest.taxAmount = "1.10"
-            venmoRequest.discountAmount = "1.10"
-            venmoRequest.shippingAmount = "0.00"
-            
-            let lineItem = BTVenmoLineItem(quantity: 1, unitAmount: "30.00", name: "item-1", kind: .debit)
-            lineItem.unitTaxAmount = "1.00"
-            venmoRequest.lineItems = [lineItem]
-        }
         
         if webFallbackToggle.isOn {
             venmoRequest.fallbackToWeb = true

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -5,6 +5,10 @@ class VenmoViewController: PaymentButtonBaseViewController {
  
     // swiftlint:disable:next implicitly_unwrapped_optional
     var venmoClient: BTVenmoClient!
+
+    let ecdOptionsToggle = ToggleWithLabel("Add ECD Options")
+    let webFallbackToggle = ToggleWithLabel("Enable Web Fallback")
+    let vaultToggle = ToggleWithLabel("Vault")
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -14,13 +18,11 @@ class VenmoViewController: PaymentButtonBaseViewController {
     
     override func createPaymentButton() -> UIView {
         let venmoButton = createButton(title: "Venmo", action: #selector(tappedVenmo))
-        let venmoECDButton = createButton(title: "Venmo (with ECD options)", action: #selector(tappedVenmoWithECD))
-        let venmoUniversalLinkButton = createButton(title: "Venmo Universal Links", action: #selector(tappedVenmoWithUniversalLinks))
 
-        let stackView = UIStackView(arrangedSubviews: [venmoButton, venmoECDButton, venmoUniversalLinkButton])
+        let stackView = UIStackView(arrangedSubviews: [ecdOptionsToggle, webFallbackToggle, vaultToggle, venmoButton])
         stackView.axis = .vertical
-        stackView.spacing = 5
-        stackView.alignment = .center
+        stackView.spacing = 15
+        stackView.alignment = .fill
         stackView.distribution = .fillEqually
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -31,44 +33,32 @@ class VenmoViewController: PaymentButtonBaseViewController {
         self.progressBlock("Tapped Venmo - initiating Venmo auth")
         
         let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
-        venmoRequest.vault = true
-        
-        checkout(request: venmoRequest)
-    }
-    
-    @objc func tappedVenmoWithECD() {
-        self.progressBlock("Tapped Venmo ECD - initiating Venmo auth")
-        
-        let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
-        venmoRequest.vault = true
-        venmoRequest.collectCustomerBillingAddress = true
-        venmoRequest.collectCustomerShippingAddress = true
-        venmoRequest.totalAmount = "30.00"
-        venmoRequest.taxAmount = "1.10"
-        venmoRequest.discountAmount = "1.10"
-        venmoRequest.shippingAmount = "0.00"
-        
-        let lineItem = BTVenmoLineItem(quantity: 1, unitAmount: "30.00", name: "item-1", kind: .debit)
-        lineItem.unitTaxAmount = "1.00"
-        venmoRequest.lineItems = [lineItem]
-        
-        checkout(request: venmoRequest)
-    }
 
-    @objc func tappedVenmoWithUniversalLinks() {
-        self.progressBlock("Tapped Venmo Universal Links - initiating Venmo auth")
-
-        let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
-        venmoRequest.vault = true
-        venmoRequest.fallbackToWeb = true
-
-        checkout(request: venmoRequest)
-    }
-
-    func checkout(request: BTVenmoRequest) {
+        if ecdOptionsToggle.isOn {
+            venmoRequest.vault = true
+            venmoRequest.collectCustomerBillingAddress = true
+            venmoRequest.collectCustomerShippingAddress = true
+            venmoRequest.totalAmount = "30.00"
+            venmoRequest.taxAmount = "1.10"
+            venmoRequest.discountAmount = "1.10"
+            venmoRequest.shippingAmount = "0.00"
+            
+            let lineItem = BTVenmoLineItem(quantity: 1, unitAmount: "30.00", name: "item-1", kind: .debit)
+            lineItem.unitTaxAmount = "1.00"
+            venmoRequest.lineItems = [lineItem]
+        }
+        
+        if webFallbackToggle.isOn {
+            venmoRequest.fallbackToWeb = true
+        }
+        
+        if vaultToggle.isOn {
+            venmoRequest.vault = true
+        }
+        
         Task {
             do {
-                let venmoAccount = try await venmoClient.tokenize(request)
+                let venmoAccount = try await venmoClient.tokenize(venmoRequest)
                 progressBlock("Got a nonce 💎!")
                 completionBlock(venmoAccount)
             } catch {

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -6,9 +6,9 @@ class VenmoViewController: PaymentButtonBaseViewController {
     // swiftlint:disable:next implicitly_unwrapped_optional
     var venmoClient: BTVenmoClient!
 
-    let ecdOptionsToggle = ToggleWithLabel("Add ECD Options")
-    let webFallbackToggle = ToggleWithLabel("Enable Web Fallback")
-    let vaultToggle = ToggleWithLabel("Vault")
+    let ecdOptionsToggle = Toggle(title: "Add ECD Options")
+    let webFallbackToggle = Toggle(title: "Enable Web Fallback")
+    let vaultToggle = Toggle(title: "Vault")
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; };
 		57108A182832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		62240F5A2B67FE1100ECE5C9 /* TextFieldWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */; };
+		8025988D2CC1A95400E7D898 /* ToggleWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */; };
 		8028B9762B28C9E100C88CE8 /* ShopperInsightsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */; };
 		8028B9782B28D42400C88CE8 /* BraintreeShopperInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */; };
 		8028B9792B28D42400C88CE8 /* BraintreeShopperInsights.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -148,6 +149,7 @@
 		62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldWithLabel.swift; sourceTree = "<group>"; };
 		6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73498B4265CA7D315E2FBF38 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleWithLabel.swift; sourceTree = "<group>"; };
 		8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShopperInsightsViewController.swift; sourceTree = "<group>"; };
 		8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeShopperInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeAmericanExpress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -293,6 +295,7 @@
 				BEAAAD042970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift */,
 				BED461822AD072D9001B0DDF /* CardHelpers.swift */,
 				62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */,
+				8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -709,6 +712,7 @@
 				BEBD52832AAB62FB005D6687 /* ApplePayViewController.swift in Sources */,
 				BEAAAD052970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift in Sources */,
 				809E86A62AD00AF4004998B0 /* AppDelegate.swift in Sources */,
+				8025988D2CC1A95400E7D898 /* ToggleWithLabel.swift in Sources */,
 				A0988F9224DB44B20095EEEE /* BraintreeDemoSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		57108A172832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; };
 		57108A182832EA04004EB870 /* BraintreePayPalNativeCheckout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57108A162832EA04004EB870 /* BraintreePayPalNativeCheckout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		62240F5A2B67FE1100ECE5C9 /* TextFieldWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */; };
-		8025988D2CC1A95400E7D898 /* ToggleWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */; };
+		8025988D2CC1A95400E7D898 /* Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8025988C2CC1A95400E7D898 /* Toggle.swift */; };
 		8028B9762B28C9E100C88CE8 /* ShopperInsightsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */; };
 		8028B9782B28D42400C88CE8 /* BraintreeShopperInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */; };
 		8028B9792B28D42400C88CE8 /* BraintreeShopperInsights.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -149,7 +149,7 @@
 		62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldWithLabel.swift; sourceTree = "<group>"; };
 		6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73498B4265CA7D315E2FBF38 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleWithLabel.swift; sourceTree = "<group>"; };
+		8025988C2CC1A95400E7D898 /* Toggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toggle.swift; sourceTree = "<group>"; };
 		8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShopperInsightsViewController.swift; sourceTree = "<group>"; };
 		8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeShopperInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		803D64EA256DAF9A00ACE692 /* BraintreeAmericanExpress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeAmericanExpress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -295,7 +295,7 @@
 				BEAAAD042970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift */,
 				BED461822AD072D9001B0DDF /* CardHelpers.swift */,
 				62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */,
-				8025988C2CC1A95400E7D898 /* ToggleWithLabel.swift */,
+				8025988C2CC1A95400E7D898 /* Toggle.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -712,7 +712,7 @@
 				BEBD52832AAB62FB005D6687 /* ApplePayViewController.swift in Sources */,
 				BEAAAD052970A70D000BD296 /* BTSEPADirectDebitTestHelper.swift in Sources */,
 				809E86A62AD00AF4004998B0 /* AppDelegate.swift in Sources */,
-				8025988D2CC1A95400E7D898 /* ToggleWithLabel.swift in Sources */,
+				8025988D2CC1A95400E7D898 /* Toggle.swift in Sources */,
 				A0988F9224DB44B20095EEEE /* BraintreeDemoSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
+++ b/Demo/UI Tests/Venmo UI Tests/Venmo_UITests.swift
@@ -31,16 +31,6 @@ class Venmo_UITests: XCTestCase {
         XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 30))
     }
     
-    func testTokenizeVenmo_withECDOptions_whenSignInSuccessfulWithPaymentContext_returnsNonce() {
-        waitForElementToBeHittable(demoApp.buttons["Venmo (with ECD options)"])
-        demoApp.buttons["Venmo (with ECD options)"].tap()
-        
-        waitForElementToBeHittable(mockVenmo.buttons["SUCCESS WITH PAYMENT CONTEXT"])
-        mockVenmo.buttons["SUCCESS WITH PAYMENT CONTEXT"].tap()
-
-        XCTAssertTrue(demoApp.buttons["Got a nonce. Tap to make a transaction."].waitForExistence(timeout: 30))
-    }
-    
     func testTokenizeVenmo_whenSignInSuccessfulWithoutPaymentContext_returnsNonce() {
         waitForElementToBeHittable(demoApp.buttons["Venmo"])
         demoApp.buttons["Venmo"].tap()


### PR DESCRIPTION
### Summary of changes

- Create re-usable Toggle + Label UIView file
- Remove 3 different Venmo buttons in favor of toggles for opt-in settings
   - This change is to prepare for another upcoming toggle to enable universal link returns from the Venmo app --> SDK (DTMOBILES-927)
- Remove ECD options button & UI test (Android doesn't have them and I've never seen us use it)

| Before    | After |
| -------- | ------- |
|  ![Screenshot 2024-10-17 at 3 55 26 PM](https://github.com/user-attachments/assets/687d2f19-e779-41c4-ac2d-4f55fc4ac16b) |  ![Screenshot 2024-10-17 at 4 56 44 PM](https://github.com/user-attachments/assets/4e1d8b67-3e91-4f1f-a1df-59483cbb82eb) |

I am indeed a designer :D 

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
