### PR TITLE
Update CMID Property Passed to the Gateway

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 import BraintreePayPal
 import BraintreeCore
 
+// swiftlint:disable type_body_length
 class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     lazy var payPalClient = BTPayPalClient(

--- a/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultEditRequest.swift
@@ -28,7 +28,7 @@ public class BTPayPalVaultEditRequest {
             "edit_paypal_vault_id": editPayPalVaultID,
             "return_url": BTCoreConstants.callbackURLScheme + "://\(BTPayPalVaultEditRequest.callbackURLHostAndPath)success",
             "cancel_url": BTCoreConstants.callbackURLScheme + "://\(BTPayPalVaultEditRequest.callbackURLHostAndPath)cancel",
-            "risk_correlation_id": riskCorrelationID
+            "correlation_id": riskCorrelationID
         ]
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -241,7 +241,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertEqual(lastPostParameters["return_url"] as? String, "sdk.ios.braintree://onetouch/v1/success")
         XCTAssertEqual(lastPostParameters["cancel_url"] as? String, "sdk.ios.braintree://onetouch/v1/cancel")
-        XCTAssertNotNil(lastPostParameters["risk_correlation_id"])
+        XCTAssertNotNil(lastPostParameters["correlation_id"])
     }
 
     func testEditFI_whenPostRequestContainsError_callsBackWithError() async {


### PR DESCRIPTION
### Summary of changes

- Rename `risk_correlation_id` to `correlation_id` to match what should be passed to the gateway for Edit FI/Error Handling.
- Update unit tests

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
