### PR TITLE
Add Shipping Callback URL to `BTPayPalCheckoutRequest` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * BraintreePayPal
+  * Add `shippingCallbackURL` to `BTPayPalCheckoutRequest`
   * Add `BTPayPalRequest.userPhoneNumber` optional property
 * BraintreeVenmo
   * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -85,6 +85,9 @@ import BraintreeCore
     /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     public var userAuthenticationEmail: String?
 
+    /// Optional: Server side shipping callback URL to be notified when a customer updates their shipping address or options. A callback request will be sent to the merchant server at this URL.
+    public var shippingCallbackURL: URL?
+    
     // MARK: - Initializer
 
     /// Initializes a PayPal Native Checkout request
@@ -98,13 +101,16 @@ import BraintreeCore
     ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
     ///   - requestBillingAgreement: Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement
     ///   during checkout. Defaults to `false`.
+    ///   - shippingCallbackURL: Optional: Server side shipping callback URL to be notified when a customer updates their shipping address or options.
+    ///   A callback request will be sent to the merchant server at this URL.
     public init(
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
         userAction: BTPayPalRequestUserAction = .none,
         offerPayLater: Bool = false,
         currencyCode: String? = nil,
-        requestBillingAgreement: Bool = false
+        requestBillingAgreement: Bool = false,
+        shippingCallbackURL: URL? = nil
     ) {
         self.amount = amount
         self.intent = intent
@@ -112,6 +118,7 @@ import BraintreeCore
         self.offerPayLater = offerPayLater
         self.currencyCode = currencyCode
         self.requestBillingAgreement = requestBillingAgreement
+        self.shippingCallbackURL = shippingCallbackURL
 
         super.init(hermesPath: "v1/paypal_hermes/create_payment_resource", paymentType: .checkout)
     }
@@ -153,6 +160,10 @@ import BraintreeCore
             if billingAgreementDescription != nil {
                 checkoutParameters["billing_agreement_details"] = ["description": billingAgreementDescription]
             }
+        }
+
+        if let shippingCallbackURL {
+            baseParameters["shipping_callback_url"] = shippingCallbackURL.absoluteString
         }
 
         if shippingAddressOverride != nil {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -176,4 +176,20 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         
         XCTAssertNil(parameters["payer_email"])
     }
+    
+    func testParameters_whenShippingCallbackURLNotSet_returnsParameters() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+
+        XCTAssertNil(request.shippingCallbackURL)
+        let parameters = request.parameters(with: configuration)
+        XCTAssertNil(parameters["shipping_callback_url"])
+    }
+
+    func testParameters_whitShippingCallbackURL_returnsParametersWithShippingCallbackURL() {
+        let request = BTPayPalCheckoutRequest(amount: "1", shippingCallbackURL: URL(string: "www.some-url.com"))
+
+        XCTAssertNotNil(request.shippingCallbackURL)
+        let parameters = request.parameters(with: configuration)
+        XCTAssertNotNil(parameters["shipping_callback_url"])
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Add a new property to the `BTPayPalCheckoutRequest` and pass it to support server-side shipping callbacks. Shipping callbacks should only be available for PayPal checkout flows.

### Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage

### Authors

- @richherrera 
