### PR TITLE
Bump GraphQL API Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## unreleased (v7)
 * Breaking Changes
   * Bump minimum supported deployment target to iOS 16+
+  * `countryCodeAlpha2` now returns a 2 character country code instead of a 3 character country code 
   * BraintreePayPalNativeCheckout
     * Remove entire PayPal Native Checkout module
-* BraintreeVenmo
-  * Update `BTVenmoRequest` to make all properties accessible on the initializer only vs via the dot syntax.
-* BraintreeSEPADirectDebit
-  * Update `BTSEPADirectDebitRequest` to make all properties accessible on the initializer only vs via the dot syntax.
-* BraintreeLocalPayment
-  * Update `BTLocalPaymentRequest` to make all properties accessible on the initializer only vs via the dot syntax.
+  * BraintreeVenmo
+    * Update `BTVenmoRequest` to make all properties accessible on the initializer only vs via the dot syntax.
+  * BraintreeSEPADirectDebit
+    * Update `BTSEPADirectDebitRequest` to make all properties accessible on the initializer only vs via the dot syntax.
+  * BraintreeLocalPayment
+    * Update `BTLocalPaymentRequest` to make all properties accessible on the initializer only vs via the dot syntax.
 
 ## unreleased
 * BraintreePayPal

--- a/Sources/BraintreeCore/BTCoreConstants.swift
+++ b/Sources/BraintreeCore/BTCoreConstants.swift
@@ -18,7 +18,7 @@ import Foundation
 
     static let apiVersion: String = "2016-10-07"
     
-    static let graphQLVersion: String = "2018-03-06"
+    static let graphQLVersion: String = "2024-11-05"
 
     // swiftlint:disable force_unwrapping
     static let payPalProductionURL = URL(string: "https://api.paypal.com")!

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
@@ -175,7 +175,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         http?.post("", configuration: fakeConfiguration, parameters: nil) { body, _, _ in
             let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
             let requestHeaders = httpRequest.allHTTPHeaderFields
-            XCTAssertEqual(requestHeaders!["Braintree-Version"], "2018-03-06")
+            XCTAssertEqual(requestHeaders!["Braintree-Version"], "2024-11-05")
             expectation.fulfill()
         }
 


### PR DESCRIPTION
### Summary of changes

- Bump the GraphQL API Version based on the current date
- Verified the card and venmo flows work as expected (these are the only flows using GQL currently)
- Android v5 PR with this change: https://github.com/braintree/braintree_android/pull/1128

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais 
