### PR TITLE
Update PayPal Messaging UI Test

### DIFF
--- a/Demo/UI Tests/PayPal Messaging UI Tests/PayPalMessaging_UITests.swift
+++ b/Demo/UI Tests/PayPal Messaging UI Tests/PayPalMessaging_UITests.swift
@@ -19,9 +19,10 @@ final class PayPalMessaging_Success_UITests: XCTestCase {
     func testStart_withValidRequest_firesDelegates() {
         XCTAssertTrue(app.buttons["DELEGATE: didAppear fired"].waitForExistence(timeout: 30))
 
-        let expectedButtonText = "PayPal - Pay monthly for purchases of $199-$10,000. Learn more"
-        waitForElementToBeHittable(app.buttons[expectedButtonText])
-        app.buttons[expectedButtonText].tap()
+        let expectedButtonTextPredicate = NSPredicate(format: "label CONTAINS[c] 'Pay monthly for purchases of'")
+        let button = app.buttons.containing(expectedButtonTextPredicate)
+        waitForElementToBeHittable(button.element)
+        button.element.tap()
         sleep(2)
 
         app.buttons["PayPal learn more modal close"].tap()


### PR DESCRIPTION
### Summary of changes

The test `testStart_withValidRequest_firesDelegates` has been failing recently. Upon investigation the text for `PayPal - Pay monthly for purchases of $199-$10,000. Learn more` has changed to `PayPal - Pay monthly for purchases of $49-$10,000. Learn more`. This is likely due to a backend change to vary the offers in some cases. Instead of just hardcoding the new value since we now know this can change, I opted to use `NSPredicate` for the portion of the text that we likely do not expect to change. This should hopefully keep our test more flexible with changes the messaging team may make to the text on the back end.

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais  
