### PR TITLE
Streamline 3DS UI Tests

### DIFF
--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_UITests_Extensions.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_UITests_Extensions.swift
@@ -29,6 +29,10 @@ internal extension XCUIApplication {
     var liabilityShiftedMessage: XCUIElement {
         return buttons["Liability shift possible and liability shifted"]
     }
+    
+    var liabilityCouldNotBeShiftedMessage: XCUIElement {
+        return buttons["3D Secure authentication was attempted but liability shift is not possible"]
+    }
 
     func enterCardDetailsWith(cardNumber: String, expirationDate: String = UITestDateGenerator.sharedInstance.futureDate()) {
         cardNumberTextField.tap()

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_UITests_Extensions.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_UITests_Extensions.swift
@@ -22,36 +22,12 @@ internal extension XCUIApplication {
         return buttons["Tokenize and Verify New Card"]
     }
 
-    var webViewPasswordTextField: XCUIElement {
-        return webViews.element.otherElements.children(matching: .other).children(matching: .secureTextField).element
-    }
-
-    var webViewSubmitButton: XCUIElement {
-        return webViews.element.otherElements.children(matching: .other).children(matching: .other).buttons["Submit"]
-    }
-
     var cardinalSubmitButton: XCUIElement {
         return buttons["SUBMIT"]
     }
 
     var liabilityShiftedMessage: XCUIElement {
         return buttons["Liability shift possible and liability shifted"]
-    }
-
-    var authenticationFailedMessage: XCUIElement {
-        return buttons["Failed to authenticate, please try a different form of payment."]
-    }
-
-    var liabilityCouldNotBeShiftedMessage: XCUIElement {
-        return buttons["3D Secure authentication was attempted but liability shift is not possible"]
-    }
-
-    var unexpectedErrorMessage: XCUIElement {
-        return buttons["An unexpected error occurred"]
-    }
-
-    var internalErrorMessage: XCUIElement {
-        return buttons["Internal Error."]
     }
 
     func enterCardDetailsWith(cardNumber: String, expirationDate: String = UITestDateGenerator.sharedInstance.futureDate()) {

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
@@ -16,15 +16,6 @@ class ThreeDSecure_V2_UITests: XCTestCase {
         app.launch()
     }
 
-    func testThreeDSecurePaymentFlowV2_frictionlessFlow_andTransacts() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001000", expirationDate: expirationDate)
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityShiftedMessage)
-    }
-
     func testThreeDSecurePaymentFlowV2_challengeFlow_andTransacts() {
         waitForElementToAppear(app.cardNumberTextField)
         app.enterCardDetailsWith(cardNumber: "4000000000001091", expirationDate: expirationDate)
@@ -45,55 +36,6 @@ class ThreeDSecure_V2_UITests: XCTestCase {
         waitForElementToAppear(app.liabilityShiftedMessage)
     }
 
-    func testThreeDSecurePaymentFlowV2_noChallenge_andFails() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "5200000000001013", expirationDate: expirationDate)
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage)
-    }
-
-    func testThreeDSecurePaymentFlowV2_challengeFlow_andFails() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001109", expirationDate: expirationDate)
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: .threeDSecureTimeout)
-
-        let textField = app.textFields.element(boundBy: 0)
-        waitForElementToBeHittable(textField)
-        textField.forceTapElement()
-        sleep(2)
-        textField.typeText("1234")
-
-        app.cardinalSubmitButton.forceTapElement()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage, timeout: 30)
-    }
-
-    func testThreeDSecurePaymentFlowV2_acceptsPassword_failsToAuthenticateNonce_dueToCardinalError() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001125")
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: .threeDSecureTimeout)
-
-        let textField = app.textFields.element(boundBy: 0)
-        waitForElementToBeHittable(textField)
-        textField.forceTapElement()
-        sleep(2)
-        textField.typeText("1234")
-
-        app.cardinalSubmitButton.forceTapElement()
-        sleep(2)
-
-        waitForElementToAppear(app.internalErrorMessage, timeout: 30)
-    }
-
     func testThreeDSecurePaymentFlowV2_returnsToApp_whenCancelTapped() {
         waitForElementToAppear(app.cardNumberTextField)
         app.enterCardDetailsWith(cardNumber: "4000000000001091")
@@ -105,32 +47,5 @@ class ThreeDSecure_V2_UITests: XCTestCase {
         app.buttons["Close"].forceTapElement()
 
         waitForElementToAppear(app.buttons["Canceled 🎲"])
-    }
-
-    func testThreeDSecurePaymentFlowV2_bypassedAuthentication() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001083")
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage)
-    }
-
-    func testThreeDSecurePaymentFlowV2_lookupError() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001034")
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage)
-    }
-
-    func testThreeDSecurePaymentFlowV2_timeout() {
-        waitForElementToAppear(app.cardNumberTextField)
-        app.enterCardDetailsWith(cardNumber: "4000000000001075")
-        app.tokenizeButton.tap()
-        sleep(2)
-
-        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage, timeout: 45)
     }
 }

--- a/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
+++ b/Demo/UI Tests/ThreeDSecure UI Tests/ThreeDSecure_V2_UITests.swift
@@ -35,6 +35,26 @@ class ThreeDSecure_V2_UITests: XCTestCase {
 
         waitForElementToAppear(app.liabilityShiftedMessage)
     }
+    
+    func testThreeDSecurePaymentFlowV2_challengeFlow_andFails() {
+        waitForElementToAppear(app.cardNumberTextField)
+        app.enterCardDetailsWith(cardNumber: "4000000000001109", expirationDate: expirationDate)
+        app.tokenizeButton.tap()
+        sleep(2)
+
+        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: .threeDSecureTimeout)
+
+        let textField = app.textFields.element(boundBy: 0)
+        waitForElementToBeHittable(textField)
+        textField.forceTapElement()
+        sleep(2)
+        textField.typeText("1234")
+
+        app.cardinalSubmitButton.forceTapElement()
+        sleep(2)
+
+        waitForElementToAppear(app.liabilityCouldNotBeShiftedMessage, timeout: 30)
+    }
 
     func testThreeDSecurePaymentFlowV2_returnsToApp_whenCancelTapped() {
         waitForElementToAppear(app.cardNumberTextField)


### PR DESCRIPTION
### Summary of changes

* Remove all 3DS UI tests except the following cases:
     1)  Successfully completes challenge flow & returns to app
     2) Cancels 3DS challenge flow & returns to app
* Why? 
    * The SDK's test suite is not responsible for serving as E2E integration tests for numerous [test card cases](https://developer.paypal.com/braintree/docs/guides/3d-secure/testing/ruby#testing). Our UI tests should capture the functionality that our SDK adds to a checkout experience.
    * UI tests are timely and expensive. Read about Mike Cohn's "Testing Pyramid" concept, where UI tests should make up the top, smallest part of the pyramid.

#### Tests removed:
Total time reduced: **2 min 20 sec** (140 seconds)

```
    ✔ testThreeDSecurePaymentFlowV2_frictionlessFlow_andTransacts (17.442 seconds)
    ✔ testThreeDSecurePaymentFlowV2_noChallenge_andFails (17.517 seconds)
    ✔ testThreeDSecurePaymentFlowV2_acceptsPassword_failsToAuthenticateNonce_dueToCardinalError (28.011 seconds)
    ✔ testThreeDSecurePaymentFlowV2_bypassedAuthentication (19.161 seconds)
    ✔ testThreeDSecurePaymentFlowV2_lookupError (17.653 seconds)
    ✔ testThreeDSecurePaymentFlowV2_timeout (41.804 seconds)
```

### Feedback

If folks agree that these 2 cases are the only ones we need to UI test for, we can make the same update to our [Android 3DS UI tests](https://github.com/braintree/braintree_android/blob/main/Demo/src/androidTest/java/com/braintreepayments/demo/test/ThreeDSecureCardinalTest.java). Keep me honest here and call out any concerns you may have.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 