### PR TITLE
Add Contact Information request object

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */; };
 		45227FC52C330FDE00A15018 /* MockURLSessionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */; };
 		45227FC72C33104100A15018 /* MockBTHTTPNetworkTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */; };
+		454722AC2CEFB291000DCF4E /* BTContactInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454722AB2CEFB291000DCF4E /* BTContactInformation.swift */; };
 		457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */; };
 		457D7FCA2C2A250E00EF6523 /* RepeatingTimer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */; };
 		458570782C34A699009CEF7A /* ConfigurationLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */; };
@@ -790,6 +791,7 @@
 		42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
 		45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionTask.swift; sourceTree = "<group>"; };
 		45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBTHTTPNetworkTiming.swift; sourceTree = "<group>"; };
+		454722AB2CEFB291000DCF4E /* BTContactInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTContactInformation.swift; sourceTree = "<group>"; };
 		457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
 		457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer_Tests.swift; sourceTree = "<group>"; };
 		458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader_Tests.swift; sourceTree = "<group>"; };
@@ -1406,6 +1408,7 @@
 				62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */,
 				807D22F32C29ADA8009FFEA4 /* RecurringBillingMetadata */,
 				62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */,
+				454722AB2CEFB291000DCF4E /* BTContactInformation.swift */,
 			);
 			path = BraintreePayPal;
 			sourceTree = "<group>";
@@ -3291,6 +3294,7 @@
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,
 				8014221C2BAE935B009F9999 /* BTPayPalApprovalURLParser.swift in Sources */,
 				BE349111294B77E100D2CF68 /* BTPayPalVaultRequest.swift in Sources */,
+				454722AC2CEFB291000DCF4E /* BTContactInformation.swift in Sources */,
 				62B811882CC002470024A688 /* BTPayPalPhoneNumber.swift in Sources */,
 				807D22F52C29ADE2009FFEA4 /* BTPayPalRecurringBillingPlanType.swift in Sources */,
 				57544820294A2EBE00DEB7B0 /* BTPayPalCreditFinancing.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreePayPal
   * Add `BTPayPalRequest.userPhoneNumber` optional property
+  * Add `BTContactInformation` request object
+  * Add `BTPayPalCheckoutRequest.contactInformation` optional property
 * BraintreeVenmo
   * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
 

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -150,6 +150,10 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         request.lineItems = [lineItem]
         request.offerPayLater = payLaterToggle.isOn
         request.intent = newPayPalCheckoutToggle.isOn ? .sale : .authorize
+        request.contactInformation = BTContactInformation(
+            recipientEmail: "some@email.com",
+            recipientPhoneNumber: .init(countryCode: "52", nationalNumber: "123456789")
+        )
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true

--- a/Sources/BraintreePayPal/BTContactInformation.swift
+++ b/Sources/BraintreePayPal/BTContactInformation.swift
@@ -11,7 +11,7 @@ public struct BTContactInformation {
     /// Intialize a BTContactInformation
     /// - Parameters:
     ///   - recipientEmail: Optional: Email address of the recipient.
-    ///   - recipientPhoneNumber: Optional:Phone number of the recipient.
+    ///   - recipientPhoneNumber: Optional: Phone number of the recipient.
     public init(recipientEmail: String? = nil, recipientPhoneNumber: BTPayPalPhoneNumber? = nil) {
         self.recipientEmail = recipientEmail
         self.recipientPhoneNumber = recipientPhoneNumber

--- a/Sources/BraintreePayPal/BTContactInformation.swift
+++ b/Sources/BraintreePayPal/BTContactInformation.swift
@@ -1,8 +1,14 @@
 /// Contact information of the recipient for the order
-struct BTContactInformation {
-    
+public struct BTContactInformation {
+
     /// Email address of the recipient
     let recipientEmail: String?
     
+    /// Phone number of the recipient
     let recipientPhoneNumber: BTPayPalPhoneNumber?
+
+    public init(recipientEmail: String? = nil, recipientPhoneNumber: BTPayPalPhoneNumber? = nil) {
+        self.recipientEmail = recipientEmail
+        self.recipientPhoneNumber = recipientPhoneNumber
+    }
 }

--- a/Sources/BraintreePayPal/BTContactInformation.swift
+++ b/Sources/BraintreePayPal/BTContactInformation.swift
@@ -1,0 +1,8 @@
+/// Contact information of the recipient for the order
+struct BTContactInformation {
+    
+    /// Email address of the recipient
+    let recipientEmail: String?
+    
+    let recipientPhoneNumber: BTPayPalPhoneNumber?
+}

--- a/Sources/BraintreePayPal/BTContactInformation.swift
+++ b/Sources/BraintreePayPal/BTContactInformation.swift
@@ -1,12 +1,17 @@
 /// Contact information of the recipient for the order
 public struct BTContactInformation {
 
-    /// Email address of the recipient
-    let recipientEmail: String?
+    // MARK: - Internal Properties
     
-    /// Phone number of the recipient
+    let recipientEmail: String?
     let recipientPhoneNumber: BTPayPalPhoneNumber?
+    
+    // MARK: - Initializer
 
+    /// Intialize a BTContactInformation
+    /// - Parameters:
+    ///   - recipientEmail: Optional: Email address of the recipient.
+    ///   - recipientPhoneNumber: Optional:Phone number of the recipient.
     public init(recipientEmail: String? = nil, recipientPhoneNumber: BTPayPalPhoneNumber? = nil) {
         self.recipientEmail = recipientEmail
         self.recipientPhoneNumber = recipientPhoneNumber

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -84,6 +84,9 @@ import BraintreeCore
     
     /// Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     public var userAuthenticationEmail: String?
+    
+    /// Optional: Contact information of the recipient for the order
+    public var contactInformation: BTContactInformation?
 
     // MARK: - Initializer
 
@@ -164,7 +167,15 @@ import BraintreeCore
             checkoutParameters["country_code"] = shippingAddressOverride?.countryCodeAlpha2
             checkoutParameters["recipient_name"] = shippingAddressOverride?.recipientName
         }
-
+        
+        if let recipientEmail = contactInformation?.recipientEmail {
+            checkoutParameters["recipient_email"] = recipientEmail
+        }
+        
+        if let recipientPhoneNumber = try? contactInformation?.recipientPhoneNumber?.toDictionary() {
+            checkoutParameters["international_phone"] = recipientPhoneNumber
+        }
+        
         return baseParameters.merging(checkoutParameters) { $1 }
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -191,7 +191,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(internationalPhone, ["country_code": "US", "national_number": "123456789"])
     }
     
-    func testParametersWithConfiguration_whenContactInformationNotSet_doesNotSetPayerEmailInRequest() {
+    func testParametersWithConfiguration_whenContactInformationNotSet_doesNotSetPayerEmailAndPhoneNumberInRequest() {
         let request = BTPayPalCheckoutRequest(amount: "1")
         
         let parameters = request.parameters(with: configuration)

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -176,4 +176,27 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         
         XCTAssertNil(parameters["payer_email"])
     }
+    
+    func testParametersWithConfiguration__withContactInformation_setsRecipientEmailAndPhoneNumber() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.contactInformation = BTContactInformation(
+            recipientEmail: "some@mail.com",
+            recipientPhoneNumber: BTPayPalPhoneNumber(countryCode: "US", nationalNumber: "123456789")
+        )
+        
+        let parameters = request.parameters(with: configuration)
+        
+        XCTAssertEqual(parameters["recipient_email"] as? String, "some@mail.com")
+        let internationalPhone = parameters["international_phone"] as? [String: String]
+        XCTAssertEqual(internationalPhone, ["country_code": "US", "national_number": "123456789"])
+    }
+    
+    func testParametersWithConfiguration_whenContactInformationNotSet_doesNotSetPayerEmailInRequest() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        
+        let parameters = request.parameters(with: configuration)
+        
+        XCTAssertNil(parameters["recipient_email"])
+        XCTAssertNil(parameters["international_phone"])
+    }
 }


### PR DESCRIPTION
### Summary of changes

Introduces support for passing recipient contact information in the `BTPayPalCheckoutRequest`
- A new class `BTContactInformation` was created to encapsulate the recipient's contact information for the order.
   Properties: `recipientEmail` and`recipientPhoneNumber`
- Updated BTPayPalCheckoutRequest: Added a new optional property `contactInformation` of type `BTContactInformation`.
- The `contactInformation.recipientEmail` and `contactInformation.recipientPhoneNumber` are passed to the `create_payment_resource` endpoint as the `recipient_email`  and `international_phone` parameters when present.

**Note:** When the new parameters (recipient_email and international_phone) are included, the gateway returns an error. I will follow up with updates once I gather more information or implement any necessary fixes.

### Checklist

- [x] Added a changelog entry
- [ ] **Pending:** Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
