### PR TITLE
Bug Fix - Update `deviceIdentifier` to Save to Keychain

### DIFF
--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -147,15 +147,14 @@ import BraintreeCore
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         if status == errSecSuccess,
-            let existingItem = item as? [String: Any],
-            let data = existingItem[kSecValueData as String] as? Data,
-            let identifier = String(data: data, encoding: String.Encoding.utf8) {
+            let data = item as? Data,
+            let identifier = String(data: data, encoding: .utf8) {
             return identifier
         }
 
         // If not, generate a new one and save it
         let newIdentifier = UUID().uuidString
-        query[kSecValueData as String] = newIdentifier
+        query[kSecValueData as String] = newIdentifier.data(using: .utf8)
         query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         SecItemAdd(query as CFDictionary, nil)
         return newIdentifier


### PR DESCRIPTION
### Summary of changes

Some recent conversations around our data collector had me investigating our comment "See if we already have an identifier in the keychain". As it turns out we were never actually saving the device identifier to the keychain and it seems like this logic has never worked as expected. 

Updating main to do the following: `let addStatus = SecItemAdd(query as CFDictionary, nil)` gave me the result `-50` for the `OSStatus`. This status means `errSecParam` - "one of the parameters you passed in a function was/are not valid". Digging into this a bit further in the [Apple Docs for ksecvaluedata](https://developer.apple.com/documentation/security/ksecvaluedata) indicate that this should be passed as a `Data` object. 

Updating this to now pass in data as well as our parsing logic to parse the data object as expected is now hitting the breakpoint in our keychain check. 🥳 

#### Testing
To test, you will need to use a real device for keychain access, this cannot be tested on simulator.

1. On `main` add a breakpoint on line 153 and 161
2. In the Data Collector integration, hit "Collect Device Data"
3. The first time should always hit line 161, but you should notice that subsequent attempts do not hit line 153 ever as expected
4. Switch to this branch and run the same test but with breakpoints on line 152 and 160
5. You should now see after the initial fetch you are hitting line 152 once the identifier is stored in the keychain

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
