### PR TITLE
V7 app switch url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
     * Update `BTThreeDSecureRequest.amount` to be a `String`
   * BraintreeCore
     * Remove `fetchPaymentMethodNonces` methods and parser
+  * BraintreePayPal
+    * Update PayPal app URL query scheme from `paypal-app-switch-checkout` to `paypal`
 
 ## unreleased
 * BraintreePayPal

--- a/Demo/Application/Supporting Files/Braintree-Demo-Info.plist
+++ b/Demo/Application/Supporting Files/Braintree-Demo-Info.plist
@@ -61,7 +61,7 @@
 	<array>
 		<string>com.braintreepayments.Demo.payments</string>
 		<string>com.venmo.touch.v2</string>
-		<string>paypal-app-switch-checkout</string>
+		<string>paypal</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/Sources/BraintreeCore/BTCoreConstants.swift
+++ b/Sources/BraintreeCore/BTCoreConstants.swift
@@ -14,7 +14,7 @@ import Foundation
     public static let venmoURLScheme: String = "com.venmo.touch.v2"
 
     /// URL Scheme for PayPal App
-    public static let payPalURLScheme: String = "paypal-app-switch-checkout"
+    public static let payPalURLScheme: String = "paypal"
 
     static let apiVersion: String = "2016-10-07"
     

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -12,6 +12,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [SEPA Direct Debit](#sepa-direct-debit)
 1. [Local Payments](#local-payments)
 1. [3D Secure](#3d-secure)]
+1. [PayPal](#paypal)
 1. [PayPal Native Checkout](#paypal-native-checkout)
 
 
@@ -39,6 +40,19 @@ v7 updates `BTLocalPaymentRequest` to require setting all properties through the
 
 ## 3D Secure
 All properties within `BTThreeDSecureRequest` can only be accessed on the initializer vs via the dot syntax.
+
+## PayPal
+
+### App Switch
+For the App Switch flow, you must update your `info.plist` with a simplified URL query scheme name, `paypal`.
+
+```diff
+<key>LSApplicationQueriesSchemes</key>
+<array>
+-  <string>paypal-app-switch-checkout</string>
++  <string>paypal</string>
+</array>
+```
 
 ## PayPal Native Checkout
 The PayPal Native Checkout integration is no longer supported. Please remove it from your app and 


### PR DESCRIPTION
### Summary of changes

- Update the PayPal App URL query scheme from `paypal-app-switch-checkout` to `paypal` 
    - See DTMOBILES-1286 for more detail.

### Checklist

- [X] Added a changelog entry
- [X] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@scannillo 
