### PR TITLE
Add URL to PayPal App Switch Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreePayPal
   * Add `BTPayPalRequest.userPhoneNumber` optional property
+  * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
 * BraintreeVenmo
   * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
 

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -284,6 +284,29 @@ import BraintreeDataCollector
         performSwitchRequest(appSwitchURL: url, paymentType: paymentType, completion: completion)
     }
 
+    func invokedOpenURLSuccessfully(_ success: Bool, url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
+        if success {
+            apiClient.sendAnalyticsEvent(
+                BTPayPalAnalytics.appSwitchSucceeded,
+                isVaultRequest: isVaultRequest,
+                linkType: linkType,
+                payPalContextID: payPalContextID,
+                appSwitchURL: url
+            )
+            BTPayPalClient.payPalClient = self
+            appSwitchCompletion = completion
+        } else {
+            apiClient.sendAnalyticsEvent(
+                BTPayPalAnalytics.appSwitchFailed,
+                isVaultRequest: isVaultRequest,
+                linkType: linkType,
+                payPalContextID: payPalContextID,
+                appSwitchURL: url
+            )
+            notifyFailure(with: BTPayPalError.appSwitchFailed, completion: completion)
+        }
+    }
+
     // MARK: - App Switch Methods
 
     func handleReturnURL(_ url: URL) {
@@ -404,28 +427,7 @@ import BraintreeDataCollector
         }
 
         application.open(redirectURL) { success in
-            self.invokedOpenURLSuccessfully(success, completion: completion)
-        }
-    }
-
-    private func invokedOpenURLSuccessfully(_ success: Bool, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
-        if success {
-            apiClient.sendAnalyticsEvent(
-                BTPayPalAnalytics.appSwitchSucceeded,
-                isVaultRequest: isVaultRequest,
-                linkType: linkType,
-                payPalContextID: payPalContextID
-            )
-            BTPayPalClient.payPalClient = self
-            appSwitchCompletion = completion
-        } else {
-            apiClient.sendAnalyticsEvent(
-                BTPayPalAnalytics.appSwitchFailed,
-                isVaultRequest: isVaultRequest,
-                linkType: linkType,
-                payPalContextID: payPalContextID
-            )
-            notifyFailure(with: BTPayPalError.appSwitchFailed, completion: completion)
+            self.invokedOpenURLSuccessfully(success, url: redirectURL, completion: completion)
         }
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -982,6 +982,24 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertNil(lastPostParameters["merchant_app_return_url"] as? String)
     }
 
+    func testInvokedOpenURLSuccessfully_whenSuccess_sendsAppSwitchSucceededWithAppSwitchURL() {
+        let eventName = BTPayPalAnalytics.appSwitchSucceeded
+        let appSwitchURL = URL(string: "some-url")!
+        payPalClient.invokedOpenURLSuccessfully(true, url: appSwitchURL) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, eventName)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
+    }
+
+    func testInvokedOpenURLSuccessfully_whenFailure_sendsAppSwitchFailedWithAppSwitchURL() {
+        let eventName = BTPayPalAnalytics.appSwitchFailed
+        let appSwitchURL = URL(string: "some-url")!
+        payPalClient.invokedOpenURLSuccessfully(false, url: appSwitchURL) { _, _ in }
+
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first!, eventName)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
+    }
+
     // MARK: - Analytics
 
     func testAPIClientMetadata_hasIntegrationSetToCustom() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -984,20 +984,20 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testInvokedOpenURLSuccessfully_whenSuccess_sendsAppSwitchSucceededWithAppSwitchURL() {
         let eventName = BTPayPalAnalytics.appSwitchSucceeded
-        let appSwitchURL = URL(string: "some-url")!
-        payPalClient.invokedOpenURLSuccessfully(true, url: appSwitchURL) { _, _ in }
+        let fakeURL = URL(string: "some-url")!
+        payPalClient.invokedOpenURLSuccessfully(true, url: fakeURL) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, eventName)
-        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], fakeURL.absoluteString)
     }
 
     func testInvokedOpenURLSuccessfully_whenFailure_sendsAppSwitchFailedWithAppSwitchURL() {
         let eventName = BTPayPalAnalytics.appSwitchFailed
-        let appSwitchURL = URL(string: "some-url")!
-        payPalClient.invokedOpenURLSuccessfully(false, url: appSwitchURL) { _, _ in }
+        let fakeURL = URL(string: "some-url")!
+        payPalClient.invokedOpenURLSuccessfully(false, url: fakeURL) { _, _ in }
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first!, eventName)
-        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], appSwitchURL.absoluteString)
+        XCTAssertEqual(mockAPIClient.postedAppSwitchURL[eventName], fakeURL.absoluteString)
     }
 
     // MARK: - Analytics


### PR DESCRIPTION
### Summary of changes

- Add `url` to `appSwitchSucceeded` and `appSwitchFailed` events
- Add unit tests

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
