### PR TITLE
Add `BTThreeDSecureRequest.requestorAppURL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * BraintreeCore
   * Deprecate `BTAppContextSwitcher.sharedInstance.returnURLScheme`
 * BraintreeThreeDSecure
-  * Add `BTThreeDSecureRequest.threeDSRequestorAppURL`
+  * Add `BTThreeDSecureRequest.requestorAppURL`
 
 ## 6.24.0 (2024-10-15)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * Add `BTVenmoClient(apiClient:universalLink:)` to use Universal Links when redirecting back from the Venmo flow
 * BraintreeCore
   * Deprecate `BTAppContextSwitcher.sharedInstance.returnURLScheme`
+* BraintreeThreeDSecure
+  * Add `BTThreeDSecureRequest.threeDSRequestorAppURL`
 
 ## 6.24.0 (2024-10-15)
 * BraintreePayPal

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -93,6 +93,10 @@ import BraintreeCore
     /// When using `BTThreeDSecureUIType.native`, all `BTThreeDSecureRenderType` options except `.html` must be set.
     public var renderTypes: [BTThreeDSecureRenderType]?
 
+    /// Optional. Three DS Requester APP URL Merchant app declaring their URL within the CReq message
+    /// so that the Authentication app can call the Merchant app after OOB authentication has occurred. 
+    public var threeDSRequestorAppURL: String?
+
     /// A delegate for receiving information about the ThreeDSecure payment flow.
     public weak var threeDSecureRequestDelegate: BTThreeDSecureRequestDelegate?
     

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -94,7 +94,7 @@ import BraintreeCore
     public var renderTypes: [BTThreeDSecureRenderType]?
 
     /// Optional. Three DS Requester APP URL Merchant app declaring their URL within the CReq message
-    /// so that the Authentication app can call the Merchant app after OOB authentication has occurred. 
+    /// so that the Authentication app can call the Merchant app after out of band authentication has occurred. 
     public var requestorAppURL: String?
 
     /// A delegate for receiving information about the ThreeDSecure payment flow.

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureRequest.swift
@@ -95,7 +95,7 @@ import BraintreeCore
 
     /// Optional. Three DS Requester APP URL Merchant app declaring their URL within the CReq message
     /// so that the Authentication app can call the Merchant app after OOB authentication has occurred. 
-    public var threeDSRequestorAppURL: String?
+    public var requestorAppURL: String?
 
     /// A delegate for receiving information about the ThreeDSecure payment flow.
     public weak var threeDSecureRequestDelegate: BTThreeDSecureRequestDelegate?

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
@@ -45,8 +45,8 @@ class BTThreeDSecureV2Provider {
             cardinalConfiguration.renderType = renderTypes.compactMap { $0.cardinalValue }
         }
 
-        if let threeDSRequestorAppURL = request.threeDSRequestorAppURL {
-            cardinalConfiguration.threeDSRequestorAppURL = threeDSRequestorAppURL
+        if let requestorAppURL = request.requestorAppURL {
+            cardinalConfiguration.threeDSRequestorAppURL = requestorAppURL
         }
 
         guard let cardinalAuthenticationJWT = configuration.cardinalAuthenticationJWT else {

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureV2Provider.swift
@@ -45,6 +45,10 @@ class BTThreeDSecureV2Provider {
             cardinalConfiguration.renderType = renderTypes.compactMap { $0.cardinalValue }
         }
 
+        if let threeDSRequestorAppURL = request.threeDSRequestorAppURL {
+            cardinalConfiguration.threeDSRequestorAppURL = threeDSRequestorAppURL
+        }
+
         guard let cardinalAuthenticationJWT = configuration.cardinalAuthenticationJWT else {
             completion(nil)
             return


### PR DESCRIPTION
### Summary of changes

- Add `BTThreeDSecureRequest.requestorAppURL` - this is a new property required by Mastercard for 3DS for out of band transactions. There was an internal request from a large merchant for exposing this field.
- There is currently not a good way to test values set on `cardinalConfiguration` so those are not included. I did test setting this value locally to ensure this value is being set on `cardinalConfiguration` when passed.

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
