### PR TITLE
If a shopperSessionID exists, override the value with the one retriev…

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -312,7 +312,12 @@ import BraintreeDataCollector
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? .universal : .deeplink
-
+        
+        // The shopper insights server SDK integration
+        if let shopperID = request.shopperSessionID {
+            apiClient.metadata.sessionID = shopperID
+        }
+        
         apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeStarted, isVaultRequest: isVaultRequest, linkType: linkType)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1030,6 +1030,8 @@ class BTPayPalClient_Tests: XCTestCase {
     }
     
     func testTokenize_whenCheckoutRequest_setSessionID() async {
+        XCTAssertNotEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
+        
         let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
         checkoutRequest.shopperSessionID = "test-shopper-insights-id"
         let _ = try? await payPalClient.tokenize(checkoutRequest)
@@ -1038,6 +1040,8 @@ class BTPayPalClient_Tests: XCTestCase {
     }
     
     func testTokenize_whenVaultRequest_setSessionID() async {
+        XCTAssertNotEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
+        
         let checkoutRequest = BTPayPalVaultRequest()
         checkoutRequest.shopperSessionID = "test-shopper-insights-id"
         let _ = try? await payPalClient.tokenize(checkoutRequest)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1028,4 +1028,20 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
+    
+    func testTokenize_whenCheckoutRequest_setSessionID() async {
+        let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
+        checkoutRequest.shopperSessionID = "test-shopper-insights-id"
+        let _ = try? await payPalClient.tokenize(checkoutRequest)
+
+        XCTAssertEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
+    }
+    
+    func testTokenize_whenVaultRequest_setSessionID() async {
+        let checkoutRequest = BTPayPalVaultRequest()
+        checkoutRequest.shopperSessionID = "test-shopper-insights-id"
+        let _ = try? await payPalClient.tokenize(checkoutRequest)
+
+        XCTAssertEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
+    }
 }


### PR DESCRIPTION
### Summary of changes
 Override the apiClient metadata.sessionID if the shopper session Id exists.
 
### Checklist
- [x] Shows up in FPTI
<img width="907" alt="Screenshot 2024-12-09 at 1 19 41 PM" src="https://github.com/user-attachments/assets/b958ad83-f5cd-45ba-b095-9abda73b1209">

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@stechiu 
@jwarmkessel 
@warmkesselj 

- 
