### PR TITLE
ShopperInsights - send `shopper_session_id` to FPTI

### DIFF
--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -56,6 +56,7 @@ struct FPTIBatchData: Codable {
 
         /// UTC millisecond timestamp when a networking task started requesting a resource. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         let requestStartTime: Int?
+        /// The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
         let shopperSessionID: String?
         /// UTC millisecond timestamp when a networking task initiated.
         let startTime: Int?

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -56,6 +56,7 @@ struct FPTIBatchData: Codable {
 
         /// UTC millisecond timestamp when a networking task started requesting a resource. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         let requestStartTime: Int?
+        let shopperSessionID: String?
         /// UTC millisecond timestamp when a networking task initiated.
         let startTime: Int?
         let timestamp = String(Date().utcTimestampMilliseconds)
@@ -76,6 +77,7 @@ struct FPTIBatchData: Codable {
             paymentMethodsDisplayed: String? = nil,
             payPalContextID: String? = nil,
             requestStartTime: Int? = nil,
+            shopperSessionID: String? = nil,
             startTime: Int? = nil
         ) {
             self.appSwitchURL = appSwitchURL?.absoluteString
@@ -92,6 +94,7 @@ struct FPTIBatchData: Codable {
             self.paymentMethodsDisplayed = paymentMethodsDisplayed
             self.payPalContextID = payPalContextID
             self.requestStartTime = requestStartTime
+            self.shopperSessionID = shopperSessionID
             self.startTime = startTime
         }
 
@@ -110,6 +113,7 @@ struct FPTIBatchData: Codable {
             case requestStartTime = "request_start_time"
             case timestamp = "t"
             case tenantName = "tenant_name"
+            case shopperSessionID = "shopper_session_id"
             case startTime = "start_time"
             case endTime = "end_time"
             case endpoint = "endpoint"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -311,7 +311,8 @@ import Foundation
         linkType: LinkType? = nil,
         paymentMethodsDisplayed: String? = nil,
         payPalContextID: String? = nil,
-        appSwitchURL: URL? = nil
+        appSwitchURL: URL? = nil,
+        shopperSessionID: String? = nil
     ) {
         analyticsService.sendAnalyticsEvent(
             FPTIBatchData.Event(
@@ -324,7 +325,8 @@ import Foundation
                 linkType: linkType?.rawValue,
                 merchantExperiment: merchantExperiment,
                 paymentMethodsDisplayed: paymentMethodsDisplayed,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                shopperSessionID: shopperSessionID
             )
         )
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -40,6 +40,9 @@ import BraintreeDataCollector
 
     /// True if `tokenize()` was called with a Vault request object type
     var isVaultRequest: Bool = false
+    
+    /// Exposed for analytics.
+    var shopperSessionID: String? = nil
 
     // MARK: - Static Properties
 
@@ -196,7 +199,8 @@ import BraintreeDataCollector
             correlationID: clientMetadataID,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
         )
 
         guard let url, BTPayPalReturnURL.isValidURLAction(url: url, linkType: linkType) else {
@@ -312,8 +316,14 @@ import BraintreeDataCollector
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? .universal : .deeplink
+        self.payPalRequest = request
 
-        apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeStarted, isVaultRequest: isVaultRequest, linkType: linkType)
+        apiClient.sendAnalyticsEvent(
+            BTPayPalAnalytics.tokenizeStarted,
+            isVaultRequest: isVaultRequest,
+            linkType: linkType,
+            shopperSessionID: payPalRequest?.shopperSessionID
+        )
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
                 self.notifyFailure(with: error, completion: completion)
@@ -332,7 +342,6 @@ import BraintreeDataCollector
                 return
             }
 
-            self.payPalRequest = request
             self.apiClient.post(
                 request.hermesPath,
                 parameters: request.parameters(
@@ -388,7 +397,8 @@ import BraintreeDataCollector
             BTPayPalAnalytics.appSwitchStarted,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
         )
 
         var urlComponents = URLComponents(url: payPalAppRedirectURL, resolvingAgainstBaseURL: true)
@@ -414,7 +424,8 @@ import BraintreeDataCollector
                 BTPayPalAnalytics.appSwitchSucceeded,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                shopperSessionID: payPalRequest?.shopperSessionID
             )
             BTPayPalClient.payPalClient = self
             appSwitchCompletion = completion
@@ -423,7 +434,8 @@ import BraintreeDataCollector
                 BTPayPalAnalytics.appSwitchFailed,
                 isVaultRequest: isVaultRequest,
                 linkType: linkType,
-                payPalContextID: payPalContextID
+                payPalContextID: payPalContextID,
+                shopperSessionID: payPalRequest?.shopperSessionID
             )
             notifyFailure(with: BTPayPalError.appSwitchFailed, completion: completion)
         }
@@ -471,14 +483,16 @@ import BraintreeDataCollector
                     isConfigFromCache: isConfigFromCache,
                     isVaultRequest: isVaultRequest,
                     linkType: linkType,
-                    payPalContextID: payPalContextID
+                    payPalContextID: payPalContextID,
+                    shopperSessionID: payPalRequest?.shopperSessionID
                 )
             } else {
                 apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationFailed,
                     isVaultRequest: isVaultRequest,
                     linkType: linkType,
-                    payPalContextID: payPalContextID
+                    payPalContextID: payPalContextID,
+                    shopperSessionID: payPalRequest?.shopperSessionID
                 )
             }
         } sessionDidCancel: { [self] in
@@ -510,7 +524,8 @@ import BraintreeDataCollector
             correlationID: clientMetadataID,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
         )
         completion(result, nil)
     }
@@ -522,7 +537,8 @@ import BraintreeDataCollector
             errorDescription: error.localizedDescription,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
         )
         completion(nil, error)
     }
@@ -533,7 +549,8 @@ import BraintreeDataCollector
             correlationID: clientMetadataID,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
         )
         completion(nil, BTPayPalError.canceled)
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -66,7 +66,7 @@ import BraintreeDataCollector
     private var linkType: LinkType?
     
     /// Use for analytics purposes. The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
-    private var shopperSessionID: String? = nil
+    private var shopperSessionID: String?
 
     // MARK: - Initializer
 
@@ -189,6 +189,7 @@ import BraintreeDataCollector
 
     // MARK: - Internal Methods
     
+    // swiftlint:disable function_body_length
     func handleReturn(
         _ url: URL?,
         paymentType: BTPayPalPaymentType,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -40,9 +40,6 @@ import BraintreeDataCollector
 
     /// True if `tokenize()` was called with a Vault request object type
     var isVaultRequest: Bool = false
-    
-    /// Exposed for analytics.
-    var shopperSessionID: String? = nil
 
     // MARK: - Static Properties
 
@@ -67,6 +64,9 @@ import BraintreeDataCollector
 
     /// Used for sending the type of flow, universal vs deeplink to FPTI
     private var linkType: LinkType?
+    
+    /// Use for analytics purposes. The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
+    private var shopperSessionID: String? = nil
 
     // MARK: - Initializer
 

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -312,12 +312,7 @@ import BraintreeDataCollector
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? .universal : .deeplink
-        
-        // The shopper insights server SDK integration
-        if let shopperID = request.shopperSessionID {
-            apiClient.metadata.sessionID = shopperID
-        }
-        
+
         apiClient.sendAnalyticsEvent(BTPayPalAnalytics.tokenizeStarted, isVaultRequest: isVaultRequest, linkType: linkType)
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -64,9 +64,6 @@ import BraintreeDataCollector
 
     /// Used for sending the type of flow, universal vs deeplink to FPTI
     private var linkType: LinkType?
-    
-    /// Use for analytics purposes. The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
-    private var shopperSessionID: String?
 
     // MARK: - Initializer
 

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -27,10 +27,6 @@ public class BTShopperInsightsClient {
     public init(apiClient: BTAPIClient, shopperSessionID: String? = nil) {
         self.apiClient = apiClient
         self.shopperSessionID = shopperSessionID
-
-        if let shopperSessionID {
-            apiClient.metadata.sessionID = shopperSessionID
-        }
     }
     
     // MARK: - Public Methods
@@ -49,7 +45,8 @@ public class BTShopperInsightsClient {
     ) async throws -> BTShopperInsightsResult {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsStarted,
-            merchantExperiment: experiment
+            merchantExperiment: experiment,
+            shopperSessionID: shopperSessionID
         )
 
         if apiClient.authorization.type != .clientToken {
@@ -102,14 +99,15 @@ public class BTShopperInsightsClient {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.payPalPresented,
             merchantExperiment: experiment,
-            paymentMethodsDisplayed: paymentMethodsDisplayedString
+            paymentMethodsDisplayed: paymentMethodsDisplayedString,
+            shopperSessionID: shopperSessionID
         )
     }
     
     /// Call this method when the PayPal button has been selected/tapped by the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience
     public func sendPayPalSelectedEvent() {
-        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.payPalSelected)
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.payPalSelected, shopperSessionID: shopperSessionID)
     }
     
     /// Call this method when the Venmo button has been successfully displayed to the buyer.
@@ -122,14 +120,15 @@ public class BTShopperInsightsClient {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.venmoPresented,
             merchantExperiment: experiment,
-            paymentMethodsDisplayed: paymentMethodsDisplayedString
+            paymentMethodsDisplayed: paymentMethodsDisplayedString,
+            shopperSessionID: shopperSessionID
         )
     }
     
     /// Call this method when the Venmo button has been selected/tapped by the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience
     public func sendVenmoSelectedEvent() {
-        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.venmoSelected)
+        apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.venmoSelected, shopperSessionID: shopperSessionID)
     }
 
     /// Indicates whether the PayPal App is installed.
@@ -149,7 +148,8 @@ public class BTShopperInsightsClient {
     private func notifySuccess(with result: BTShopperInsightsResult, for experiment: String?) -> BTShopperInsightsResult {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsSucceeded,
-            merchantExperiment: experiment
+            merchantExperiment: experiment,
+            shopperSessionID: shopperSessionID
         )
         return result
     }
@@ -158,7 +158,8 @@ public class BTShopperInsightsClient {
         apiClient.sendAnalyticsEvent(
             BTShopperInsightsAnalytics.recommendedPaymentsFailed,
             errorDescription: error.localizedDescription,
-            merchantExperiment: experiment
+            merchantExperiment: experiment,
+            shopperSessionID: shopperSessionID
         )
         return error
     }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1028,24 +1028,4 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
-    
-    func testTokenize_whenCheckoutRequest_setSessionID() async {
-        XCTAssertNotEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
-        
-        let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
-        checkoutRequest.shopperSessionID = "test-shopper-insights-id"
-        let _ = try? await payPalClient.tokenize(checkoutRequest)
-
-        XCTAssertEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
-    }
-    
-    func testTokenize_whenVaultRequest_setSessionID() async {
-        XCTAssertNotEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
-        
-        let checkoutRequest = BTPayPalVaultRequest()
-        checkoutRequest.shopperSessionID = "test-shopper-insights-id"
-        let _ = try? await payPalClient.tokenize(checkoutRequest)
-
-        XCTAssertEqual(mockAPIClient.metadata.sessionID, "test-shopper-insights-id")
-    }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1028,4 +1028,13 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
     }
+    
+    func testTokenize_whenShopperSessionIDSetOnRequest_includesInAnalytics() async {
+        let checkoutRequest = BTPayPalCheckoutRequest(amount: "2.00")
+        checkoutRequest.shopperSessionID = "fake-shopper-session-id"
+        
+        let _ = try? await payPalClient.tokenize(checkoutRequest)
+
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClient_Tests.swift
@@ -32,7 +32,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockAPIClient = MockAPIClient(authorization: clientToken)
-        sut = BTShopperInsightsClient(apiClient: mockAPIClient!)
+        sut = BTShopperInsightsClient(apiClient: mockAPIClient!, shopperSessionID: "fake-shopper-session-id")
     }
     
     // MARK: - getRecommendedPaymentMethods()
@@ -78,6 +78,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertEqual(error.domain, "fake-error-domain")
             
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:failed")
+            XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
         }
     }
     
@@ -101,6 +102,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertTrue(result.isVenmoRecommended)
             XCTAssertFalse(result.isPayPalRecommended)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
         } catch let error as NSError {
             XCTFail("An error was not expected.")
         }
@@ -127,6 +129,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertTrue(result.isEligibleInPayPalNetwork)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
             XCTAssertEqual(mockAPIClient.postedMerchantExperiment, sampleExperiment)
+            XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -152,6 +155,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertTrue(result.isVenmoRecommended)
             XCTAssertTrue(result.isEligibleInPayPalNetwork)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -181,6 +185,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
             XCTAssertFalse(result.isVenmoRecommended)
             XCTAssertFalse(result.isEligibleInPayPalNetwork)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:get-recommended-payments:succeeded")
+            XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
         } catch {
             XCTFail("An error was not expected.")
         }
@@ -204,6 +209,7 @@ class BTShopperInsightsClient_Tests: XCTestCase {
     func testSendPayPalPresentedEvent_sendsAnalytic() {
         sut.sendPayPalPresentedEvent()
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
     }
     
     func testSendPayPalPresentedEvent_whenPaymentMethodsDisplayedNotNil_sendsAnalytic() {
@@ -211,26 +217,25 @@ class BTShopperInsightsClient_Tests: XCTestCase {
         sut.sendPayPalPresentedEvent(paymentMethodsDisplayed: paymentMethods)
         XCTAssertEqual(mockAPIClient.postedPaymentMethodsDisplayed, paymentMethods.joined(separator: ", "))
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-presented")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
     }
     
     func testSendPayPalSelectedEvent_sendsAnalytic() {
         sut.sendPayPalSelectedEvent()
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:paypal-selected")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
     }
     
     func testSendVenmoPresentedEvent_sendsAnalytic() {
         sut.sendVenmoPresentedEvent()
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-presented")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
     }
     
     func testSendVenmoSelectedEvent_sendsAnalytic() {
         sut.sendVenmoSelectedEvent()
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.first, "shopper-insights:venmo-selected")
-    }
-
-    func testShopperInsightsClient_withSessionID_setSessionIDInMetadata() {
-        sut = BTShopperInsightsClient(apiClient: mockAPIClient, shopperSessionID: "123456")
-        XCTAssertEqual(mockAPIClient.metadata.sessionID, "123456")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, "fake-shopper-session-id")
     }
 
     // MARK: - App Installed Methods

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -18,7 +18,8 @@ public class MockAPIClient: BTAPIClient {
     public var postedMerchantExperiment: String? = nil
     public var postedPaymentMethodsDisplayed: String? = nil
     public var postedAppSwitchURL: [String: String?] = [:]
-
+    public var postedShopperSessionID: String? = nil
+    
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
 
@@ -101,7 +102,8 @@ public class MockAPIClient: BTAPIClient {
         linkType: LinkType? = nil,
         paymentMethodsDisplayed: String? = nil,
         payPalContextID: String? = nil,
-        appSwitchURL: URL? = nil
+        appSwitchURL: URL? = nil,
+        shopperSessionID: String? = nil
     ) {
         postedPayPalContextID = payPalContextID
         postedLinkType = linkType
@@ -110,6 +112,7 @@ public class MockAPIClient: BTAPIClient {
         postedPaymentMethodsDisplayed = paymentMethodsDisplayed
         postedAppSwitchURL[name] = appSwitchURL?.absoluteString
         postedAnalyticsEvents.append(name)
+        postedShopperSessionID = shopperSessionID
     }
 
     func didFetchPaymentMethods(sorted: Bool) -> Bool {


### PR DESCRIPTION
### Summary 

- This PR addresses some previous confusion around requirements for how to log the `shopperSessionID`

### Changes
- Send a new FPTI param with the tag `shopper_session_id`
    - Send this anywhere a shopperSessionID is accessible (in the PayPalClient & ShopperInsightsClient)
- Revert change to of overriding the SDK sessionID with the shopperSessionID
    - Keeps `/v2/payments/find-eligible-methods` API call as it was prior
    - Note: This API call will be swapped in the future to one that actually requires a shopperSessionID. Will get tackled in RP3. This is when we can require the shopperSessionID at the init level.

This feature has been a bit confusing, so please let me know if there are questions!

### Checklist
- ~Added a changelog entry~
- ~Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors
@scannillo 
