### PR TITLE
[v7] Update Venmo to Support Only Universal Links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * BraintreeVenmo
     * Update `BTVenmoRequest` to make all properties accessible on the initializer only vs via the dot syntax.
     * Remove `fallbacktoWeb` property from `BTVenmoRequest`. All Venmo flows will now use universal links to switch to the Venmo app or fallback to the web flow if the Venmo app is not installed
+    * Remove `BTAppContextSwitcher.sharedInstance.returnURLScheme`
+    * `BTVenmoClient` initializer now requires a `universalLink` for switching to and from the Venmo app or web fallback flow
   * BraintreeSEPADirectDebit
     * Update `BTSEPADirectDebitRequest` to make all properties accessible on the initializer only vs via the dot syntax.
   * BraintreeLocalPayment

--- a/Demo/Application/Base/AppDelegate.swift
+++ b/Demo/Application/Base/AppDelegate.swift
@@ -3,7 +3,6 @@ import BraintreeCore
 
 @UIApplicationMain class AppDelegate: UIResponder, UIApplicationDelegate {
         
-    private let returnURLScheme = "com.braintreepayments.Demo.payments"
     private let processInfoArgs = ProcessInfo.processInfo.arguments
     private let userDefaults = UserDefaults.standard
     
@@ -13,7 +12,6 @@ import BraintreeCore
     ) -> Bool {
         registerDefaultsFromSettings()
         persistDemoSettings()
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = returnURLScheme
 
         userDefaults.setValue(true, forKey: "magnes.debug.mode")
         

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -51,4 +51,20 @@ class PaymentButtonBaseViewController: BaseViewController {
         button.addTarget(self, action: action, for: .touchUpInside)
         return button
     }
+
+    // MARK: - Helpers
+
+    func buttonsStackView(label: String, views: [UIView]) -> UIStackView {
+        let titleLabel = UILabel()
+        titleLabel.text = label
+
+        let buttonsStackView = UIStackView(arrangedSubviews: [titleLabel] + views)
+        buttonsStackView.axis = .vertical
+        buttonsStackView.distribution = .fillProportionally
+        buttonsStackView.backgroundColor = .systemGray6
+        buttonsStackView.layoutMargins = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+        buttonsStackView.isLayoutMarginsRelativeArrangement = true
+
+        return buttonsStackView
+    }
 }

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -250,20 +250,4 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             self.completionBlock(nonce)
         }
     }
-    
-    // MARK: - Helpers
-    
-    private func buttonsStackView(label: String, views: [UIView]) -> UIStackView {
-        let titleLabel = UILabel()
-        titleLabel.text = label
-        
-        let buttonsStackView = UIStackView(arrangedSubviews: [titleLabel] + views)
-        buttonsStackView.axis = .vertical
-        buttonsStackView.distribution = .fillProportionally
-        buttonsStackView.backgroundColor = .systemGray6
-        buttonsStackView.layoutMargins = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
-        buttonsStackView.isLayoutMarginsRelativeArrangement = true
-        
-        return buttonsStackView
-    }
 }

--- a/Demo/Application/Features/ShopperInsightsViewController.swift
+++ b/Demo/Application/Features/ShopperInsightsViewController.swift
@@ -8,8 +8,12 @@ class ShopperInsightsViewController: PaymentButtonBaseViewController {
     
     lazy var shopperInsightsClient = BTShopperInsightsClient(apiClient: apiClient)
     lazy var payPalClient = BTPayPalClient(apiClient: apiClient)
-    lazy var venmoClient = BTVenmoClient(apiClient: apiClient)
-    
+    lazy var venmoClient = BTVenmoClient(
+        apiClient: apiClient,
+        // swiftlint:disable:next force_unwrapping
+        universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+    )
+
     lazy var payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(payPalVaultButtonTapped))
     lazy var venmoButton = createButton(title: "Venmo", action: #selector(venmoButtonTapped))
     

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -28,8 +28,6 @@ class VenmoViewController: PaymentButtonBaseViewController {
             venmoButton
         ])
 
-        venmoStackView.axis = .vertical
-        venmoStackView.distribution = .fillProportionally
         venmoStackView.spacing = 12
         venmoStackView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -7,26 +7,33 @@ class VenmoViewController: PaymentButtonBaseViewController {
     var venmoClient: BTVenmoClient!
 
     let vaultToggle = Toggle(title: "Vault")
-    let universalLinkReturnToggle = Toggle(title: "Use Universal Link Return")
 
     override func viewDidLoad() {
         super.heightConstraint = 150
         super.viewDidLoad()
-        venmoClient = BTVenmoClient(apiClient: apiClient)
+        venmoClient = BTVenmoClient(
+            apiClient: apiClient,
+            // swiftlint:disable:next force_unwrapping
+            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+        )
+
         title = "Custom Venmo Button"
     }
     
     override func createPaymentButton() -> UIView {
         let venmoButton = createButton(title: "Venmo", action: #selector(tappedVenmo))
 
-        let stackView = UIStackView(arrangedSubviews: [vaultToggle, universalLinkReturnToggle, venmoButton])
-        stackView.axis = .vertical
-        stackView.spacing = 15
-        stackView.alignment = .fill
-        stackView.distribution = .fillEqually
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let venmoStackView = buttonsStackView(label: "Venmo Payment Flow", views: [
+            vaultToggle,
+            venmoButton
+        ])
 
-        return stackView
+        venmoStackView.axis = .vertical
+        venmoStackView.distribution = .fillProportionally
+        venmoStackView.spacing = 12
+        venmoStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        return venmoStackView
     }
     
     @objc func tappedVenmo() {
@@ -37,14 +44,6 @@ class VenmoViewController: PaymentButtonBaseViewController {
             paymentMethodUsage: .multiUse,
             vault: isVaultingEnabled
         )
-
-        if universalLinkReturnToggle.isOn {
-            venmoClient = BTVenmoClient(
-                apiClient: apiClient,
-                // swiftlint:disable:next force_unwrapping
-                universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
-            )
-        }
 
         Task {
             do {

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -24,7 +24,10 @@ class ViewController: UIViewController {
         let payPalClient = BTPayPalClient(apiClient: apiClient)
         let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
-        let venmoClient = BTVenmoClient(apiClient: apiClient)
+        let venmoClient = BTVenmoClient(
+            apiClient: apiClient,
+            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+        )
         let sepaDirectDebitClient = BTSEPADirectDebitClient(apiClient: apiClient)
     }
 }

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -24,7 +24,10 @@ class ViewController: UIViewController {
         let payPalClient = BTPayPalClient(apiClient: apiClient)
         let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
         let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
-        let venmoClient = BTVenmoClient(apiClient: apiClient)
+        let venmoClient = BTVenmoClient(
+            apiClient: apiClient,
+            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+        )
         let sepaDirectDebitClient = BTSEPADirectDebitClient(apiClient: apiClient)
     }
 }

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -9,27 +9,6 @@ import UIKit
     
     /// Singleton for shared instance of `BTAppContextSwitcher`
     public static let sharedInstance = BTAppContextSwitcher()
-   
-    // NEXT_MAJOR_VERSION: move this property into the feature client request where it is used
-    /// The URL scheme to return to this app after switching to another app or opening a SFSafariViewController.
-    /// This URL scheme must be registered as a URL Type in the app's info.plist, and it must start with the app's bundle ID.
-    /// - Note: This property should only be used for the Venmo flow.
-    @available(
-        *,
-        deprecated,
-        message: "returnURLScheme is deprecated and will be removed in a future version. Use BTVenmoClient(apiClient:universalLink:)."
-    )
-    public var returnURLScheme: String {
-        get { _returnURLScheme }
-        set { _returnURLScheme = newValue }
-    }
-
-    // swiftlint:disable identifier_name
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    /// Property for `returnURLScheme`. Created to avoid deprecation warnings upon accessing
-    /// `returnURLScheme` directly within our SDK. Use this value instead.
-    public var _returnURLScheme: String = ""
-    // swiftlint:enable identifier_name
 
     // MARK: - Private Properties
     

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchRedirectURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchRedirectURL.swift
@@ -6,16 +6,7 @@ import BraintreeCore
 
 struct BTVenmoAppSwitchRedirectURL {
 
-    // MARK: - Internal Properties
-
-    /// The base app switch URL for Venmo. Does not include specific parameters.
-    static var baseAppSwitchURL: URL? {
-        appSwitchBaseURLComponents().url
-    }
-
     // MARK: - Private Properties
-
-    static private let xCallbackTemplate: String = "scheme://x-callback-url/path"
 
     private var queryParameters: [String: Any?] = [:]
 
@@ -24,8 +15,7 @@ struct BTVenmoAppSwitchRedirectURL {
     init(
         paymentContextID: String,
         metadata: BTClientMetadata,
-        returnURLScheme: String?,
-        universalLink: URL?,
+        universalLink: URL,
         forMerchantID merchantID: String?,
         accessToken: String?,
         bundleDisplayName: String?,
@@ -56,15 +46,9 @@ struct BTVenmoAppSwitchRedirectURL {
             "customerClient": "MOBILE_APP"
         ]
 
-        if let universalLink {
-            queryParameters["x-success"] = universalLink.appendingPathComponent("success").absoluteString
-            queryParameters["x-error"] = universalLink.appendingPathComponent("error").absoluteString
-            queryParameters["x-cancel"] = universalLink.appendingPathComponent("cancel").absoluteString
-        } else if let returnURLScheme {
-            queryParameters["x-success"] = constructRedirectURL(with: returnURLScheme, result: "success")
-            queryParameters["x-error"] = constructRedirectURL(with: returnURLScheme, result: "error")
-            queryParameters["x-cancel"] = constructRedirectURL(with: returnURLScheme, result: "cancel")
-        }
+        queryParameters["x-success"] = universalLink.appendingPathComponent("success").absoluteString
+        queryParameters["x-error"] = universalLink.appendingPathComponent("error").absoluteString
+        queryParameters["x-cancel"] = universalLink.appendingPathComponent("cancel").absoluteString
     }
 
     // MARK: - Internal Methods
@@ -81,21 +65,5 @@ struct BTVenmoAppSwitchRedirectURL {
         urlComponent.percentEncodedQuery = BTURLUtils.queryString(from: queryParameters as NSDictionary)
 
         return urlComponent.url
-    }
-
-    // MARK: - Private Helper Methods
-
-    private func constructRedirectURL(with scheme: String, result: String) -> URL? {
-        var components = URLComponents(string: BTVenmoAppSwitchRedirectURL.xCallbackTemplate)
-        components?.scheme = scheme
-        components?.percentEncodedPath = "/vzero/auth/venmo/\(result)"
-        return components?.url
-    }
-
-    private static func appSwitchBaseURLComponents() -> URLComponents {
-        var components: URLComponents = URLComponents(string: xCallbackTemplate) ?? URLComponents()
-        components.scheme = BTCoreConstants.venmoURLScheme
-        components.percentEncodedPath = "/vzero/auth"
-        return components
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchRedirectURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchRedirectURL.swift
@@ -43,12 +43,11 @@ struct BTVenmoAppSwitchRedirectURL {
             "braintree_environment": environment,
             "resource_id": paymentContextID,
             "braintree_sdk_data": base64EncodedBraintreeData ?? "",
-            "customerClient": "MOBILE_APP"
+            "customerClient": "MOBILE_APP",
+            "x-success": universalLink.appendingPathComponent("success").absoluteString,
+            "x-error": universalLink.appendingPathComponent("error").absoluteString,
+            "x-cancel": universalLink.appendingPathComponent("cancel").absoluteString
         ]
-
-        queryParameters["x-success"] = universalLink.appendingPathComponent("success").absoluteString
-        queryParameters["x-error"] = universalLink.appendingPathComponent("error").absoluteString
-        queryParameters["x-cancel"] = universalLink.appendingPathComponent("cancel").absoluteString
     }
 
     // MARK: - Internal Methods

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -69,6 +69,5 @@ struct BTVenmoAppSwitchReturnURL {
     /// - Returns: `true` if the url represents a Venmo Touch app switch return
     static func isValid(url: URL) -> Bool {
         (url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")))
-        || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -56,6 +56,8 @@ import BraintreeCore
     ///   - universalLink: The URL for the Venmo app to redirect to after user authentication completes. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     @objc(initWithAPIClient:universalLink:)
     public init(apiClient: BTAPIClient, universalLink: URL) {
+        BTAppContextSwitcher.sharedInstance.register(BTVenmoClient.self)
+
         self.apiClient = apiClient
         self.universalLink = universalLink
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -29,6 +29,15 @@ import BraintreeCore
     /// Stored property used to determine whether a Venmo account nonce should be vaulted after an app switch return
     var shouldVault: Bool = false
 
+    /// Used for linking events from the client to server side request
+    /// In the Venmo flow this will be the payment context ID
+    private var payPalContextID: String?
+
+    /// Used for sending the type of flow, universal vs deeplink to FPTI
+    private var linkType: LinkType?
+
+    private var universalLink: URL
+
     /// Used internally as a holder for the completion in methods that do not pass a completion such as `handleOpen`.
     /// This allows us to set and return a completion in our methods that otherwise cannot require a completion.
     var appSwitchCompletion: (BTVenmoAccountNonce?, Error?) -> Void = { _, _ in }
@@ -39,32 +48,15 @@ import BraintreeCore
     /// We require a static reference of the client to call `handleReturnURL` and return to the app.
     static var venmoClient: BTVenmoClient?
 
-    /// Used for linking events from the client to server side request
-    /// In the Venmo flow this will be the payment context ID
-    private var payPalContextID: String?
-
-    /// Used for sending the type of flow, universal vs deeplink to FPTI
-    private var linkType: LinkType?
-
-    private var universalLink: URL?
-
     // MARK: - Initializer
-
-    /// Creates a Venmo client
-    /// - Parameter apiClient: An API client
-    @objc(initWithAPIClient:)
-    public init(apiClient: BTAPIClient) {
-        BTAppContextSwitcher.sharedInstance.register(BTVenmoClient.self)
-        self.apiClient = apiClient
-    }
 
     /// Initialize a new Venmo client instance.
     /// - Parameters:
     ///   - apiClient: The API Client
     ///   - universalLink: The URL for the Venmo app to redirect to after user authentication completes. Must be a valid HTTPS URL dedicated to Braintree app switch returns.
     @objc(initWithAPIClient:universalLink:)
-    public convenience init(apiClient: BTAPIClient, universalLink: URL) {
-        self.init(apiClient: apiClient)
+    public init(apiClient: BTAPIClient, universalLink: URL) {
+        self.apiClient = apiClient
         self.universalLink = universalLink
     }
 
@@ -77,27 +69,9 @@ import BraintreeCore
     ///   an instance of `BTVenmoAccountNonce`; on failure or user cancelation you will receive an error.
     ///   If the user cancels out of the flow, the error code will be `.canceled`.
     @objc(tokenizeWithVenmoRequest:completion:)
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     public func tokenize(_ request: BTVenmoRequest, completion: @escaping (BTVenmoAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault)
-        let returnURLScheme = BTAppContextSwitcher.sharedInstance._returnURLScheme
-
-        if returnURLScheme.isEmpty {
-            NSLog(
-                "%@ Venmo requires a return URL scheme to be configured via [BTAppContextSwitcher setReturnURLScheme:]",
-                BTLogLevelDescription.string(for: .critical)
-            )
-            notifyFailure(with: BTVenmoError.appNotAvailable, completion: completion)
-            return
-        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
-            NSLog(
-                // swiftlint:disable:next line_length
-                "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",
-                BTLogLevelDescription.string(for: .critical),
-                bundleIdentifier,
-                returnURLScheme
-            )
-        }
 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             if let error {
@@ -164,7 +138,6 @@ import BraintreeCore
                     let appSwitchURL = try BTVenmoAppSwitchRedirectURL(
                         paymentContextID: paymentContextID,
                         metadata: metadata,
-                        returnURLScheme: returnURLScheme,
                         universalLink: self.universalLink,
                         forMerchantID: merchantProfileID,
                         accessToken: configuration.venmoAccessToken,

--- a/Sources/BraintreeVenmo/BTVenmoError.swift
+++ b/Sources/BraintreeVenmo/BTVenmoError.swift
@@ -34,34 +34,31 @@ public enum BTVenmoError: Error, CustomNSError, LocalizedError, Equatable {
     /// 1. Venmo is not enabled
     case disabled
 
-    /// 2. The Venmo app is not installed or configured for app Switch
-    case appNotAvailable
-
-    /// 3. Bundle display name is nil
+    /// 2. Bundle display name is nil
     case bundleDisplayNameMissing
 
-    /// 4. App Switch could not complete
+    /// 3. App Switch could not complete
     case appSwitchFailed
 
-    /// 5. Return URL is invalid
+    /// 4. Return URL is invalid
     case invalidReturnURL(String)
 
-    /// 6. No body was returned from the request
+    /// 5. No body was returned from the request
     case invalidBodyReturned
 
-    /// 7. Invalid request URL
+    /// 6. Invalid request URL
     case invalidRedirectURL(String)
 
-    /// 8. Failed to fetch Braintree configuration
+    /// 7. Failed to fetch Braintree configuration
     case fetchConfigurationFailed
 
-    /// 9. Enriched Customer Data is disabled
+    /// 8. Enriched Customer Data is disabled
     case enrichedCustomerDataDisabled
     
-    /// 10.  The Venmo flow was canceled by the user
+    /// 9.  The Venmo flow was canceled by the user
     case canceled
 
-    /// 11. One or more values in redirect URL are invalid
+    /// 10. One or more values in redirect URL are invalid
     case invalidRedirectURLParameter
 
     public static var errorDomain: String {
@@ -74,26 +71,24 @@ public enum BTVenmoError: Error, CustomNSError, LocalizedError, Equatable {
             return 0
         case .disabled:
             return 1
-        case .appNotAvailable:
-            return 2
         case .bundleDisplayNameMissing:
-            return 3
+            return 2
         case .appSwitchFailed:
-            return 4
+            return 3
         case .invalidReturnURL:
-            return 5
+            return 4
         case .invalidBodyReturned:
-            return 6
+            return 5
         case .invalidRedirectURL:
-            return 7
+            return 6
         case .fetchConfigurationFailed:
-            return 8
+            return 7
         case .enrichedCustomerDataDisabled:
-            return 9
+            return 8
         case .canceled:
-            return 10
+            return 9
         case .invalidRedirectURLParameter:
-            return 11
+            return 10
         }
     }
 
@@ -103,8 +98,6 @@ public enum BTVenmoError: Error, CustomNSError, LocalizedError, Equatable {
             return "An unknown error occurred. Please contact support."
         case .disabled:
             return "Venmo is not enabled for this merchant account."
-        case .appNotAvailable:
-            return "The Venmo app is not installed on this device, or it is not configured or available for app switch."
         case .bundleDisplayNameMissing:
             return "CFBundleDisplayName must be non-nil. Please set 'Bundle display name' in your Info.plist."
         case .appSwitchFailed:

--- a/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAppContextSwitcher_Tests.swift
@@ -16,11 +16,6 @@ class BTAppContextSwitcher_Tests: XCTestCase {
         super.tearDown()
     }
 
-    func testSetReturnURLScheme() {
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "com.some.scheme"
-        XCTAssertEqual(appSwitch.returnURLScheme, "com.some.scheme")
-    }
-
     func testHandleOpenURL_whenClientIsRegistered_invokesCanHandleReturnURL() {
         appSwitch.register(MockAppContextSwitchClient.self)
         let expectedURL = URL(string: "fake://url")!

--- a/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
+++ b/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
@@ -20,7 +20,6 @@ class BTLocalPaymentClient_UnitTests: XCTestCase {
         )
         localPaymentRequest.localPaymentFlowDelegate = mockLocalPaymentRequestDelegate
         mockAPIClient = MockAPIClient(authorization: tempClientToken)!
-        BTAppContextSwitcher.sharedInstance.returnURLScheme = "com.my-return-url-scheme"
     }
     
     func testStartPayment_returnsErrorWhenConfigurationNil() {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAppSwitchRedirectURL_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAppSwitchRedirectURL_Tests.swift
@@ -9,8 +9,7 @@ class BTVenmoAppSwitchRedirectURL_Tests: XCTestCase {
             _ = try BTVenmoAppSwitchRedirectURL(
                 paymentContextID: "12345",
                 metadata: BTClientMetadata(),
-                returnURLScheme: "url-scheme",
-                universalLink: nil,
+                universalLink: URL(string: "https://mywebsite.com/braintree-payments")!,
                 forMerchantID: nil,
                 accessToken: "access-token",
                 bundleDisplayName: "display-name",
@@ -18,7 +17,7 @@ class BTVenmoAppSwitchRedirectURL_Tests: XCTestCase {
             )
         } catch {
             XCTAssertEqual(error as? BTVenmoError, .invalidRedirectURLParameter)
-            XCTAssertEqual((error as NSError).code, 11)
+            XCTAssertEqual((error as NSError).code, 10)
             XCTAssertEqual((error as NSError).localizedDescription, "One or more values in redirect URL are invalid.")
         }
     }
@@ -28,8 +27,7 @@ class BTVenmoAppSwitchRedirectURL_Tests: XCTestCase {
             let requestURL = try BTVenmoAppSwitchRedirectURL(
                 paymentContextID: "12345",
                 metadata: BTClientMetadata(),
-                returnURLScheme: nil,
-                universalLink: URL(string: "https://mywebsite.com/braintree-payments"),
+                universalLink: URL(string: "https://mywebsite.com/braintree-payments")!,
                 forMerchantID: "merchant-id",
                 accessToken: "access-token",
                 bundleDisplayName: "display-name",

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -710,9 +710,7 @@ class BTVenmoClient_Tests: XCTestCase {
     // MARK: - BTAppContextSwitchClient
 
     func testCanHandleReturnURL_withValidHost_andValidPath_returnsTrue() {
-        let host = "x-callback-url"
-        let path = "/vzero/auth/venmo/"
-        XCTAssertTrue(BTVenmoClient.canHandleReturnURL(URL(string: "fake-scheme://\(host)\(path)fake-result")!))
+        XCTAssertTrue(BTVenmoClient.canHandleReturnURL(URL(string: "https://www.braintreesample.com/success")!))
     }
 
     func testCanHandleReturnURL_withInvalidHost_andValidPath_returnsFalse() {

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -14,8 +14,6 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [3D Secure](#3d-secure)]
 1. [PayPal](#paypal)
 1. [PayPal Native Checkout](#paypal-native-checkout)
-1. [PayPal](#paypal)
-
 
 ## Supported Versions
 
@@ -27,10 +25,20 @@ v7 updates `BTCard` to require setting all properties through the initializer, r
 ## Venmo
 All properties within `BTVenmoRequest` can only be accessed on the initializer vs via the dot syntax.
 
-Remove the `fallbackToWeb` boolean parameter from `BTVenmoRequest`. If a Buyer has the Venmo app installed and taps on "Pay with Venmo", they will automatically be switched to the Venmo app. If the Venmo app isn't installed, the Buyer will fallback to their default web brower to checkout.
+Remove the `fallbackToWeb` boolean parameter from `BTVenmoRequest`. If a Buyer has the Venmo app installed and taps on "Pay with Venmo", they will automatically be switched to the Venmo app. If the Venmo app isn't installed, the Buyer will fallback to their default web browser to checkout.
 
 ```
 let venmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse, vault: true)
+```
+
+The `BTVenmoClient` initializer now requires a `universalLink` for switching to and from the Venmo app or web fallback flow
+
+```swift
+let apiClient = BTAPIClient("<TOKENIZATION_KEY_OR_CLIENT_TOKEN>")
+let venmoClient = BTVenmoClient(
+    apiClient: apiClient, 
+    universalLink: URL(string: "https://merchant-app.com/braintree-payments")! // merchant universal link
+)
 ```
 
 ## SEPA Direct Debit
@@ -43,6 +51,8 @@ v7 updates `BTLocalPaymentRequest` to require setting all properties through the
 All properties within `BTThreeDSecureRequest` can only be accessed on the initializer vs via the dot syntax.
 
 ## PayPal
+
+v7 updates `BTPayPalRequest`, `BTPayPalVaultRequest` and `BTPayPalCheckoutRequest` to make all properties accessible on the initializer only vs via the dot syntax.
 
 ### App Switch
 For the App Switch flow, you must update your `info.plist` with a simplified URL query scheme name, `paypal`.
@@ -58,6 +68,3 @@ For the App Switch flow, you must update your `info.plist` with a simplified URL
 ## PayPal Native Checkout
 The PayPal Native Checkout integration is no longer supported. Please remove it from your app and 
 use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal/overview/ios/v6) integration.
-
-## PayPal
-v7 updates `BTPayPalRequest`, `BTPayPalVaultRequest` and `BTPayPalCheckoutRequest` to make all properties accessible on the initializer only vs via the dot syntax.


### PR DESCRIPTION
### Summary of changes

- Remove `BTAppContextSwitcher.sharedInstance.returnURLScheme`
- Remove `BTVenmoClient(apiClient:)` init in favor of `universalLink` init
- Cleanup demo app
- Remove logic around `returnURLScheme` in the Venmo flow since this is no longer needed
- Remove no longer needed error case
- Cleanup unit tests based on updated logic

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
