### PR TITLE
[V7] Add `Encodable` protocol for PayPal Checkout

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		428F976626727333001042E1 /* BTMockOpenURLContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 428F976526727333001042E1 /* BTMockOpenURLContext.m */; };
 		42FC218B25CDE0290047C49A /* BTPayPalRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */; };
 		42FC237125CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */; };
+		451508362D400C050071E385 /* BTPayPalPaymentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451508352D400C050071E385 /* BTPayPalPaymentType.swift */; };
+		451508382D400C400071E385 /* BTPayPalRequestLandingPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451508372D400C400071E385 /* BTPayPalRequestLandingPageType.swift */; };
 		45227FC52C330FDE00A15018 /* MockURLSessionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */; };
 		45227FC72C33104100A15018 /* MockBTHTTPNetworkTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */; };
 		454722B02CF0DA34000DCF4E /* LocalPaymentPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454722AF2CF0DA27000DCF4E /* LocalPaymentPOSTBody.swift */; };
@@ -719,6 +721,8 @@
 		42F75E5A24D48138007DC5E7 /* BTThreeDSecureClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureClient_Tests.swift; sourceTree = "<group>"; };
 		42FC218A25CDE0290047C49A /* BTPayPalRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalRequest_Tests.swift; sourceTree = "<group>"; };
 		42FC237025CE0E110047C49A /* BTPayPalCheckoutRequest_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutRequest_Tests.swift; sourceTree = "<group>"; };
+		451508352D400C050071E385 /* BTPayPalPaymentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalPaymentType.swift; sourceTree = "<group>"; };
+		451508372D400C400071E385 /* BTPayPalRequestLandingPageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalRequestLandingPageType.swift; sourceTree = "<group>"; };
 		45227FC32C330FDE00A15018 /* MockURLSessionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionTask.swift; sourceTree = "<group>"; };
 		45227FC62C33104100A15018 /* MockBTHTTPNetworkTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBTHTTPNetworkTiming.swift; sourceTree = "<group>"; };
 		454722AF2CF0DA27000DCF4E /* LocalPaymentPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPaymentPOSTBody.swift; sourceTree = "<group>"; };
@@ -1299,13 +1303,15 @@
 				57544F5D295258AC00DEB7B0 /* BTPayPalError.swift */,
 				BEF5D2E5294A18B300FFD56D /* BTPayPalLineItem.swift */,
 				57D9436D2968A8080079EAB1 /* BTPayPalLocaleCode.swift */,
+				451508352D400C050071E385 /* BTPayPalPaymentType.swift */,
+				62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */,
 				BE349112294B798300D2CF68 /* BTPayPalRequest.swift */,
+				451508372D400C400071E385 /* BTPayPalRequestLandingPageType.swift */,
 				BE6BC22D2BA9CFFC00C3E321 /* BTPayPalReturnURL.swift */,
 				BE349110294B77E100D2CF68 /* BTPayPalVaultRequest.swift */,
 				45E8CE4A2D1F291400D7A2DC /* Models */,
 				62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */,
 				807D22F32C29ADA8009FFEA4 /* RecurringBillingMetadata */,
-				62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */,
 			);
 			path = BraintreePayPal;
 			sourceTree = "<group>";
@@ -3119,12 +3125,14 @@
 				BE549F112BF5445F00B6F441 /* BTPayPalReturnURL.swift in Sources */,
 				57544F5C295254A500DEB7B0 /* BTJSON+PayPal.swift in Sources */,
 				3B7A261129C0CAA40087059D /* BTPayPalAnalytics.swift in Sources */,
+				451508382D400C400071E385 /* BTPayPalRequestLandingPageType.swift in Sources */,
 				BE8E5CEF294B6937001BF017 /* BTPayPalCheckoutRequest.swift in Sources */,
 				807D22F02C29A93A009FFEA4 /* BTPayPalBillingCycle.swift in Sources */,
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
 				45E8CE4C2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift in Sources */,
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,
+				451508362D400C050071E385 /* BTPayPalPaymentType.swift in Sources */,
 				8014221C2BAE935B009F9999 /* BTPayPalApprovalURLParser.swift in Sources */,
 				BE349111294B77E100D2CF68 /* BTPayPalVaultRequest.swift in Sources */,
 				62B811882CC002470024A688 /* BTPayPalPhoneNumber.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		458570782C34A699009CEF7A /* ConfigurationLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */; };
 		4585707A2C34B1E1009CEF7A /* MockClientAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */; };
 		4585707C2C34B7B5009CEF7A /* MockConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */; };
-		45E8CE4C2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */; };
+		45E8CE4C2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8CE4B2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift */; };
 		45EFC3972C2DBF32005E7F5B /* ConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
@@ -726,7 +726,7 @@
 		458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader_Tests.swift; sourceTree = "<group>"; };
 		458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClientAuthorization.swift; sourceTree = "<group>"; };
 		4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationLoader.swift; sourceTree = "<group>"; };
-		45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutPOSTBody.swift; sourceTree = "<group>"; };
+		45E8CE4B2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCheckoutPOSTBody.swift; sourceTree = "<group>"; };
 		45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1319,7 +1319,7 @@
 		45E8CE4A2D1F291400D7A2DC /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */,
+				45E8CE4B2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3119,7 +3119,7 @@
 				807D22F02C29A93A009FFEA4 /* BTPayPalBillingCycle.swift in Sources */,
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
-				45E8CE4C2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift in Sources */,
+				45E8CE4C2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift in Sources */,
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,
 				8014221C2BAE935B009F9999 /* BTPayPalApprovalURLParser.swift in Sources */,
 				BE349111294B77E100D2CF68 /* BTPayPalVaultRequest.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		458570782C34A699009CEF7A /* ConfigurationLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */; };
 		4585707A2C34B1E1009CEF7A /* MockClientAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */; };
 		4585707C2C34B7B5009CEF7A /* MockConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */; };
+		45E8CE4C2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */; };
 		45EFC3972C2DBF32005E7F5B /* ConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
@@ -725,6 +726,7 @@
 		458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader_Tests.swift; sourceTree = "<group>"; };
 		458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClientAuthorization.swift; sourceTree = "<group>"; };
 		4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationLoader.swift; sourceTree = "<group>"; };
+		45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCheckoutPOSTBody.swift; sourceTree = "<group>"; };
 		45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1298,6 +1300,7 @@
 				BE349112294B798300D2CF68 /* BTPayPalRequest.swift */,
 				BE6BC22D2BA9CFFC00C3E321 /* BTPayPalReturnURL.swift */,
 				BE349110294B77E100D2CF68 /* BTPayPalVaultRequest.swift */,
+				45E8CE4A2D1F291400D7A2DC /* Models */,
 				62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */,
 				807D22F32C29ADA8009FFEA4 /* RecurringBillingMetadata */,
 				62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */,
@@ -1309,6 +1312,14 @@
 			isa = PBXGroup;
 			children = (
 				454722AF2CF0DA27000DCF4E /* LocalPaymentPOSTBody.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		45E8CE4A2D1F291400D7A2DC /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				45E8CE4B2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3108,6 +3119,7 @@
 				807D22F02C29A93A009FFEA4 /* BTPayPalBillingCycle.swift in Sources */,
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
+				45E8CE4C2D1F29BA00D7A2DC /* BTPayPalCheckoutPOSTBody.swift in Sources */,
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,
 				8014221C2BAE935B009F9999 /* BTPayPalApprovalURLParser.swift in Sources */,
 				BE349111294B77E100D2CF68 /* BTPayPalVaultRequest.swift in Sources */,

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -144,12 +144,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             amount: "5.00",
             intent: newPayPalCheckoutToggle.isOn ? .sale : .authorize,
             offerPayLater: payLaterToggle.isOn,
+            lineItems: [lineItem],
             userAuthenticationEmail: emailTextField.text,
             userPhoneNumber: BTPayPalPhoneNumber(
                 countryCode: countryCodeTextField.text ?? "",
                 nationalNumber: nationalNumberTextField.text ?? ""
-            ),
-            lineItems: [lineItem]
+            )
         )
 
         payPalClient.tokenize(request) { nonce, error in

--- a/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
+++ b/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
@@ -22,4 +22,9 @@ extension BTConfiguration {
     var displayName: String? {
         json?["paypal"]["displayName"].asString()
     }
+    
+    /// Retrieves the currencyIsoCode
+    var currencyIsoCode: String? {
+        json?["paypal"]["currencyIsoCode"].asString()
+    }
 }

--- a/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
+++ b/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
@@ -17,4 +17,9 @@ extension BTConfiguration {
     var isBillingAgreementsEnabled: Bool {
         json?["paypal"]["billingAgreementsEnabled"].isTrue ?? false
     }
+    
+    /// Retrieves the display name associated with the PayPal account.
+    var displayName: String? {
+        json?["paypal"]["displayName"].asString()
+    }
 }

--- a/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
+++ b/Sources/BraintreePayPal/BTConfiguration+PayPal.swift
@@ -23,7 +23,7 @@ extension BTConfiguration {
         json?["paypal"]["displayName"].asString()
     }
     
-    /// Retrieves the currencyIsoCode
+    /// Retrieves the currencyIsoCode.
     var currencyIsoCode: String? {
         json?["paypal"]["currencyIsoCode"].asString()
     }

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -165,23 +165,23 @@ import BraintreeCore
         experienceProfile["no_shipping"] = !isShippingAddressRequired
         experienceProfile["brand_name"] = displayName != nil ? displayName : configuration.json?["paypal"]["displayName"].asString()
 
-        if landingPageType?.stringValue != nil {
-            experienceProfile["landing_page_type"] = landingPageType?.stringValue
+        if let landingPageType = landingPageType?.stringValue {
+            experienceProfile["landing_page_type"] = landingPageType
         }
 
-        if localeCode?.stringValue != nil {
-            experienceProfile["locale_code"] = localeCode?.stringValue
+        if let localeCode = localeCode?.stringValue {
+            experienceProfile["locale_code"] = localeCode
         }
 
         experienceProfile["address_override"] = shippingAddressOverride != nil ? !isShippingAddressEditable : false
 
         var baseParameters: [String: Any] = [:]
 
-        if merchantAccountID != nil {
+        if let merchantAccountID {
             baseParameters["merchant_account_id"] = merchantAccountID
         }
 
-        if riskCorrelationID != nil {
+        if let riskCorrelationID {
             baseParameters["correlation_id"] = riskCorrelationID
         }
         
@@ -210,7 +210,7 @@ import BraintreeCore
 
         let currencyCode = currencyCode != nil ? currencyCode : configuration.json?["paypal"]["currencyIsoCode"].asString()
 
-        if currencyCode != nil {
+        if let currencyCode {
             checkoutParameters["currency_iso_code"] = currencyCode
         }
 
@@ -219,7 +219,7 @@ import BraintreeCore
             baseParameters["experience_profile"] = experienceProfile
         }
 
-        if requestBillingAgreement != false {
+        if requestBillingAgreement {
             checkoutParameters["request_billing_agreement"] = requestBillingAgreement
 
             if billingAgreementDescription != nil {
@@ -227,14 +227,14 @@ import BraintreeCore
             }
         }
 
-        if shippingAddressOverride != nil {
-            checkoutParameters["line1"] = shippingAddressOverride?.streetAddress
-            checkoutParameters["line2"] = shippingAddressOverride?.extendedAddress
-            checkoutParameters["city"] = shippingAddressOverride?.locality
-            checkoutParameters["state"] = shippingAddressOverride?.region
-            checkoutParameters["postal_code"] = shippingAddressOverride?.postalCode
-            checkoutParameters["country_code"] = shippingAddressOverride?.countryCodeAlpha2
-            checkoutParameters["recipient_name"] = shippingAddressOverride?.recipientName
+        if let shippingAddressOverride {
+            checkoutParameters["line1"] = shippingAddressOverride.streetAddress
+            checkoutParameters["line2"] = shippingAddressOverride.extendedAddress
+            checkoutParameters["city"] = shippingAddressOverride.locality
+            checkoutParameters["state"] = shippingAddressOverride.region
+            checkoutParameters["postal_code"] = shippingAddressOverride.postalCode
+            checkoutParameters["country_code"] = shippingAddressOverride.countryCodeAlpha2
+            checkoutParameters["recipient_name"] = shippingAddressOverride.recipientName
         }
 
         return baseParameters.merging(checkoutParameters) { $1 }

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -56,17 +56,32 @@ import BraintreeCore
 }
 
 /// Options for the PayPal Checkout flow.
-@objcMembers open class BTPayPalCheckoutRequest: BTPayPalRequest {
-
+@objcMembers public class BTPayPalCheckoutRequest: NSObject, PayPalRequest {
+    
     // MARK: - Internal Properties
+    
+    let hermesPath: String
+    let paymentType: BTPayPalPaymentType
     
     var amount: String
     var intent: BTPayPalRequestIntent
     var userAction: BTPayPalRequestUserAction
     var offerPayLater: Bool
+    var billingAgreementDescription: String?
     var currencyCode: String?
+    var displayName: String?
+    var isShippingAddressEditable: Bool = false
+    var isShippingAddressRequired: Bool = false
+    var landingPageType: BTPayPalRequestLandingPageType?
+    var lineItems: [BTPayPalLineItem]?
+    var localeCode: BTPayPalLocaleCode?
+    var merchantAccountID: String?
     var requestBillingAgreement: Bool
-
+    var riskCorrelationID: String?
+    var shippingAddressOverride: BTPostalAddress?
+    var userAuthenticationEmail: String?
+    var userPhoneNumber: BTPayPalPhoneNumber?
+    
     // MARK: - Initializer
 
     /// Initializes a PayPal Native Checkout request
@@ -75,48 +90,117 @@ import BraintreeCore
     ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
     ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.none`.
     ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
+    ///   - billingAgreementDescription: Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set
     ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
     ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
+    ///   - displayName: Optional: The merchant name displayed inside of the PayPal flow; defaults to the company name on your Braintree account
+    ///   - isShippingAddressEditable: Defaults to false. Set to true to enable user editing of the shipping address.
+    ///   - isShippingAddressRequired: Defaults to false. When set to true, the shipping address selector will be displayed.
+    ///   - landingPageType: Optional: Landing page type. Defaults to `.none`.
+    ///     - Note: Setting the BTPayPalRequest's landingPageType changes the PayPal page to display when a user lands on the PayPal site to complete the payment.
+    ///        `.login` specifies a PayPal account login page is used.
+    ///        `.billing` specifies a non-PayPal account landing page is used.
+    ///   - lineItems: Optional: The line items for this transaction. It can include up to 249 line items.
+    ///   - localeCode: Optional: A locale code to use for the transaction.
+    ///   - merchantAccountID: Optional: A non-default merchant account to use for tokenization.
     ///   - requestBillingAgreement: Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement
     ///   during checkout. Defaults to `false`.
+    ///   - riskCorrelationID: Optional: A risk correlation ID created with Set Transaction Context on your server.
+    ///   - shippingAddressOverride: Optional: A valid shipping address to be displayed in the transaction flow. An error will occur if this address is not valid.
     ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     ///   - userPhoneNumber: Optional: A user's phone number to initiate a quicker authentication flow in the scenario where the user has a PayPal account
     ///   identified with the same phone number.
-    ///   - lineItems: Optional: The line items for this transaction. It can include up to 249 line items.
     public init(
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
         userAction: BTPayPalRequestUserAction = .none,
         offerPayLater: Bool = false,
+        billingAgreementDescription: String? = nil,
         currencyCode: String? = nil,
+        displayName: String? = nil,
+        isShippingAddressEditable: Bool = false,
+        isShippingAddressRequired: Bool = false,
+        landingPageType: BTPayPalRequestLandingPageType = .none,
+        lineItems: [BTPayPalLineItem]? = nil,
+        localeCode: BTPayPalLocaleCode = .none,
+        merchantAccountID: String? = nil,
         requestBillingAgreement: Bool = false,
+        riskCorrelationID: String? = nil,
+        shippingAddressOverride: BTPostalAddress? = nil,
         userAuthenticationEmail: String? = nil,
-        userPhoneNumber: BTPayPalPhoneNumber? = nil,
-        lineItems: [BTPayPalLineItem]? = nil
+        userPhoneNumber: BTPayPalPhoneNumber? = nil
     ) {
+        self.hermesPath = "v1/paypal_hermes/create_payment_resource"
+        self.paymentType = .checkout
         self.amount = amount
         self.intent = intent
         self.userAction = userAction
         self.offerPayLater = offerPayLater
+        self.billingAgreementDescription = billingAgreementDescription
         self.currencyCode = currencyCode
+        self.displayName = displayName
+        self.isShippingAddressEditable = isShippingAddressEditable
+        self.isShippingAddressRequired = isShippingAddressRequired
+        self.landingPageType = landingPageType
+        self.lineItems = lineItems
+        self.localeCode = localeCode
+        self.merchantAccountID = merchantAccountID
         self.requestBillingAgreement = requestBillingAgreement
-        super.init(
-            hermesPath: "v1/paypal_hermes/create_payment_resource",
-            paymentType: .checkout,
-            lineItems: lineItems,
-            userAuthenticationEmail: userAuthenticationEmail,
-            userPhoneNumber: userPhoneNumber
-        )
+        self.riskCorrelationID = riskCorrelationID
+        self.shippingAddressOverride = shippingAddressOverride
+        self.userAuthenticationEmail = userAuthenticationEmail
+        self.userPhoneNumber = userPhoneNumber
     }
 
     // MARK: Internal Methods
 
-    override func parameters(
+    func parameters(
         with configuration: BTConfiguration,
         universalLink: URL? = nil,
         isPayPalAppInstalled: Bool = false
     ) -> [String: Any] {
-        var baseParameters = super.parameters(with: configuration)
+        var experienceProfile: [String: Any] = [:]
+
+        experienceProfile["no_shipping"] = !isShippingAddressRequired
+        experienceProfile["brand_name"] = displayName != nil ? displayName : configuration.json?["paypal"]["displayName"].asString()
+
+        if landingPageType?.stringValue != nil {
+            experienceProfile["landing_page_type"] = landingPageType?.stringValue
+        }
+
+        if localeCode?.stringValue != nil {
+            experienceProfile["locale_code"] = localeCode?.stringValue
+        }
+
+        experienceProfile["address_override"] = shippingAddressOverride != nil ? !isShippingAddressEditable : false
+
+        var baseParameters: [String: Any] = [:]
+
+        if merchantAccountID != nil {
+            baseParameters["merchant_account_id"] = merchantAccountID
+        }
+
+        if riskCorrelationID != nil {
+            baseParameters["correlation_id"] = riskCorrelationID
+        }
+        
+        if let lineItems, !lineItems.isEmpty {
+            let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
+            baseParameters["line_items"] = lineItemsArray
+        }
+        
+        if let userAuthenticationEmail, !userAuthenticationEmail.isEmpty {
+            baseParameters["payer_email"] = userAuthenticationEmail
+        }
+        
+        if let userPhoneNumberDict = try? userPhoneNumber?.toDictionary() {
+            baseParameters["phone_number"] = userPhoneNumberDict
+        }
+
+        baseParameters["return_url"] = BTCoreConstants.callbackURLScheme + "://\(Self.callbackURLHostAndPath)success"
+        baseParameters["cancel_url"] = BTCoreConstants.callbackURLScheme + "://\(Self.callbackURLHostAndPath)cancel"
+        baseParameters["experience_profile"] = experienceProfile
+        
         var checkoutParameters: [String: Any] = [
             "intent": intent.stringValue,
             "amount": amount,

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -60,8 +60,8 @@ import BraintreeCore
     
     // MARK: - Internal Properties
     
-    let hermesPath: String
-    let paymentType: BTPayPalPaymentType
+    let hermesPath = "v1/paypal_hermes/create_payment_resource"
+    let paymentType: BTPayPalPaymentType = .checkout
     
     var amount: String
     var intent: BTPayPalRequestIntent
@@ -130,8 +130,6 @@ import BraintreeCore
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil
     ) {
-        self.hermesPath = "v1/paypal_hermes/create_payment_resource"
-        self.paymentType = .checkout
         self.amount = amount
         self.intent = intent
         self.userAction = userAction

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -154,6 +154,7 @@ import BraintreeCore
 
     // MARK: Internal Methods
 
+    // swiftlint:disable cyclomatic_complexity
     func parameters(
         with configuration: BTConfiguration,
         universalLink: URL? = nil,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -356,12 +356,13 @@ import BraintreeDataCollector
             }
 
             self.payPalRequest = request
-            
-            let parameters = PayPalCheckoutPOSTBody(payPalRequest: request as! BTPayPalCheckoutRequest, configuration: configuration)
-            
             self.apiClient.post(
                 request.hermesPath,
-                parameters: parameters
+                parameters: request.parameters(
+                    with: configuration,
+                    universalLink: self.universalLink,
+                    isPayPalAppInstalled: self.application.isPayPalAppInstalled()
+                )
             ) { body, _, error in
                 if let error = error as? NSError {
                     guard let jsonResponseBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON else {
@@ -401,28 +402,6 @@ import BraintreeDataCollector
         }
     }
 
-    func printJSON(from dictionary: [String: Any]) {
-        if let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted),
-           let jsonString = String(data: jsonData, encoding: .utf8) {
-            print(jsonString)
-        } else {
-            print("Failed to convert dictionary to JSON.")
-        }
-    }
-    
-    func printJSONEncodable(from model: Encodable) {
-        do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let jsonData = try encoder.encode(model)
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            }
-        } catch {
-            print("Error encoding JSON: \(error)")
-        }
-    }
-    
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
         baToken: String,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -356,13 +356,12 @@ import BraintreeDataCollector
             }
 
             self.payPalRequest = request
+            
+            let parameters = PayPalCheckoutPOSTBody(payPalRequest: request as! BTPayPalCheckoutRequest, configuration: configuration)
+            
             self.apiClient.post(
                 request.hermesPath,
-                parameters: request.parameters(
-                    with: configuration,
-                    universalLink: self.universalLink,
-                    isPayPalAppInstalled: self.application.isPayPalAppInstalled()
-                )
+                parameters: parameters
             ) { body, _, error in
                 if let error = error as? NSError {
                     guard let jsonResponseBody = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON else {
@@ -402,6 +401,28 @@ import BraintreeDataCollector
         }
     }
 
+    func printJSON(from dictionary: [String: Any]) {
+        if let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            print(jsonString)
+        } else {
+            print("Failed to convert dictionary to JSON.")
+        }
+    }
+    
+    func printJSONEncodable(from model: Encodable) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let jsonData = try encoder.encode(model)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                print(jsonString)
+            }
+        } catch {
+            print("Error encoding JSON: \(error)")
+        }
+    }
+    
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
         baToken: String,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -29,7 +29,7 @@ import BraintreeDataCollector
     var clientMetadataID: String?
     
     /// Exposed for testing the intent associated with this request
-    var payPalRequest: BTPayPalRequest?
+    var payPalRequest: PayPalRequest?
 
     /// Exposed for testing, the ASWebAuthenticationSession instance used for the PayPal flow
     var webAuthenticationSession: BTWebAuthenticationSession
@@ -331,7 +331,7 @@ import BraintreeDataCollector
     // MARK: - Private Methods
 
     private func tokenize(
-        request: BTPayPalRequest,
+        request: PayPalRequest,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         linkType = (request as? BTPayPalVaultRequest)?.enablePayPalAppSwitch == true ? .universal : .deeplink

--- a/Sources/BraintreePayPal/BTPayPalLineItem.swift
+++ b/Sources/BraintreePayPal/BTPayPalLineItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Use this option to specify whether a line item is a debit (sale) or credit (refund) to the customer.
-@objc public enum BTPayPalLineItemKind: Int {
+@objc public enum BTPayPalLineItemKind: Int, Encodable {
     /// Debit
     case debit
 
@@ -16,11 +16,16 @@ import Foundation
             return "credit"
         }
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(stringValue)
+    }
 }
 
 // swiftlint:disable identifier_name
 /// Use this option to specify  the UPC type of the line item.
-@objc public enum BTPayPalLineItemUPCType: Int {
+@objc public enum BTPayPalLineItemUPCType: Int, Encodable {
 
     /// Default
     case none
@@ -66,6 +71,11 @@ import Foundation
         case .UPC_5:
             return "UPC-5"
         }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(stringValue)
     }
 }
 
@@ -135,25 +145,6 @@ import Foundation
         case upcCode = "upc_code"
         case upcType = "upc_type"
         case url
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(quantity, forKey: .quantity)
-        try container.encode(unitAmount, forKey: .unitAmount)
-        try container.encode(name, forKey: .name)
-        try container.encode(kind.stringValue, forKey: .kind)
-        
-        if let unitTaxAmount, !unitTaxAmount.isEmpty {
-            try container.encode(unitAmount, forKey: .unitTaxAmount)
-        }
-        
-        try container.encodeIfPresent(itemDescription, forKey: .itemDescription)
-        try container.encodeIfPresent(productCode, forKey: .productCode)
-        try container.encodeIfPresent(url?.absoluteString, forKey: .url)
-        try container.encodeIfPresent(imageURL?.absoluteString, forKey: .imageURL)
-        try container.encodeIfPresent(upcCode, forKey: .upcCode)
-        try container.encodeIfPresent(upcType.stringValue, forKey: .upcType)
     }
     
     // MARK: - Internal Methods

--- a/Sources/BraintreePayPal/BTPayPalLineItem.swift
+++ b/Sources/BraintreePayPal/BTPayPalLineItem.swift
@@ -7,6 +7,15 @@ import Foundation
 
     /// Credit
     case credit
+    
+    var stringValue: String {
+        switch self {
+        case .debit:
+            return "debit"
+        case .credit:
+            return "credit"
+        }
+    }
 }
 
 // swiftlint:disable identifier_name
@@ -61,7 +70,7 @@ import Foundation
 }
 
 /// A PayPal line item to be displayed in the PayPal checkout flow.
-@objcMembers public class BTPayPalLineItem: NSObject {
+@objcMembers public class BTPayPalLineItem: NSObject, Encodable {
 
     // MARK: - Public Properties
     
@@ -112,6 +121,39 @@ import Foundation
         self.unitAmount = unitAmount
         self.name = name
         self.kind = kind
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case imageURL = "image_url"
+        case itemDescription = "description"
+        case kind
+        case name
+        case productCode = "product_code"
+        case quantity
+        case unitAmount = "unit_amount"
+        case unitTaxAmount = "unit_tax_amount"
+        case upcCode = "upc_code"
+        case upcType = "upc_type"
+        case url
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(quantity, forKey: .quantity)
+        try container.encode(unitAmount, forKey: .unitAmount)
+        try container.encode(name, forKey: .name)
+        try container.encode(kind.stringValue, forKey: .kind)
+        
+        if let unitTaxAmount, !unitTaxAmount.isEmpty {
+            try container.encode(unitAmount, forKey: .unitTaxAmount)
+        }
+        
+        try container.encodeIfPresent(itemDescription, forKey: .itemDescription)
+        try container.encodeIfPresent(productCode, forKey: .productCode)
+        try container.encodeIfPresent(url?.absoluteString, forKey: .url)
+        try container.encodeIfPresent(imageURL?.absoluteString, forKey: .imageURL)
+        try container.encodeIfPresent(upcCode, forKey: .upcCode)
+        try container.encodeIfPresent(upcType.stringValue, forKey: .upcType)
     }
     
     // MARK: - Internal Methods

--- a/Sources/BraintreePayPal/BTPayPalPaymentType.swift
+++ b/Sources/BraintreePayPal/BTPayPalPaymentType.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@objc public enum BTPayPalPaymentType: Int {
+    
+    /// Checkout
+    case checkout
+
+    /// Vault
+    case vault
+    
+    var stringValue: String {
+        switch self {
+        case .vault:
+            return "paypal-ba"
+        case .checkout:
+            return "paypal-single-payment"
+        }
+    }
+}

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -80,11 +80,11 @@ import BraintreeCore
     ///    - hermesPath: Required :nodoc: The hermes path or endpoint URI path. This property is not covered by semantic versioning.
     ///    - paymentType: Required :nodoc: The payment type, either checkout or vault. This property is not covered by semantic versioning.
     ///    - isShippingAddressRequired: Defaults to false. When set to true, the shipping address selector will be displayed.
-    ///    - isShippingAddressEditable: Defaults to false. Set to true to enable user editing of the shipping address. 
+    ///    - isShippingAddressEditable: Defaults to false. Set to true to enable user editing of the shipping address.
     ///     - Note: Only applies when `shippingAddressOverride` is set.
     ///    - localeCode: Optional: A locale code to use for the transaction.
     ///    - shippingAddressOverride: Optional: A valid shipping address to be displayed in the transaction flow. An error will occur if this address is not valid.
-    ///    - landingPageType: Optional: Landing page type. Defaults to `.none`.  
+    ///    - landingPageType: Optional: Landing page type. Defaults to `.none`.
     ///     - Note: Setting the BTPayPalRequest's landingPageType changes the PayPal page to display when a user lands on the PayPal site to complete the payment.
     ///        `.login` specifies a PayPal account login page is used.
     ///        `.billing` specifies a non-PayPal account landing page is used.

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -48,9 +48,43 @@ import BraintreeCore
     }
 }
 
+protocol PayPalRequest {
+    var hermesPath: String { get }
+    var paymentType: BTPayPalPaymentType { get }
+    var billingAgreementDescription: String? { get }
+    var displayName: String? { get }
+    var isShippingAddressEditable: Bool { get }
+    var isShippingAddressRequired: Bool { get }
+    var landingPageType: BTPayPalRequestLandingPageType? { get }
+    var lineItems: [BTPayPalLineItem]? { get }
+    var localeCode: BTPayPalLocaleCode? { get }
+    var merchantAccountID: String? { get }
+    var riskCorrelationID: String? { get }
+    var shippingAddressOverride: BTPostalAddress? { get }
+    var userAuthenticationEmail: String? { get }
+    var userPhoneNumber: BTPayPalPhoneNumber? { get }
+    
+    // MARK: - Static Properties
+    
+    static var callbackURLHostAndPath: String { get }
+    
+    func parameters(
+        with configuration: BTConfiguration,
+        universalLink: URL?,
+        isPayPalAppInstalled: Bool
+    ) -> [String: Any]
+}
+
+extension PayPalRequest {
+    
+    static var callbackURLHostAndPath: String {
+        "onetouch/v1/"
+    }
+}
+
 /// Base options for PayPal Checkout and PayPal Vault flows.
 /// - Note: Do not instantiate this class directly. Instead, use BTPayPalCheckoutRequest or BTPayPalVaultRequest.
-@objcMembers open class BTPayPalRequest: NSObject {
+@objcMembers open class BTPayPalRequest: NSObject, PayPalRequest {
 
     // MARK: - Internal Properties
     
@@ -68,10 +102,6 @@ import BraintreeCore
     var riskCorrelationID: String?
     var userAuthenticationEmail: String?
     var userPhoneNumber: BTPayPalPhoneNumber?
-    
-    // MARK: - Static Properties
-    
-    static let callbackURLHostAndPath: String = "onetouch/v1/"
 
     // MARK: - Initializer
 

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -4,50 +4,7 @@ import UIKit
 import BraintreeCore
 #endif
 
-@objc public enum BTPayPalPaymentType: Int {
-    
-    /// Checkout
-    case checkout
-
-    /// Vault
-    case vault
-    
-    var stringValue: String {
-        switch self {
-        case .vault:
-            return "paypal-ba"
-        case .checkout:
-            return "paypal-single-payment"
-        }
-    }
-}
-
-/// Use this option to specify the PayPal page to display when a user lands on the PayPal site to complete the payment.
-@objc public enum BTPayPalRequestLandingPageType: Int {
-
-    /// Default
-    case none // Obj-C enums cannot be nil; this default option is used to make `landingPageType` optional for merchants
-
-    /// Login
-    case login
-
-    /// Billing
-    case billing
-
-    var stringValue: String? {
-        switch self {
-        case .login:
-            return "login"
-
-        case .billing:
-            return "billing"
-
-        default:
-            return nil
-        }
-    }
-}
-
+/// Defines the structure and requirements for PayPal Checkout and PayPal Vault flows.
 protocol PayPalRequest {
     var hermesPath: String { get }
     var paymentType: BTPayPalPaymentType { get }

--- a/Sources/BraintreePayPal/BTPayPalRequestLandingPageType.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequestLandingPageType.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Use this option to specify the PayPal page to display when a user lands on the PayPal site to complete the payment.
+@objc public enum BTPayPalRequestLandingPageType: Int {
+
+    /// Default
+    case none // Obj-C enums cannot be nil; this default option is used to make `landingPageType` optional for merchants
+
+    /// Login
+    case login
+
+    /// Billing
+    case billing
+
+    var stringValue: String? {
+        switch self {
+        case .login:
+            return "login"
+
+        case .billing:
+            return "billing"
+
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -9,8 +9,8 @@ import BraintreeCore
 
     // MARK: - Internal Properties
     
-    let hermesPath: String
-    let paymentType: BTPayPalPaymentType
+    let hermesPath = "v1/paypal_hermes/setup_billing_agreement"
+    let paymentType: BTPayPalPaymentType = .vault
     
     var offerCredit: Bool
     var enablePayPalAppSwitch: Bool = false
@@ -87,8 +87,6 @@ import BraintreeCore
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil
     ) {
-        self.hermesPath = "v1/paypal_hermes/setup_billing_agreement"
-        self.paymentType = .vault
         self.offerCredit = offerCredit
         self.billingAgreementDescription = billingAgreementDescription
         self.displayName = displayName

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -106,7 +106,7 @@ import BraintreeCore
         self.userPhoneNumber = userPhoneNumber
     }
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity function_body_length
     func parameters(
         with configuration: BTConfiguration,
         universalLink: URL? = nil,

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -117,23 +117,23 @@ import BraintreeCore
         experienceProfile["no_shipping"] = !isShippingAddressRequired
         experienceProfile["brand_name"] = displayName != nil ? displayName : configuration.json?["paypal"]["displayName"].asString()
 
-        if landingPageType?.stringValue != nil {
-            experienceProfile["landing_page_type"] = landingPageType?.stringValue
+        if let landingPageType = landingPageType?.stringValue {
+            experienceProfile["landing_page_type"] = landingPageType
         }
 
-        if localeCode?.stringValue != nil {
-            experienceProfile["locale_code"] = localeCode?.stringValue
+        if let localeCode = localeCode?.stringValue {
+            experienceProfile["locale_code"] = localeCode
         }
 
         experienceProfile["address_override"] = shippingAddressOverride != nil ? !isShippingAddressEditable : false
 
         var baseParameters: [String: Any] = [:]
 
-        if merchantAccountID != nil {
+        if let merchantAccountID {
             baseParameters["merchant_account_id"] = merchantAccountID
         }
 
-        if riskCorrelationID != nil {
+        if let riskCorrelationID {
             baseParameters["correlation_id"] = riskCorrelationID
         }
         

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -5,15 +5,30 @@ import BraintreeCore
 #endif
 
 ///  Options for the PayPal Vault flow.
-@objcMembers public class BTPayPalVaultRequest: BTPayPalRequest {
-    
+@objcMembers public class BTPayPalVaultRequest: NSObject, PayPalRequest {
+
     // MARK: - Internal Properties
+    
+    let hermesPath: String
+    let paymentType: BTPayPalPaymentType
     
     var offerCredit: Bool
     var enablePayPalAppSwitch: Bool = false
-    var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
+    var billingAgreementDescription: String?
+    var displayName: String?
+    var isShippingAddressEditable: Bool = false
+    var isShippingAddressRequired: Bool = false
+    var landingPageType: BTPayPalRequestLandingPageType?
+    var lineItems: [BTPayPalLineItem]?
+    var localeCode: BTPayPalLocaleCode?
+    var merchantAccountID: String?
     var recurringBillingDetails: BTPayPalRecurringBillingDetails?
-
+    var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
+    var riskCorrelationID: String?
+    var shippingAddressOverride: BTPostalAddress?
+    var userAuthenticationEmail: String?
+    var userPhoneNumber: BTPayPalPhoneNumber?
+    
     // MARK: - Initializers
 
     /// Initializes a PayPal Vault request for the PayPal App Switch flow
@@ -35,35 +50,108 @@ import BraintreeCore
     /// Initializes a PayPal Vault request
     /// - Parameters:
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    ///   - billingAgreementDescription: Optional: Display a custom description to the user for a billing agreement. For Checkout with Vault flows, you must also set
+    ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
+    ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
+    ///   - displayName: Optional: The merchant name displayed inside of the PayPal flow; defaults to the company name on your Braintree account
+    ///   - isShippingAddressEditable: Defaults to false. Set to true to enable user editing of the shipping address.
+    ///   - isShippingAddressRequired: Defaults to false. When set to true, the shipping address selector will be displayed.
+    ///   - landingPageType: Optional: Landing page type. Defaults to `.none`.
+    ///     - Note: Setting the BTPayPalRequest's landingPageType changes the PayPal page to display when a user lands on the PayPal site to complete the payment.
+    ///        `.login` specifies a PayPal account login page is used.
+    ///        `.billing` specifies a non-PayPal account landing page is used.
+    ///   - lineItems: Optional: The line items for this transaction. It can include up to 249 line items.
+    ///   - localeCode: Optional: A locale code to use for the transaction.
+    ///   - merchantAccountID: Optional: A non-default merchant account to use for tokenization.
     ///   - recurringBillingDetails: Optional: Recurring billing product details.
     ///   - recurringBillingPlanType: Optional: Recurring billing plan type, or charge pattern.
+    ///   - riskCorrelationID: Optional: A risk correlation ID created with Set Transaction Context on your server.
+    ///   - shippingAddressOverride: Optional: A valid shipping address to be displayed in the transaction flow. An error will occur if this address is not valid.
     ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
     ///   - userPhoneNumber: Optional: A user's phone number to initiate a quicker authentication flow in the scenario where the user has a PayPal account
     /// identified with the same phone number.
     public init(
         offerCredit: Bool = false,
+        billingAgreementDescription: String? = nil,
+        displayName: String? = nil,
+        isShippingAddressEditable: Bool = false,
+        isShippingAddressRequired: Bool = false,
+        landingPageType: BTPayPalRequestLandingPageType = .none,
+        lineItems: [BTPayPalLineItem]? = nil,
+        localeCode: BTPayPalLocaleCode = .none,
+        merchantAccountID: String? = nil,
         recurringBillingDetails: BTPayPalRecurringBillingDetails? = nil,
         recurringBillingPlanType: BTPayPalRecurringBillingPlanType? = nil,
+        riskCorrelationID: String? = nil,
+        shippingAddressOverride: BTPostalAddress? = nil,
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil
     ) {
+        self.hermesPath = "v1/paypal_hermes/setup_billing_agreement"
+        self.paymentType = .vault
         self.offerCredit = offerCredit
+        self.billingAgreementDescription = billingAgreementDescription
+        self.displayName = displayName
+        self.isShippingAddressEditable = isShippingAddressEditable
+        self.isShippingAddressRequired = isShippingAddressRequired
+        self.landingPageType = landingPageType
+        self.lineItems = lineItems
+        self.localeCode = localeCode
+        self.merchantAccountID = merchantAccountID
         self.recurringBillingDetails = recurringBillingDetails
         self.recurringBillingPlanType = recurringBillingPlanType
-        super.init(
-            hermesPath: "v1/paypal_hermes/setup_billing_agreement",
-            paymentType: .vault,
-            userAuthenticationEmail: userAuthenticationEmail,
-            userPhoneNumber: userPhoneNumber
-        )
+        self.riskCorrelationID = riskCorrelationID
+        self.shippingAddressOverride = shippingAddressOverride
+        self.userAuthenticationEmail = userAuthenticationEmail
+        self.userPhoneNumber = userPhoneNumber
     }
 
-    public override func parameters(
+    func parameters(
         with configuration: BTConfiguration,
         universalLink: URL? = nil,
         isPayPalAppInstalled: Bool = false
     ) -> [String: Any] {
-        var baseParameters = super.parameters(with: configuration)
+        var experienceProfile: [String: Any] = [:]
+
+        experienceProfile["no_shipping"] = !isShippingAddressRequired
+        experienceProfile["brand_name"] = displayName != nil ? displayName : configuration.json?["paypal"]["displayName"].asString()
+
+        if landingPageType?.stringValue != nil {
+            experienceProfile["landing_page_type"] = landingPageType?.stringValue
+        }
+
+        if localeCode?.stringValue != nil {
+            experienceProfile["locale_code"] = localeCode?.stringValue
+        }
+
+        experienceProfile["address_override"] = shippingAddressOverride != nil ? !isShippingAddressEditable : false
+
+        var baseParameters: [String: Any] = [:]
+
+        if merchantAccountID != nil {
+            baseParameters["merchant_account_id"] = merchantAccountID
+        }
+
+        if riskCorrelationID != nil {
+            baseParameters["correlation_id"] = riskCorrelationID
+        }
+        
+        if let lineItems, !lineItems.isEmpty {
+            let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
+            baseParameters["line_items"] = lineItemsArray
+        }
+        
+        if let userAuthenticationEmail, !userAuthenticationEmail.isEmpty {
+            baseParameters["payer_email"] = userAuthenticationEmail
+        }
+        
+        if let userPhoneNumberDict = try? userPhoneNumber?.toDictionary() {
+            baseParameters["phone_number"] = userPhoneNumberDict
+        }
+
+        baseParameters["return_url"] = BTCoreConstants.callbackURLScheme + "://\(Self.callbackURLHostAndPath)success"
+        baseParameters["cancel_url"] = BTCoreConstants.callbackURLScheme + "://\(Self.callbackURLHostAndPath)cancel"
+        baseParameters["experience_profile"] = experienceProfile
 
         if let universalLink, enablePayPalAppSwitch, isPayPalAppInstalled {
             let appSwitchParameters: [String: Any] = [

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -106,6 +106,7 @@ import BraintreeCore
         self.userPhoneNumber = userPhoneNumber
     }
 
+    // swiftlint:disable cyclomatic_complexity
     func parameters(
         with configuration: BTConfiguration,
         universalLink: URL? = nil,

--- a/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
@@ -163,6 +163,7 @@ extension BTPayPalCheckoutPOSTBody {
             }
         }
         
+        // swiftlint:disable nesting
         enum CodingKeys: String, CodingKey {
             case isShippingAddressRequired = "no_shipping"
             case displayName = "brand_name"

--- a/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
@@ -9,19 +9,62 @@ struct BTPayPalCheckoutPOSTBody: Encodable {
     
     // MARK: - Private Properties
     
+    private let amount: String
+    private let intent: String
+    private let offerPayLater: Bool
     private let userPhoneNumber: BTPayPalPhoneNumber?
     private let returnURL: String
     private let cancelURL: String
     private let experienceProfile: ExperienceProfile
     
-    private var merchantAccountID: String?
-    private var riskCorrelationID: String?
+    private var billingAgreementDescription: BillingAgreemeentDescription?
+    private var currencyCode: String?
     private var lineItems: [[String: String]]?
+    private var merchantAccountID: String?
+    private var requestBillingAgreement: Bool?
+    private var riskCorrelationID: String?
     private var userAuthenticationEmail: String?
+    
+    // Address properties
+    private var streetAddress: String?
+    private var extendedAddress: String?
+    private var locality: String?
+    private var countryCodeAlpha2: String?
+    private var postalCode: String?
+    private var region: String?
+    private var recipientName: String?
     
     // MARK: - Initializer
     
-    init(payPalRequest: BTPayPalRequest, configuration: BTConfiguration) {
+    init(payPalRequest: BTPayPalCheckoutRequest, configuration: BTConfiguration) {
+        self.amount = payPalRequest.amount
+        self.intent = payPalRequest.intent.stringValue
+        self.offerPayLater = payPalRequest.offerPayLater
+        
+        let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode
+        
+        if let currencyIsoCode {
+            self.currencyCode = currencyIsoCode
+        }
+        
+        if payPalRequest.requestBillingAgreement {
+            self.requestBillingAgreement = payPalRequest.requestBillingAgreement
+            
+            if let billingAgreementDescription = payPalRequest.billingAgreementDescription {
+                self.billingAgreementDescription = BillingAgreemeentDescription(description: billingAgreementDescription)
+            }
+        }
+        
+        if let shippingAddressOverride = payPalRequest.shippingAddressOverride {
+            self.streetAddress = shippingAddressOverride.streetAddress
+            self.extendedAddress = shippingAddressOverride.extendedAddress
+            self.locality = shippingAddressOverride.locality
+            self.countryCodeAlpha2 = shippingAddressOverride.countryCodeAlpha2
+            self.postalCode = shippingAddressOverride.postalCode
+            self.region = shippingAddressOverride.region
+            self.recipientName = shippingAddressOverride.recipientName
+        }
+        
         if let merchantAccountID = payPalRequest.merchantAccountID {
             self.merchantAccountID = merchantAccountID
         }
@@ -46,18 +89,46 @@ struct BTPayPalCheckoutPOSTBody: Encodable {
     }
     
     enum CodingKeys: String, CodingKey {
-        case merchantAccountID = "merchant_account_id"
-        case riskCorrelationID = "correlation_id"
+        case amount
+        case billingAgreementDescription = "billing_agreement_details"
+        case cancelURL = "cancel_url"
+        case currencyCode = "currency_iso_code"
+        case experienceProfile = "experience_profile"
+        case intent
         case lineItems = "line_items"
+        case merchantAccountID = "merchant_account_id"
+        case offerPayLater = "offer_pay_later"
+        case requestBillingAgreement = "request_billing_agreement"
+        case returnURL = "return_url"
+        case riskCorrelationID = "correlation_id"
         case userAuthenticationEmail = "payer_email"
         case userPhoneNumber = "phone_number"
-        case returnURL = "return_url"
-        case cancelURL = "cancel_url"
-        case experienceProfile = "experience_profile"
+        
+        // Address keys
+        case streetAddress = "line1"
+        case extendedAddress = "line2"
+        case locality = "city"
+        case countryCodeAlpha2 = "country_code"
+        case postalCode = "postal_code"
+        case region = "state"
+        case recipientName = "recipient_name"
     }
 }
 
 extension BTPayPalCheckoutPOSTBody {
+    
+    struct BillingAgreemeentDescription: Encodable {
+        
+        // MARK: - Private Properties
+        
+        private let description: String
+        
+        // MARK: - Initializer
+        
+        init(description: String) {
+            self.description = description
+        }
+    }
     
     struct ExperienceProfile: Encodable {
         
@@ -69,10 +140,11 @@ extension BTPayPalCheckoutPOSTBody {
         
         private var landingPageType: String?
         private var localeCode: String?
+        private var userAction: String?
         
         // MARK: - Initializer
         
-        init(payPalRequest: BTPayPalRequest, configuration: BTConfiguration) {
+        init(payPalRequest: BTPayPalCheckoutRequest, configuration: BTConfiguration) {
             self.displayName = payPalRequest.displayName != nil ? payPalRequest.displayName : configuration.displayName
             self.isShippingAddressRequired = !payPalRequest.isShippingAddressRequired
             
@@ -85,6 +157,10 @@ extension BTPayPalCheckoutPOSTBody {
             }
             
             self.shippingAddressOverride = payPalRequest.shippingAddressOverride != nil ? !payPalRequest.isShippingAddressEditable : false
+            
+            if payPalRequest.userAction != .none {
+                self.userAction = payPalRequest.userAction.stringValue
+            }
         }
         
         enum CodingKeys: String, CodingKey {
@@ -93,6 +169,7 @@ extension BTPayPalCheckoutPOSTBody {
             case landingPageType = "landing_page_type"
             case localeCode = "locale_code"
             case shippingAddressOverride = "address_override"
+            case userAction = "user_action"
         }
     }
 }

--- a/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/BTPayPalCheckoutPOSTBody.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif
+
+/// The POST body for v1/paypal_hermes/create_payment_resource
+struct BTPayPalCheckoutPOSTBody: Encodable {
+    
+    // MARK: - Private Properties
+    
+    private let userPhoneNumber: BTPayPalPhoneNumber?
+    private let returnURL: String
+    private let cancelURL: String
+    private let experienceProfile: ExperienceProfile
+    
+    private var merchantAccountID: String?
+    private var riskCorrelationID: String?
+    private var lineItems: [[String: String]]?
+    private var userAuthenticationEmail: String?
+    
+    // MARK: - Initializer
+    
+    init(payPalRequest: BTPayPalRequest, configuration: BTConfiguration) {
+        if let merchantAccountID = payPalRequest.merchantAccountID {
+            self.merchantAccountID = merchantAccountID
+        }
+        
+        if let riskCorrelationID = payPalRequest.riskCorrelationID {
+            self.riskCorrelationID = riskCorrelationID
+        }
+        
+        if let lineItems = payPalRequest.lineItems, !lineItems.isEmpty {
+            let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
+            self.lineItems = lineItemsArray
+        }
+        
+        if let userAuthenticationEmail = payPalRequest.userAuthenticationEmail, !userAuthenticationEmail.isEmpty {
+            self.userAuthenticationEmail = userAuthenticationEmail
+        }
+        
+        self.userPhoneNumber = payPalRequest.userPhoneNumber
+        self.returnURL = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)success"
+        self.cancelURL = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)cancel"
+        self.experienceProfile = ExperienceProfile(payPalRequest: payPalRequest, configuration: configuration)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case merchantAccountID = "merchant_account_id"
+        case riskCorrelationID = "correlation_id"
+        case lineItems = "line_items"
+        case userAuthenticationEmail = "payer_email"
+        case userPhoneNumber = "phone_number"
+        case returnURL = "return_url"
+        case cancelURL = "cancel_url"
+        case experienceProfile = "experience_profile"
+    }
+}
+
+extension BTPayPalCheckoutPOSTBody {
+    
+    struct ExperienceProfile: Encodable {
+        
+        // MARK: - Private Properties
+        
+        private let displayName: String?
+        private let isShippingAddressRequired: Bool
+        private let shippingAddressOverride: Bool
+        
+        private var landingPageType: String?
+        private var localeCode: String?
+        
+        // MARK: - Initializer
+        
+        init(payPalRequest: BTPayPalRequest, configuration: BTConfiguration) {
+            self.displayName = payPalRequest.displayName != nil ? payPalRequest.displayName : configuration.displayName
+            self.isShippingAddressRequired = !payPalRequest.isShippingAddressRequired
+            
+            if let landingPageType = payPalRequest.landingPageType?.stringValue {
+                self.landingPageType = landingPageType
+            }
+            
+            if let localeCode = payPalRequest.localeCode?.stringValue {
+                self.localeCode = localeCode
+            }
+            
+            self.shippingAddressOverride = payPalRequest.shippingAddressOverride != nil ? !payPalRequest.isShippingAddressEditable : false
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case isShippingAddressRequired = "no_shipping"
+            case displayName = "brand_name"
+            case landingPageType = "landing_page_type"
+            case localeCode = "locale_code"
+            case shippingAddressOverride = "address_override"
+        }
+    }
+}

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -5,7 +5,7 @@ import BraintreeCore
 #endif
 
 /// The POST body for v1/paypal_hermes/create_payment_resource
-struct BTPayPalCheckoutPOSTBody: Encodable {
+struct PayPalCheckoutPOSTBody: Encodable {
     
     // MARK: - Private Properties
     
@@ -115,7 +115,7 @@ struct BTPayPalCheckoutPOSTBody: Encodable {
     }
 }
 
-extension BTPayPalCheckoutPOSTBody {
+extension PayPalCheckoutPOSTBody {
     
     struct BillingAgreemeentDescription: Encodable {
         

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -4,7 +4,7 @@ import Foundation
 import BraintreeCore
 #endif
 
-/// The POST body for v1/paypal_hermes/create_payment_resource
+/// The POST body for `v1/paypal_hermes/create_payment_resource`
 struct PayPalCheckoutPOSTBody: Encodable {
     
     // MARK: - Private Properties

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -19,7 +19,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
     
     private var billingAgreementDescription: BillingAgreemeentDescription?
     private var currencyCode: String?
-    private var lineItems: [[String: String]]?
+    private var lineItems: [BTPayPalLineItem]?
     private var merchantAccountID: String?
     private var requestBillingAgreement: Bool?
     private var riskCorrelationID: String?
@@ -74,8 +74,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
         }
         
         if let lineItems = payPalRequest.lineItems, !lineItems.isEmpty {
-            let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
-            self.lineItems = lineItemsArray
+            self.lineItems = lineItems
         }
         
         if let userAuthenticationEmail = payPalRequest.userAuthenticationEmail, !userAuthenticationEmail.isEmpty {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -441,8 +441,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testHandleBrowserSwitchReturn_whenBrowserSwitchSucceeds_merchantAccountIdIsSet() {
         let merchantAccountID = "alternate-merchant-account-id"
-        payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
-        payPalClient.payPalRequest?.merchantAccountID = merchantAccountID
+        payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34", merchantAccountID: merchantAccountID)
 
         let returnURL = URL(string: "bar://onetouch/v1/success?token=hermes_token")!
         payPalClient.handleReturn(returnURL, paymentType: .checkout) { _, _ in }
@@ -493,8 +492,7 @@ class BTPayPalClient_Tests: XCTestCase {
 
     func testHandleBrowserSwitchReturn_whenBrowserSwitchSucceeds_parametersAreConstructedAsExpected() {
         let merchantAccountID = "alternate-merchant-account-id"
-        payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34")
-        payPalClient.payPalRequest?.merchantAccountID = merchantAccountID
+        payPalClient.payPalRequest = BTPayPalCheckoutRequest(amount: "1.34", merchantAccountID: merchantAccountID)
         payPalClient.clientMetadataID = "a-fake-cmid"
 
         let returnURL = URL(string: "bar://onetouch/v1/success?token=hermes_token")!


### PR DESCRIPTION
### Summary of changes

- Add `PayPalRequest` protocol to define the contract for the base properties for `BTPayPalCheckoutRequest` and `BTPayPalVaultRequest`
- Conform to the new protocol in the three concrete classes (BTPayPalRequest, BTPayPalCheckoutRequest and BTPayPalVaultRequest) to eliminate inheritance
- Update docstrings for classes BTPayPalCheckoutRequest and BTPayPalVaultRequest
- LineItems now conforms to the Encodable protocol.
- Add encodable types for `post` bodies used in the PayPal Checkout flow.
- PayPal Checkout has been tested in the Demo app to ensure the dictionaries are still constructed as expected.

**Note**: Since we have two different classes (`PayPalCheckoutRequest` and `PayPalVaultRequest`) used in `PayPalClient`, it's currently not possible to use `Encodable` until the same implementation is done for `PayPalVaultRequest`. We tested the flow, but we need to complete task `DTMOBILES-1177` to be able to use `Encodable`.

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
