### PR TITLE
Lpm accounts encodable

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		458570782C34A699009CEF7A /* ConfigurationLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */; };
 		4585707A2C34B1E1009CEF7A /* MockClientAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */; };
 		4585707C2C34B7B5009CEF7A /* MockConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */; };
+		45E8CE522D2C920000D7A2DC /* LocalPaymentAccountsPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8CE512D2C91F000D7A2DC /* LocalPaymentAccountsPOSTBody.swift */; };
 		45EFC3972C2DBF32005E7F5B /* ConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
@@ -725,6 +726,7 @@
 		458570772C34A699009CEF7A /* ConfigurationLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader_Tests.swift; sourceTree = "<group>"; };
 		458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClientAuthorization.swift; sourceTree = "<group>"; };
 		4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationLoader.swift; sourceTree = "<group>"; };
+		45E8CE512D2C91F000D7A2DC /* LocalPaymentAccountsPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPaymentAccountsPOSTBody.swift; sourceTree = "<group>"; };
 		45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1308,6 +1310,7 @@
 		454722AE2CF0DA14000DCF4E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				45E8CE512D2C91F000D7A2DC /* LocalPaymentAccountsPOSTBody.swift */,
 				454722AF2CF0DA27000DCF4E /* LocalPaymentPOSTBody.swift */,
 			);
 			path = Models;
@@ -3075,6 +3078,7 @@
 				454722B02CF0DA34000DCF4E /* LocalPaymentPOSTBody.swift in Sources */,
 				80BA64B229D7937E00E15264 /* BTLocalPaymentRequest.swift in Sources */,
 				BE9834A22A041B6200B6C3CC /* BTConfiguration+LocalPayment.swift in Sources */,
+				45E8CE522D2C920000D7A2DC /* LocalPaymentAccountsPOSTBody.swift in Sources */,
 				80CF988529DB64D400D51979 /* BTLocalPaymentError.swift in Sources */,
 				80BA64AC29D788E000E15264 /* BTLocalPaymentResult.swift in Sources */,
 				3B57E9EA29ECC1AF00245174 /* BTLocalPaymentAnalytics.swift in Sources */,

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -121,34 +121,12 @@ import BraintreeDataCollector
             return
         }
 
-        var paypalAccount: [String: Any] = [
-            "response": ["webURL": url.absoluteString],
-            "response_type": "web",
-            "options": ["validate": false],
-            "intent": "sale"
-        ]
-
-        if let correlationID = request?.correlationID {
-            paypalAccount["correlation_id"] = correlationID
-        }
-
-        var requestParameters: [String: Any] = [:]
-
-        if let merchantAccountID = request?.merchantAccountID {
-            requestParameters["merchant_account_id"] = merchantAccountID
-        }
-
-        requestParameters["paypal_account"] = paypalAccount
-
-        let metadataParameters: [String: String] = [
-            "source": apiClient.metadata.source.stringValue,
-            "integration": apiClient.metadata.integration.stringValue,
-            "sessionId": apiClient.metadata.sessionID
-        ]
-
-        requestParameters["_meta"] = metadataParameters
-
-        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: requestParameters) { [weak self] body, _, error in
+        let localPaymentPayPalAccountRequest = LocalPaymentPayPalAccountsPOSTBody(
+            request: request,
+            clientMetadata: apiClient.metadata,
+            url: url
+        )
+        apiClient.post("/v1/payment_methods/paypal_accounts", parameters: localPaymentPayPalAccountRequest) { [weak self] body, _, error in
             guard let self else {
                 NSLog("%@ BTLocalPaymentClient has been deallocated.", BTLogLevelDescription.string(for: .critical))
                 return

--- a/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
+++ b/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif

--- a/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
+++ b/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
@@ -3,3 +3,94 @@ import Foundation
 #if canImport(BraintreeCore)
 import BraintreeCore
 #endif
+
+/// The POST body for v1/payment_methods/paypal_accounts
+struct LocalPaymentPayPalAccountsPOSTBody: Encodable {
+    
+    // MARK: - Private Properties
+    
+    private let paypalAccount: LocalPaymentPayPalAccount
+    private let meta: LocalPaymentPayPalAccountMetadata
+    
+    private var merchantAccountID: String?
+    
+    init(
+        request: BTLocalPaymentRequest?,
+        clientMetadata: BTClientMetadata,
+        url: URL
+    ) {
+        self.meta = LocalPaymentPayPalAccountMetadata(clientMetadata: clientMetadata)
+        self.paypalAccount = LocalPaymentPayPalAccount(request: request, url: url)
+        
+        if let merchantAccountID = request?.merchantAccountID {
+            self.merchantAccountID = merchantAccountID
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case merchantAccountID = "merchant_account_id"
+        case meta = "_meta"
+        case paypalAccount = "paypal_account"
+    }
+}
+
+extension LocalPaymentPayPalAccountsPOSTBody {
+    
+    struct LocalPaymentPayPalAccount: Encodable {
+        
+        let intent = "sale"
+        let response: Response
+        let responseType = "web"
+        let options = [Option()]
+        
+        var correlationID: String?
+        
+        // swiftlint:disable nesting
+        struct Option: Encodable {
+            
+            let validate = false
+        }
+        
+        // swiftlint:disable nesting
+        struct Response: Encodable {
+            
+            let webURL: String
+        }
+        
+        init(request: BTLocalPaymentRequest?, url: URL) {
+            self.response = Response(webURL: url.absoluteString)
+            
+            if let correlationID = request?.correlationID {
+                self.correlationID = correlationID
+            }
+        }
+        
+        // swiftlint:disable nesting
+        enum CodingKeys: String, CodingKey {
+            case correlationID = "correlation_id"
+            case intent
+            case options
+            case responseType = "response_type"
+        }
+    }
+    
+    struct LocalPaymentPayPalAccountMetadata: Encodable {
+        
+        let integration: String
+        let sessionID: String
+        let source: String
+        
+        init(clientMetadata: BTClientMetadata) {
+            self.integration = clientMetadata.integration.stringValue
+            self.sessionID = clientMetadata.sessionID
+            self.source = clientMetadata.source.stringValue
+        }
+        
+        // swiftlint:disable nesting
+        enum CodingKeys: String, CodingKey {
+            case integration
+            case sessionID = "sessionId"
+            case source
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Add encodable types for `post` bodies used in the LocalPayment PayPal Accounts flow.
- LocalPaymentPayPalAccounts has been tested in the Demo app to ensure the dictionaries are still constructed as expected.

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 