### PR TITLE
Remove `paymentMethodsDisplayed`

### DIFF
--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -54,8 +54,6 @@ struct FPTIBatchData: Codable {
         let merchantExperiment: String?
         /// The type of page where the payment button is displayed or where an event occured.
         let pageType: String?
-        /// The list of payment methods displayed, in the same order in which they are rendered on the page, associated with the `BTShopperInsights` flow.
-        let paymentMethodsDisplayed: String?
         /// Used for linking events from the client to server side request
         /// This value will be PayPal Order ID, Payment Token, EC token, Billing Agreement, or Venmo Context ID depending on the flow
         let payPalContextID: String?
@@ -84,7 +82,6 @@ struct FPTIBatchData: Codable {
             linkType: String? = nil,
             merchantExperiment: String? = nil,
             pageType: String? = nil,
-            paymentMethodsDisplayed: String? = nil,
             payPalContextID: String? = nil,
             requestStartTime: Int? = nil,
             shopperSessionID: String? = nil,
@@ -104,7 +101,6 @@ struct FPTIBatchData: Codable {
             self.linkType = linkType
             self.merchantExperiment = merchantExperiment
             self.pageType = pageType
-            self.paymentMethodsDisplayed = paymentMethodsDisplayed
             self.payPalContextID = payPalContextID
             self.requestStartTime = requestStartTime
             self.shopperSessionID = shopperSessionID
@@ -124,7 +120,6 @@ struct FPTIBatchData: Codable {
             case linkType = "link_type"
             case merchantExperiment = "experiment"
             case pageType = "page_type"
-            case paymentMethodsDisplayed = "payment_methods_displayed"
             case payPalContextID = "paypal_context_id"
             case requestStartTime = "request_start_time"
             case timestamp = "t"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -313,7 +313,6 @@ import Foundation
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
         pageType: String? = nil,
-        paymentMethodsDisplayed: String? = nil,
         payPalContextID: String? = nil,
         shopperSessionID: String? = nil
     ) {
@@ -330,7 +329,6 @@ import Foundation
                 linkType: linkType?.rawValue,
                 merchantExperiment: merchantExperiment,
                 pageType: pageType,
-                paymentMethodsDisplayed: paymentMethodsDisplayed,
                 payPalContextID: payPalContextID,
                 shopperSessionID: shopperSessionID
             )

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -19,7 +19,6 @@ public class MockAPIClient: BTAPIClient {
     public var postedLinkType: LinkType? = nil
     public var postedMerchantExperiment: String? = nil
     public var postedPageType: String? = nil
-    public var postedPaymentMethodsDisplayed: String? = nil
     public var postedPayPalContextID: String? = nil
     public var postedShopperSessionID: String? = nil
     
@@ -107,7 +106,6 @@ public class MockAPIClient: BTAPIClient {
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
         pageType: String? = nil,
-        paymentMethodsDisplayed: String? = nil,
         payPalContextID: String? = nil,
         shopperSessionID: String? = nil
     ) {
@@ -118,7 +116,6 @@ public class MockAPIClient: BTAPIClient {
         postedLinkType = linkType
         postedIsVaultRequest = isVaultRequest ?? false
         postedMerchantExperiment = experiment
-        postedPaymentMethodsDisplayed = paymentMethodsDisplayed
         postedAppSwitchURL[eventName] = appSwitchURL?.absoluteString
         postedAnalyticsEvents.append(eventName)
         postedShopperSessionID = shopperSessionID


### PR DESCRIPTION
### Summary of changes

- Remove `paymentMethodsDisplayed` - no longer needed for v1.5 of Shopper Insights

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
