### PR TITLE
Add Payer Email to Base Parameters if not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased 
+* BraintreePayPal
+  * Fix bug to ensure that `BTPayPalVaultRequest.userAuthenticationEmail` is not sent as an empty string
+
 ## 6.25.0 (2024-12-11)
 * BraintreePayPal
   * Add `BTPayPalRequest.userPhoneNumber` optional property

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -68,7 +68,7 @@ import BraintreeCore
     ) -> [String: Any] {
         var baseParameters = super.parameters(with: configuration)
 
-        if let userAuthenticationEmail {
+        if let userAuthenticationEmail, !userAuthenticationEmail.isEmpty {
             baseParameters["payer_email"] = userAuthenticationEmail
         }
 


### PR DESCRIPTION
### Summary of changes

- Add a conditional check to ensure that the userAuthenticationEmail is not empty before setting it as the payer_email in baseParameters. 

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
