### PR TITLE
[OPEN DEV] Move BraintreeShopperInsightsTests to Demo

### DIFF
--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -262,6 +262,16 @@
                ReferencedContainer = "container:../Braintree.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8046983D2B27C5530090878E"
+               BuildableName = "BraintreeShopperInsightsTests.xctest"
+               BlueprintName = "BraintreeShopperInsightsTests"
+               ReferencedContainer = "container:../Braintree.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
### Summary of changes

- Move `BraintreeShopperInsightsTests` into the Demo apps testable reference with all of our other tests

| Before | After |
|-----|-----|
|![Screenshot 2025-01-10 at 8 49 07 AM](https://github.com/user-attachments/assets/6cee7890-aeee-413b-b3d2-160b4c031a41)|<img width="281" alt="Screenshot 2025-01-10 at 1 01 41 PM" src="https://github.com/user-attachments/assets/f75312c7-a060-4cb1-85c7-7ffc1690e5ad" />|

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
