### PR TITLE
Bug Fix: Handle Missing 3DS `dfReferenceId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeThreeDSecure
+  * Return error if no `dfReferenceId` is returned in the 3D Secure flow
+
 ## 6.25.0 (2024-12-11)
 * BraintreePayPal
   * Add `BTPayPalRequest.userPhoneNumber` optional property

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -250,8 +250,12 @@ import BraintreeCore
                     request: request,
                     cardinalSession: cardinalSession
                 ) { lookupParameters in
-                    guard let dfReferenceID = lookupParameters?["dfReferenceId"] else {
-                        completion(BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "There was an error retrieving the dfReferenceId."]))
+                    guard let dfReferenceID = lookupParameters?["dfReferenceId"], !dfReferenceID.isEmpty else {
+                        completion(
+                            BTThreeDSecureError.failedLookup(
+                                [NSLocalizedDescriptionKey: "There was an error retrieving the dfReferenceId."]
+                            )
+                        )
                         return
                     }
 

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -250,9 +250,12 @@ import BraintreeCore
                     request: request,
                     cardinalSession: cardinalSession
                 ) { lookupParameters in
-                    if let dfReferenceID = lookupParameters?["dfReferenceId"] {
-                        request.dfReferenceID = dfReferenceID
+                    guard let dfReferenceID = lookupParameters?["dfReferenceId"] else {
+                        completion(BTThreeDSecureError.failedLookup([NSLocalizedDescriptionKey: "There was an error retrieving the dfReferenceId."]))
+                        return
                     }
+
+                    request.dfReferenceID = dfReferenceID
                     completion(nil)
                 }
             } else {

--- a/UnitTests/BraintreeThreeDSecureTests/MockCardinalSession.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/MockCardinalSession.swift
@@ -3,7 +3,9 @@ import CardinalMobile
 @testable import BraintreeThreeDSecure
 
 class MockCardinalSession: CardinalSessionTestable {
-    
+
+    var dfReferenceID = "fake-df-reference-id"
+
     func configure(_ sessionConfig: CardinalSessionConfiguration) {
         // do nothing
     }
@@ -13,7 +15,7 @@ class MockCardinalSession: CardinalSessionTestable {
         completed didCompleteHandler: @escaping CardinalSessionSetupDidCompleteHandler,
         validated didValidateHandler: @escaping CardinalSessionSetupDidValidateHandler
     ) {
-        didCompleteHandler("fake-df-reference-id")
+        didCompleteHandler(dfReferenceID)
     }
     
     func continueWith(transactionId: String, payload: String, validationDelegate: CardinalValidationDelegate) {


### PR DESCRIPTION
### Summary of changes

- Return error if no `dfReferenceId` is returned in the 3D Secure flow
    - Confirmed with Cardinal that we should not continue the flow if we do not get a `dfReferenceId` back, there is also no fallback mechanism on mobile like exists on web

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 