### PR TITLE
[V7] Update workflows to use Xcode 16.2.0 + Swift Version 5.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   cocoapods:
     name: CocoaPods (Xcode 16.2.0)
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
         run: pod lib lint
   carthage:
     name: Carthage (Xcode 16.2.0)
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
     name: SPM (Xcode 16.2.0)
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 16.0)
+    name: CocoaPods (Xcode 16.2.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -13,14 +13,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
-    name: Carthage (Xcode 16.0)
+    name: Carthage (Xcode 16.2.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -29,8 +29,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -47,7 +47,7 @@ jobs:
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
-    name: SPM (Xcode 16.0)
+    name: SPM (Xcode 16.2.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -55,8 +55,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 15.0.1)
+    name: CocoaPods (Xcode 16.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -13,14 +13,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   carthage:
-    name: Carthage (Xcode 15.0.1)
+    name: Carthage (Xcode 16.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -29,8 +29,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Remove SPMTest
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -47,7 +47,7 @@ jobs:
       - name: Build CarthageTest
         run: xcodebuild -project 'SampleApps/CarthageTest/CarthageTest.xcodeproj' -scheme 'CarthageTest' clean build CODE_SIGNING_ALLOWED=NO
   spm:
-    name: SPM (Xcode 15.0.1)
+    name: SPM (Xcode 16.0)
     runs-on: macOS-14-xlarge
     steps:
       - name: Check out repository
@@ -55,8 +55,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -30,12 +30,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -45,11 +45,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,21 +6,21 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -30,12 +30,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -45,11 +45,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.2
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
@@ -30,8 +30,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
@@ -45,8 +45,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 16.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies
@@ -30,8 +30,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
@@ -45,8 +45,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.0.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Use Xcode 16.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.0.app
       - name: Install Package dependencies
         run: swift package resolve
       - name: Install CocoaPod dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.2' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-14-xlarge
+    runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14-xlarge
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14-xlarge
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator18.1' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=18.1,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.platform         = :ios, "16.0"
   s.compiler_flags   = "-Wall -Werror -Wextra"
-  s.swift_version    = "5.9"
+  s.swift_version    = "5.10"
 
   s.default_subspecs = %w[Core Card PayPal]
 

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -146,17 +146,6 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9CE5179A282D54030013C740"
-               BuildableName = "BraintreePayPalNativeCheckoutTests.xctest"
-               BlueprintName = "BraintreePayPalNativeCheckoutTests"
-               ReferencedContainer = "container:Braintree.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "BE642D8E27D0132A00694A5B"
                BuildableName = "BraintreeSEPADirectDebitTests.xctest"
                BlueprintName = "BraintreeSEPADirectDebitTests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased (v7)
+* Require Xcode 16.2+ and Swift 5.10+
 * Breaking Changes
   * Bump minimum supported deployment target to iOS 16+
   * `countryCodeAlpha2` now returns a 2 character country code instead of a 3 character country code 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 Welcome to Braintree's iOS SDK. This library will help you accept card and alternative payments in your iOS app.
 
+**The Braintree iOS SDK permits a deployment target of iOS 16.0 or higher**. It requires Xcode 16.2+ and Swift 5.10+.
+
 ## 📣 Announcements
 
 - **Upgrade your integration to continue accepting Braintree payments** 📣 The SSL certificates for current iOS SDK versions (v5 and v6) are set to expire by June 31, 2025. Upgrade to v5.26.0+ and v6.17.0+, respectively, to continue using the Braintree SDK. [Click here for more details](https://github.com/braintree/braintree_ios/issues/1277)
 
 - v6 is the latest major version of Braintree iOS. To update from v5, see the [v6 migration guide](https://github.com/braintree/braintree_ios/blob/main/V6_MIGRATION.md). If you have not yet migrated to v5, see the [v5 migration guide](https://github.com/braintree/braintree_ios/blob/5.x/V5_MIGRATION.md)
-
-**The Braintree iOS SDK permits a deployment target of iOS 16.0 or higher**. It requires Xcode 15.0+ and Swift 5.9+.
 
 ## Supported Payment Methods
 

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -17,7 +17,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 
 ## Supported Versions
 
-v7 bumps to a minimum deployment target of iOS 16+.
+v7 supports a minimum deployment target of iOS 16+. It requires the use of Xcode 16.2+ and Swift 5.10+.
 
 ## Card
 v7 updates `BTCard` to require setting all properties through the initializer, removing support for dot syntax. To construct a `BTCard`, pass the properties directly in the initializer.


### PR DESCRIPTION
### Summary of changes

- Update all workflow to use Xcode 16.2.0 ([resource](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode))
- Bump `Package.swift` and `Braintree.podspec` to use Swift 5.10
- Update CHANGELOG, Migration guide and Readme

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @richherrera 
