### PR TITLE
Allow Merchant to Only Set Universal Links for Venmo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeVenmo
+  * Allow universal links to be set without a return URL scheme (fixes #1505)
+
 ## 6.27.0 (2025-01-23)
 * BraintreePayPal
   * Add `BTContactInformation` request object
@@ -11,8 +15,6 @@
   * Add `shippingCallbackURL` to `BTPayPalCheckoutRequest`
 * BraintreeThreeDSecure
   * Return error if no `dfReferenceId` is returned in the 3D Secure flow
-* BraintreeVenmo
-  * Allow universal links to be set without a return URL scheme
 
 ## 6.25.0 (2024-12-11)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Fix bug to ensure that `BTPayPalVaultRequest.userAuthenticationEmail` is not sent as an empty string
 * BraintreeThreeDSecure
   * Return error if no `dfReferenceId` is returned in the 3D Secure flow
+* BraintreeVenmo
+  * Allow universal links to be set without a return URL scheme
 
 ## 6.25.0 (2024-12-11)
 * BraintreePayPal

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -8,22 +8,19 @@ class VenmoViewController: PaymentButtonBaseViewController {
 
     let webFallbackToggle = Toggle(title: "Enable Web Fallback")
     let vaultToggle = Toggle(title: "Vault")
+    let universalLinkReturnToggle = Toggle(title: "Use Universal Link Return")
 
     override func viewDidLoad() {
         super.heightConstraint = 150
         super.viewDidLoad()
-        venmoClient = BTVenmoClient(
-            apiClient: apiClient,
-            // swiftlint:disable:next force_unwrapping
-            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
-        )
+        venmoClient = BTVenmoClient(apiClient: apiClient)
         title = "Custom Venmo Button"
     }
     
     override func createPaymentButton() -> UIView {
         let venmoButton = createButton(title: "Venmo", action: #selector(tappedVenmo))
 
-        let stackView = UIStackView(arrangedSubviews: [webFallbackToggle, vaultToggle, venmoButton])
+        let stackView = UIStackView(arrangedSubviews: [webFallbackToggle, vaultToggle, universalLinkReturnToggle, venmoButton])
         stackView.axis = .vertical
         stackView.spacing = 15
         stackView.alignment = .fill
@@ -44,6 +41,14 @@ class VenmoViewController: PaymentButtonBaseViewController {
         
         if vaultToggle.isOn {
             venmoRequest.vault = true
+        }
+
+        if universalLinkReturnToggle.isOn {
+            venmoClient = BTVenmoClient(
+                apiClient: apiClient,
+                // swiftlint:disable:next force_unwrapping
+                universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+            )
         }
 
         Task {

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -8,19 +8,21 @@ class VenmoViewController: PaymentButtonBaseViewController {
 
     let webFallbackToggle = Toggle(title: "Enable Web Fallback")
     let vaultToggle = Toggle(title: "Vault")
-    let universalLinkReturnToggle = Toggle(title: "Use Universal Link Return")
 
     override func viewDidLoad() {
         super.heightConstraint = 150
         super.viewDidLoad()
-        venmoClient = BTVenmoClient(apiClient: apiClient)
+        venmoClient = BTVenmoClient(
+            apiClient: apiClient,
+            universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
+        )
         title = "Custom Venmo Button"
     }
     
     override func createPaymentButton() -> UIView {
         let venmoButton = createButton(title: "Venmo", action: #selector(tappedVenmo))
 
-        let stackView = UIStackView(arrangedSubviews: [webFallbackToggle, vaultToggle, universalLinkReturnToggle, venmoButton])
+        let stackView = UIStackView(arrangedSubviews: [webFallbackToggle, vaultToggle, venmoButton])
         stackView.axis = .vertical
         stackView.spacing = 15
         stackView.alignment = .fill
@@ -41,14 +43,6 @@ class VenmoViewController: PaymentButtonBaseViewController {
         
         if vaultToggle.isOn {
             venmoRequest.vault = true
-        }
-
-        if universalLinkReturnToggle.isOn {
-            venmoClient = BTVenmoClient(
-                apiClient: apiClient,
-                // swiftlint:disable:next force_unwrapping
-                universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
-            )
         }
 
         Task {

--- a/Demo/Application/Features/VenmoViewController.swift
+++ b/Demo/Application/Features/VenmoViewController.swift
@@ -14,6 +14,7 @@ class VenmoViewController: PaymentButtonBaseViewController {
         super.viewDidLoad()
         venmoClient = BTVenmoClient(
             apiClient: apiClient,
+            // swiftlint:disable:next force_unwrapping
             universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
         )
         title = "Custom Venmo Button"

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -93,7 +93,10 @@ import BraintreeCore
                 completion: completion
             )
             return
-        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) && (universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil) {
+        } else if
+            let bundleIdentifier = bundle.bundleIdentifier,
+                !returnURLScheme.hasPrefix(bundleIdentifier)
+                && (universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil) {
             NSLog(
                 // swiftlint:disable:next line_length
                 "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -83,26 +83,24 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault, linkType: linkType)
         let returnURLScheme = BTAppContextSwitcher.sharedInstance._returnURLScheme
 
-        if universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil {
-            if returnURLScheme.isEmpty {
-                NSLog(
-                    "%@ Venmo requires a return URL scheme or universal link to be configured.",
-                    BTLogLevelDescription.string(for: .critical)
-                )
-                notifyFailure(
-                    with: BTVenmoError.invalidReturnURL("Venmo requires a return URL scheme or universal link to be configured."),
-                    completion: completion
-                )
-                return
-            } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
-                NSLog(
-                    // swiftlint:disable:next line_length
-                    "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",
-                    BTLogLevelDescription.string(for: .critical),
-                    bundleIdentifier,
-                    returnURLScheme
-                )
-            }
+        if universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil && returnURLScheme.isEmpty {
+            NSLog(
+                "%@ Venmo requires a return URL scheme or universal link to be configured.",
+                BTLogLevelDescription.string(for: .critical)
+            )
+            notifyFailure(
+                with: BTVenmoError.invalidReturnURL("Venmo requires a return URL scheme or universal link to be configured."),
+                completion: completion
+            )
+            return
+        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
+            NSLog(
+                // swiftlint:disable:next line_length
+                "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",
+                BTLogLevelDescription.string(for: .critical),
+                bundleIdentifier,
+                returnURLScheme
+            )
         }
 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -83,7 +83,7 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault, linkType: linkType)
         let returnURLScheme = BTAppContextSwitcher.sharedInstance._returnURLScheme
 
-        if universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil && returnURLScheme.isEmpty {
+        if (universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil) && returnURLScheme.isEmpty {
             NSLog(
                 "%@ Venmo requires a return URL scheme or universal link to be configured.",
                 BTLogLevelDescription.string(for: .critical)
@@ -93,7 +93,7 @@ import BraintreeCore
                 completion: completion
             )
             return
-        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
+        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) && (universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil) {
             NSLog(
                 // swiftlint:disable:next line_length
                 "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -89,7 +89,10 @@ import BraintreeCore
                     "%@ Venmo requires a return URL scheme or universal link to be configured.",
                     BTLogLevelDescription.string(for: .critical)
                 )
-                notifyFailure(with: BTVenmoError.appNotAvailable, completion: completion)
+                notifyFailure(
+                    with: BTVenmoError.invalidReturnURL("Venmo requires a return URL scheme or universal link to be configured."),
+                    completion: completion
+                )
                 return
             } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
                 NSLog(

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -83,21 +83,23 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault, linkType: linkType)
         let returnURLScheme = BTAppContextSwitcher.sharedInstance._returnURLScheme
 
-        if let universalLink, universalLink.absoluteString.isEmpty || returnURLScheme.isEmpty {
-            NSLog(
-                "%@ Venmo requires a return URL scheme or universal link to be configured.",
-                BTLogLevelDescription.string(for: .critical)
-            )
-            notifyFailure(with: BTVenmoError.appNotAvailable, completion: completion)
-            return
-        } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
-            NSLog(
-                // swiftlint:disable:next line_length
-                "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",
-                BTLogLevelDescription.string(for: .critical),
-                bundleIdentifier,
-                returnURLScheme
-            )
+        if universalLink?.absoluteString.isEmpty == true || universalLink?.absoluteString == nil {
+            if returnURLScheme.isEmpty {
+                NSLog(
+                    "%@ Venmo requires a return URL scheme or universal link to be configured.",
+                    BTLogLevelDescription.string(for: .critical)
+                )
+                notifyFailure(with: BTVenmoError.appNotAvailable, completion: completion)
+                return
+            } else if let bundleIdentifier = bundle.bundleIdentifier, !returnURLScheme.hasPrefix(bundleIdentifier) {
+                NSLog(
+                    // swiftlint:disable:next line_length
+                    "%@ Venmo requires [BTAppContextSwitcher setReturnURLScheme:] to be configured to begin with your app's bundle ID (%@). Currently, it is set to (%@)",
+                    BTLogLevelDescription.string(for: .critical),
+                    bundleIdentifier,
+                    returnURLScheme
+                )
+            }
         }
 
         apiClient.fetchOrReturnRemoteConfiguration { configuration, error in

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -83,9 +83,9 @@ import BraintreeCore
         apiClient.sendAnalyticsEvent(BTVenmoAnalytics.tokenizeStarted, isVaultRequest: shouldVault, linkType: linkType)
         let returnURLScheme = BTAppContextSwitcher.sharedInstance._returnURLScheme
 
-        if returnURLScheme.isEmpty {
+        if let universalLink, universalLink.absoluteString.isEmpty || returnURLScheme.isEmpty {
             NSLog(
-                "%@ Venmo requires a return URL scheme to be configured via [BTAppContextSwitcher setReturnURLScheme:]",
+                "%@ Venmo requires a return URL scheme or universal link to be configured.",
                 BTLogLevelDescription.string(for: .critical)
             )
             notifyFailure(with: BTVenmoError.appNotAvailable, completion: completion)

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -80,7 +80,7 @@ class BTVenmoClient_Tests: XCTestCase {
         
         let expectation = expectation(description: "authorization callback")
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
-            guard let error = error as NSError? else {return}
+            guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTVenmoError.errorDomain)
             XCTAssertEqual(error.code, BTVenmoError.invalidReturnURL("").errorCode)
             expectation.fulfill()

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -82,7 +82,7 @@ class BTVenmoClient_Tests: XCTestCase {
         venmoClient.tokenize(venmoRequest) { venmoAccount, error in
             guard let error = error as NSError? else {return}
             XCTAssertEqual(error.domain, BTVenmoError.errorDomain)
-            XCTAssertEqual(error.code, BTVenmoError.appNotAvailable.errorCode)
+            XCTAssertEqual(error.code, BTVenmoError.invalidReturnURL("").errorCode)
             expectation.fulfill()
         }
 

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -89,6 +89,20 @@ class BTVenmoClient_Tests: XCTestCase {
         waitForExpectations(timeout: 2)
     }
 
+    func testTokenizeVenmoAccount_whenReturnURLSchemeAndUniversalLinkIsNil_andCallsBackWithError() {
+        let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
+
+        let expectation = expectation(description: "authorization callback")
+        venmoClient.tokenize(venmoRequest) { venmoAccount, error in
+            guard let error = error as NSError? else {return}
+            XCTAssertEqual(error.domain, BTVenmoError.errorDomain)
+            XCTAssertEqual(error.code, BTVenmoError.appNotAvailable.errorCode)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+
     func testTokenizeVenmoAccount_whenPaymentMethodUsageSet_createsPaymentContext() {
         let venmoClient = BTVenmoClient(apiClient: mockAPIClient)
         venmoRequest.displayName = "app-display-name"


### PR DESCRIPTION
### Summary of changes

- A bug was recently brought to the service channel where if a merchant trys to move from the deprecated `BTAppContextSwitcher.sharedInstance.returnURLScheme` for Venmo they get an error if only passing a universal link. We should allow merchants to only use universal links without needing to set both that and a `returnURLScheme`

I tested the following flows on device, please feel free to retest these or call out any use cases I missed:
- `universalLink` and `returnURLScheme` not set (returns an error)
- only `returnURLScheme` set (uses `returnURLScheme` for switch and return)
- only `universalLink` set (uses `universalLink`  for switch and return)

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
