### PR TITLE
Launch PayPal App For Checkout Flow

### DIFF
--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -107,6 +107,11 @@
                BlueprintName = "BraintreePayPalTests"
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BTPayPalClient_Tests/testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO"

--- a/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Braintree.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -107,11 +107,6 @@
                BlueprintName = "BraintreePayPalTests"
                ReferencedContainer = "container:Braintree.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "BTPayPalClient_Tests/testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO"

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,7 +366,7 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
-                    guard let _ = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
+                    guard (self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken) != nil else {
                         self.notifyFailure(
                             with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
                             completion: completion

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,6 +366,13 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
+                    guard let token = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
+                        self.notifyFailure(
+                            with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
+                            completion: completion
+                        )
+                        return
+                    }
                     self.launchPayPalApp(with: url, completion: completion)
                 case .webBrowser(let url):
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,7 +366,7 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
-                    guard let token = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
+                    guard let _ = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
                         self.notifyFailure(
                             with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
                             completion: completion

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,13 +366,6 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
-                    guard let token = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
-                        self.notifyFailure(
-                            with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
-                            completion: completion
-                        )
-                        return
-                    }
                     self.launchPayPalApp(with: url, completion: completion)
                 case .webBrowser(let url):
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)
@@ -397,6 +390,7 @@ import BraintreeDataCollector
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000))))
         ]
+        
         urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)
         
         guard let redirectURL = urlComponents?.url else {

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,12 +366,14 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
-                    guard let baToken = approvalURL.baToken else {
-                        self.notifyFailure(with: BTPayPalError.missingBAToken, completion: completion)
+                    guard let token = approvalURL.baToken ?? approvalURL.ecToken else {
+                        self.notifyFailure(
+                            with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
+                            completion: completion
+                        )
                         return
                     }
-
-                    self.launchPayPalApp(with: url, baToken: baToken, completion: completion)
+                    self.launchPayPalApp(with: url, token: token, completion: completion)
                 case .webBrowser(let url):
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)
                 }
@@ -381,7 +383,7 @@ import BraintreeDataCollector
 
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
-        baToken: String,
+        token: String? = nil,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         apiClient.sendAnalyticsEvent(
@@ -393,7 +395,7 @@ import BraintreeDataCollector
 
         var urlComponents = URLComponents(url: payPalAppRedirectURL, resolvingAgainstBaseURL: true)
         urlComponents?.queryItems = [
-            URLQueryItem(name: "ba_token", value: baToken),
+            URLQueryItem(name: isVaultRequest ? "ba_token" : "token", value: token),
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000))))
         ]

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -366,7 +366,7 @@ import BraintreeDataCollector
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
-                    guard let token = approvalURL.baToken ?? approvalURL.ecToken else {
+                    guard let token = self.isVaultRequest ? approvalURL.baToken : approvalURL.ecToken else {
                         self.notifyFailure(
                             with: self.isVaultRequest ? BTPayPalError.missingBAToken : BTPayPalError.missingECToken,
                             completion: completion

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -373,7 +373,7 @@ import BraintreeDataCollector
                         )
                         return
                     }
-                    self.launchPayPalApp(with: url, token: token, completion: completion)
+                    self.launchPayPalApp(with: url, completion: completion)
                 case .webBrowser(let url):
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)
                 }
@@ -383,7 +383,6 @@ import BraintreeDataCollector
 
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
-        token: String? = nil,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         apiClient.sendAnalyticsEvent(
@@ -394,11 +393,11 @@ import BraintreeDataCollector
         )
 
         var urlComponents = URLComponents(url: payPalAppRedirectURL, resolvingAgainstBaseURL: true)
-        urlComponents?.queryItems = [
-            URLQueryItem(name: isVaultRequest ? "ba_token" : "token", value: token),
+        let additionalQueryItems: [URLQueryItem] = [
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000))))
         ]
+        urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)
         
         guard let redirectURL = urlComponents?.url else {
             self.notifyFailure(with: BTPayPalError.invalidURL("Unable to construct PayPal app redirect URL."), completion: completion)

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -39,8 +39,14 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 11. App Switch could not complete
     case appSwitchFailed
     
+    /// 12. Missing BA Token for App Switch
+    case missingBAToken
+    
     /// 13. Missing PayPal Request
     case missingPayPalRequest
+    
+    /// 14. Missing EC Token for App Switch
+    case missingECToken
 
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
@@ -72,8 +78,12 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 10
         case .appSwitchFailed:
             return 11
-        case .missingPayPalRequest:
+        case .missingBAToken:
             return 12
+        case .missingPayPalRequest:
+            return 13
+        case .missingECToken:
+            return 14
         }
     }
 
@@ -105,8 +115,12 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "The App Switch return URL did not contain the cancel or success path."
         case .appSwitchFailed:
             return "UIApplication failed to perform app switch to PayPal."
+        case .missingBAToken:
+            return "Missing BA Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
+        case .missingECToken:
+            return "Missing EC Token for PayPal App Switch."
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -42,11 +42,11 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 12. Missing BA Token for App Switch
     case missingBAToken
     
-    /// 13. Missing EC Token for App Switch
-    case missingECToken
-
     /// 13. Missing PayPal Request
     case missingPayPalRequest
+    
+    /// 14. Missing EC Token for App Switch
+    case missingECToken
 
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
@@ -80,9 +80,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 11
         case .missingBAToken:
             return 12
-        case .missingECToken:
-            return 13
         case .missingPayPalRequest:
+            return 13
+        case .missingECToken:
             return 14
         }
     }
@@ -117,10 +117,10 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "UIApplication failed to perform app switch to PayPal."
         case .missingBAToken:
             return "Missing BA Token for PayPal App Switch."
-        case .missingECToken:
-            return "Missing EC Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
+        case .missingECToken:
+            return "Missing EC Token for PayPal App Switch."
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -38,15 +38,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 11. App Switch could not complete
     case appSwitchFailed
-
-    /// 12. Missing BA Token for App Switch
-    case missingBAToken
     
     /// 13. Missing PayPal Request
     case missingPayPalRequest
-    
-    /// 14. Missing EC Token for App Switch
-    case missingECToken
 
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
@@ -78,12 +72,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 10
         case .appSwitchFailed:
             return 11
-        case .missingBAToken:
-            return 12
         case .missingPayPalRequest:
-            return 13
-        case .missingECToken:
-            return 14
+            return 12
         }
     }
 
@@ -115,12 +105,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "The App Switch return URL did not contain the cancel or success path."
         case .appSwitchFailed:
             return "UIApplication failed to perform app switch to PayPal."
-        case .missingBAToken:
-            return "Missing BA Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
-        case .missingECToken:
-            return "Missing EC Token for PayPal App Switch."
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -41,6 +41,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 12. Missing BA Token for App Switch
     case missingBAToken
+    
+    /// 13. Missing EC Token for App Switch
+    case missingECToken
 
     /// 13. Missing PayPal Request
     case missingPayPalRequest
@@ -77,8 +80,10 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 11
         case .missingBAToken:
             return 12
-        case .missingPayPalRequest:
+        case .missingECToken:
             return 13
+        case .missingPayPalRequest:
+            return 14
         }
     }
 
@@ -112,6 +117,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "UIApplication failed to perform app switch to PayPal."
         case .missingBAToken:
             return "Missing BA Token for PayPal App Switch."
+        case .missingECToken:
+            return "Missing EC Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
         }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -781,6 +781,35 @@ class BTPayPalClient_Tests: XCTestCase {
             XCTFail("Expected integer value for query param `switch_initiated_time`")
         }
     }
+    
+    func testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError() {
+        let fakeApplication = FakeApplication()
+        payPalClient.application = fakeApplication
+        
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
+            ]
+        ])
+        
+        let vaultRequest = BTPayPalVaultRequest(
+            userAuthenticationEmail: "fake@gmail.com",
+            enablePayPalAppSwitch: true
+        )
+        
+        let expectation = expectation(description: "completion block called")
+        payPalClient.tokenize(vaultRequest) { nonce, error in
+            XCTAssertNil(nonce)
+            
+            guard let error = error as NSError? else { XCTFail(); return }
+            XCTAssertEqual(error.code, 12)
+            XCTAssertEqual(error.localizedDescription, "Missing BA Token for PayPal App Switch.")
+            XCTAssertEqual(error.domain, "com.braintreepayments.BTPayPalErrorDomain")
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
 
     func testTokenizeVaultAccount_whenOpenURLReturnsFalse_returnsError() {
         let fakeApplication = FakeApplication()

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -782,35 +782,6 @@ class BTPayPalClient_Tests: XCTestCase {
         }
     }
 
-    func testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError() {
-        let fakeApplication = FakeApplication()
-        payPalClient.application = fakeApplication
-
-        mockAPIClient.cannedResponseBody = BTJSON(value: [
-            "agreementSetup": [
-                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?token=value1"
-            ]
-        ])
-
-        let vaultRequest = BTPayPalVaultRequest(
-            userAuthenticationEmail: "fake@gmail.com",
-            enablePayPalAppSwitch: true
-        )
-
-        let expectation = expectation(description: "completion block called")
-        payPalClient.tokenize(vaultRequest) { nonce, error in
-            XCTAssertNil(nonce)
-
-            guard let error = error as NSError? else { XCTFail(); return }
-            XCTAssertEqual(error.code, 12)
-            XCTAssertEqual(error.localizedDescription, "Missing BA Token for PayPal App Switch.")
-            XCTAssertEqual(error.domain, "com.braintreepayments.BTPayPalErrorDomain")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
-    }
-
     func testTokenizeVaultAccount_whenOpenURLReturnsFalse_returnsError() {
         let fakeApplication = FakeApplication()
         fakeApplication.cannedOpenURLSuccess = false


### PR DESCRIPTION
### Summary of changes

- Update logic to launch the PP app for the 1-time checkout flow.

**Note**: verified app-switch flow works as expected for both flows w/ intercepting the url before app-switch - would need to wait until #1500 is merged in and gateway/other components changes have been deployed.

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
