### PR TITLE
[v7] Remove ObjC annotations from internal classes

### DIFF
--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -155,7 +155,6 @@ import Foundation
     ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
     ///   `nil` and `error` will contain the error that occurred.
     @_documentation(visibility: private)
-    @objc(POST:parameters:httpType:completion:)
     public func post(
         _ path: String,
         parameters: [String: Any]? = nil,

--- a/Sources/BraintreeCore/BTAPIClientHTTPType.swift
+++ b/Sources/BraintreeCore/BTAPIClientHTTPType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// :nodoc: This enum is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 @_documentation(visibility: private)
-@objc public enum BTAPIClientHTTPService: Int {
+public enum BTAPIClientHTTPService: Int {
     /// Use the Gateway
     case gateway
 

--- a/Sources/BraintreeCore/BTAppContextSwitchClient.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitchClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// :nodoc: This protocol is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
 public protocol BTAppContextSwitchClient: AnyObject {
     
     /// Determine whether the return URL can be handled.

--- a/Sources/BraintreeCore/BTAppContextSwitchClient.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitchClient.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 /// :nodoc: This protocol is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-@_documentation(visibility: private)
-@objc public protocol BTAppContextSwitchClient: AnyObject {
+public protocol BTAppContextSwitchClient: AnyObject {
     
     /// Determine whether the return URL can be handled.
     /// - Parameter url: the URL you receive in  `scene(_:openURLContexts:)` (or `application(_:open:options:)` if not using SceneDelegate) when returning to your app

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Handles return URLs when returning from app context switch and routes the return URL to the correct app context switch client class.
 /// - Note: `returnURLScheme` must contain your app's registered URL Type that starts with the app's bundle ID.
 /// When your app returns from app switch, the app delegate should call  `handleOpenURL` (or `handleOpen` if not using SceneDelegate)
-@objcMembers public class BTAppContextSwitcher: NSObject {
+public class BTAppContextSwitcher: NSObject {
     
     // MARK: - Public Properties
     
@@ -19,7 +19,6 @@ import UIKit
     /// Determine whether the return URL can be handled.
     /// - Parameters: url the URL you receive in  `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate) when returning to your app
     /// - Returns: `true` when the SDK can process the return URL
-    @objc(handleOpenURLContext:)
     @discardableResult public func handleOpenURL(context: UIOpenURLContext) -> Bool {
         handleOpen(context.url)
     }
@@ -27,7 +26,6 @@ import UIKit
     /// Complete payment flow after returning from app or browser switch.
     /// - Parameter url:  The URL you receive in `scene:openURLContexts:` (or `application:openURL:options:` if not using SceneDelegate)
     /// - Returns: `true` when the SDK has handled the URL successfully
-    @objc(handleOpenURL:)
     @discardableResult public func handleOpen(_ url: URL) -> Bool {
         for appContextSwitchClient in appContextSwitchClients where appContextSwitchClient.canHandleReturnURL(url) {
             appContextSwitchClient.handleReturnURL(url)
@@ -38,7 +36,6 @@ import UIKit
     
     /// Registers a class `Type` that can handle a return from app context switch with a static method.
     /// - Parameter client: A class `Type` that implements `BTAppContextSwitchClient`, the methods of which will be invoked statically on the class.
-    @objc(registerAppContextSwitchClient:)
     public func register(_ client: BTAppContextSwitchClient.Type) {
         appContextSwitchClients.append(client)
     }

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -3,7 +3,6 @@ import UIKit
 /// Handles return URLs when returning from app context switch and routes the return URL to the correct app context switch client class.
 /// - Note: `returnURLScheme` must contain your app's registered URL Type that starts with the app's bundle ID.
 /// When your app returns from app switch, the app delegate should call  `handleOpenURL` (or `handleOpen` if not using SceneDelegate)
-@_documentation(visibility: private)
 public class BTAppContextSwitcher: NSObject {
     
     // MARK: - Public Properties

--- a/Sources/BraintreeCore/BTAppContextSwitcher.swift
+++ b/Sources/BraintreeCore/BTAppContextSwitcher.swift
@@ -3,6 +3,7 @@ import UIKit
 /// Handles return URLs when returning from app context switch and routes the return URL to the correct app context switch client class.
 /// - Note: `returnURLScheme` must contain your app's registered URL Type that starts with the app's bundle ID.
 /// When your app returns from app switch, the app delegate should call  `handleOpenURL` (or `handleOpen` if not using SceneDelegate)
+@_documentation(visibility: private)
 public class BTAppContextSwitcher: NSObject {
     
     // MARK: - Public Properties

--- a/Sources/BraintreeCore/BTClientMetadataIntegration.swift
+++ b/Sources/BraintreeCore/BTClientMetadataIntegration.swift
@@ -1,7 +1,6 @@
 /// :nodoc: This enum is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Integration Types
-@_documentation(visibility: private)
-@objc public enum BTClientMetadataIntegration: Int {
+public enum BTClientMetadataIntegration: Int {
     /// Custom
     case custom
     

--- a/Sources/BraintreeCore/BTClientMetadataIntegration.swift
+++ b/Sources/BraintreeCore/BTClientMetadataIntegration.swift
@@ -1,5 +1,6 @@
 /// :nodoc: This enum is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Integration Types
+@_documentation(visibility: private)
 public enum BTClientMetadataIntegration: Int {
     /// Custom
     case custom

--- a/Sources/BraintreeCore/BTClientMetadataSource.swift
+++ b/Sources/BraintreeCore/BTClientMetadataSource.swift
@@ -1,7 +1,6 @@
 /// :nodoc: This enum is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Source of the metadata
-@_documentation(visibility: private)
-@objc public enum BTClientMetadataSource: Int {
+public enum BTClientMetadataSource: Int {
     
     /// Unknown source
     case unknown

--- a/Sources/BraintreeCore/BTClientMetadataSource.swift
+++ b/Sources/BraintreeCore/BTClientMetadataSource.swift
@@ -1,5 +1,6 @@
 /// :nodoc: This enum is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Source of the metadata
+@_documentation(visibility: private)
 public enum BTClientMetadataSource: Int {
     
     /// Unknown source

--- a/Sources/BraintreeCore/BTCoreConstants.swift
+++ b/Sources/BraintreeCore/BTCoreConstants.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
 public class BTCoreConstants: NSObject {
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.

--- a/Sources/BraintreeCore/BTCoreConstants.swift
+++ b/Sources/BraintreeCore/BTCoreConstants.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-@_documentation(visibility: private)
-@objcMembers public class BTCoreConstants: NSObject {
+public class BTCoreConstants: NSObject {
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     public static var braintreeSDKVersion: String = "6.27.0"

--- a/Sources/BraintreeCore/BTJSON.swift
+++ b/Sources/BraintreeCore/BTJSON.swift
@@ -40,8 +40,7 @@ import Foundation
 ///    json["baz"] = [ 1, 2, 3 ] // json.asJSON => { "foo": ["bar"], "baz": [1,2,3] }
 ///    json["quux"] = NSSet() // json.isError => true, json.asJSON => throws NSError(domain: BTJSONErrorDomain, code: BTJSONErrorInvalidData)
 /// ```
-@_documentation(visibility: private)
-@objcMembers public class BTJSON: NSObject {
+public class BTJSON: NSObject {
 
     var value: Any? = [:] as [AnyHashable?: Any]
 

--- a/Sources/BraintreeCore/BTJSON.swift
+++ b/Sources/BraintreeCore/BTJSON.swift
@@ -40,6 +40,7 @@ import Foundation
 ///    json["baz"] = [ 1, 2, 3 ] // json.asJSON => { "foo": ["bar"], "baz": [1,2,3] }
 ///    json["quux"] = NSSet() // json.isError => true, json.asJSON => throws NSError(domain: BTJSONErrorDomain, code: BTJSONErrorInvalidData)
 /// ```
+@_documentation(visibility: private)
 public class BTJSON: NSObject {
 
     var value: Any? = [:] as [AnyHashable?: Any]

--- a/Sources/BraintreeCore/BTPaymentMethodNonce.swift
+++ b/Sources/BraintreeCore/BTPaymentMethodNonce.swift
@@ -9,7 +9,7 @@ import Foundation
 ///  The payment method nonce is a public token that acts as a placeholder for sensitive payments data that
 ///  has been uploaded to Braintree for subsequent processing. The nonce is safe to access on the client and can be
 ///  used on your server to reference the data in Braintree operations, such as Transaction.sale.
-@objcMembers open class BTPaymentMethodNonce: NSObject {
+open class BTPaymentMethodNonce: NSObject {
 
     /// The payment method nonce.
     public var nonce: String
@@ -23,7 +23,6 @@ import Foundation
     /// Initialize a new Payment Method Nonce.
     /// - Parameter nonce: A transact-able payment method nonce.
     /// - Returns: A Payment Method Nonce, or `nil` if nonce is nil.
-    @objc(initWithNonce:)
     public init(nonce: String) {
         self.nonce = nonce
         self.type = "Unknown"
@@ -35,7 +34,6 @@ import Foundation
     ///   - nonce: A transact-able payment method nonce.
     ///   - type: A string identifying the type of the payment method.
     /// - Returns: A Payment Method Nonce, or `nil` if nonce is nil.
-    @objc(initWithNonce:type:)
     public init(nonce: String, type: String) {
         self.nonce = nonce
         self.type = type
@@ -48,7 +46,6 @@ import Foundation
     ///   - type: A string identifying the type of the payment method.
     ///   - isDefault: A boolean indicating whether this is a default payment method.
     /// - Returns: A Payment Method Nonce, or `nil` if nonce is nil.
-    @objc(initWithNonce:type:isDefault:)
     public init(nonce: String, type: String, isDefault: Bool) {
         self.nonce = nonce
         self.type = type

--- a/Sources/BraintreeCore/BTURLUtils.swift
+++ b/Sources/BraintreeCore/BTURLUtils.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// A helper class for converting URL queries to and from dictionaries
+@_documentation(visibility: private)
 public class BTURLUtils: NSObject {
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.

--- a/Sources/BraintreeCore/BTURLUtils.swift
+++ b/Sources/BraintreeCore/BTURLUtils.swift
@@ -2,8 +2,7 @@ import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// A helper class for converting URL queries to and from dictionaries
-@_documentation(visibility: private)
-@objc public class BTURLUtils: NSObject {
+public class BTURLUtils: NSObject {
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Converts a key/value dictionary to a valid query string

--- a/Sources/BraintreeCore/Configuration/BTConfiguration.swift
+++ b/Sources/BraintreeCore/Configuration/BTConfiguration.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Contains information specific to a merchant's Braintree integration
+@_documentation(visibility: private)
 public class BTConfiguration: NSObject {
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.

--- a/Sources/BraintreeCore/Configuration/BTConfiguration.swift
+++ b/Sources/BraintreeCore/Configuration/BTConfiguration.swift
@@ -2,8 +2,7 @@ import Foundation
 
 /// :nodoc: This class is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 /// Contains information specific to a merchant's Braintree integration
-@_documentation(visibility: private)
-@objcMembers public class BTConfiguration: NSObject {
+public class BTConfiguration: NSObject {
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// The merchant account's configuration as a `BTJSON` object
@@ -40,7 +39,6 @@ import Foundation
     /// :nodoc: This initalizer is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     ///  Used to initialize a `BTConfiguration`
     /// - Parameter json: The `BTJSON` to initialize with
-    @objc(initWithJSON:)
     public init(json: BTJSON?) {
         self.json = json
     }

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
@@ -321,8 +321,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 
@@ -367,8 +368,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String : Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 
@@ -397,8 +399,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 
@@ -425,8 +428,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 
@@ -521,8 +525,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 
@@ -552,8 +557,9 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
 
             let error = error as NSError?
-            let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as AnyObject
-            XCTAssertEqual(errorDictionary.asDictionary(), expectedErrorBody as NSDictionary)
+            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
+                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+            }
             expectation.fulfill()
         }
 

--- a/UnitTests/BraintreeCoreTests/BTJSON_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTJSON_Tests.swift
@@ -88,19 +88,19 @@ class BTJSON_Tests: XCTestCase {
         XCTAssertNil(array[3].asString())
         XCTAssertFalse(array[3].isString)
 
-        XCTAssertNil((array["hello"] as AnyObject).asString())
+        XCTAssertNil(array["hello"].asString())
     }
 
     func testObjectAccess() {
         let JSON = "{ \"key\": \"value\" }".data(using: String.Encoding.utf8)!
         let obj = BTJSON(data: JSON)
         
-        XCTAssertEqual((obj["key"] as AnyObject).asString(), "value")
+        XCTAssertEqual(obj["key"].asString(), "value")
 
-        XCTAssertNil((obj["not present"] as AnyObject).asString())
+        XCTAssertNil(obj["not present"].asString())
         XCTAssertNil(obj[0].asString())
 
-        XCTAssertTrue((obj["not present"] as AnyObject).isError)
+        XCTAssertTrue(obj["not present"].isError)
 
         XCTAssertTrue(obj[0].isError)
     }
@@ -167,13 +167,13 @@ class BTJSON_Tests: XCTestCase {
     func testAsURL() {
         let JSON = "{ \"url\": \"http://example.com\" }".data(using: String.Encoding.utf8)!
         let url = BTJSON(data: JSON)
-        XCTAssertEqual((url["url"] as AnyObject).asURL(), URL(string: "http://example.com")!)
+        XCTAssertEqual(url["url"].asURL(), URL(string: "http://example.com")!)
     }
 
     func testAsURLForInvalidValue() {
         let JSON = "{ \"url\": 42 }".data(using: String.Encoding.utf8)!
         let url = BTJSON(data: JSON)
-        XCTAssertNil((url["url"] as AnyObject).asURL())
+        XCTAssertNil(url["url"].asURL())
     }
 
     func testAsStringArray() {
@@ -313,10 +313,10 @@ class BTJSON_Tests: XCTestCase {
         XCTAssertFalse(foo["meaningful"] as! Bool)
         XCTAssertNil(obj["notADictionary"].asDictionary())
         XCTAssertNil(obj["aString"].asDictionary())
-        XCTAssertEqual((obj["aURL"] as AnyObject).asURL(), URL(string: "https://test.example.com:1234/path"))
-        XCTAssertNil((obj["notAURL"] as AnyObject).asURL())
-        XCTAssertNil((obj["aString"] as AnyObject).asURL())
-        XCTAssertNil((obj["anInvalidURL"] as AnyObject).asURL()) // nil for invalid URLs
+        XCTAssertEqual(obj["aURL"].asURL(), URL(string: "https://test.example.com:1234/path"))
+        XCTAssertNil(obj["notAURL"].asURL())
+        XCTAssertNil(obj["aString"].asURL())
+        XCTAssertNil(obj["anInvalidURL"].asURL()) // nil for invalid URLs
         // nested resources:
         let btJson = obj["aLookupDictionary"].asDictionary() as! [String: AnyObject]
         XCTAssertEqual((btJson["foo"] as! NSDictionary)["definition"] as! String, "A meaningless word")

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -19,7 +19,9 @@ class BTDataCollector_Tests: XCTestCase {
                 let json = BTJSON(data: deviceData.data(using: String.Encoding.utf8)!)
                 XCTAssertNil(json["fraud_merchant_id"].asString())
                 XCTAssertNil(json["device_session_id"].asString())
-                XCTAssert((json["correlation_id"] as AnyObject).asString()!.count > 0)
+                if let correlationId = json["correlation_id"].asString() {
+                    XCTAssert(correlationId.count > 0)
+                }
                 expectation.fulfill()
             } else {
                 XCTFail("We should return the expected data")

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -19,8 +19,8 @@ class BTDataCollector_Tests: XCTestCase {
                 let json = BTJSON(data: deviceData.data(using: String.Encoding.utf8)!)
                 XCTAssertNil(json["fraud_merchant_id"].asString())
                 XCTAssertNil(json["device_session_id"].asString())
-                if let correlationId = json["correlation_id"].asString() {
-                    XCTAssert(correlationId.count > 0)
+                if let correlationID = json["correlation_id"].asString() {
+                    XCTAssert(correlationID.count > 0)
                 }
                 expectation.fulfill()
             } else {


### PR DESCRIPTION
### Summary of changes

- Remove `@objc` annotations from several internal classes
- Remove and update related tests

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
