### PR TITLE
Update to use `NSSecureCoding` protocol 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Update to use `NSSecureCoding` protocol (fixes #1508)
+
 ## 6.27.0 (2025-01-23)
 * BraintreePayPal
   * Add `BTContactInformation` request object

--- a/Sources/BraintreeCore/Authorization/BTClientToken.swift
+++ b/Sources/BraintreeCore/Authorization/BTClientToken.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// An authorization string used to initialize the Braintree SDK
 @_documentation(visibility: private)
-@objcMembers public class BTClientToken: NSObject, NSCoding, NSCopying, ClientAuthorization {
+@objcMembers public class BTClientToken: NSObject, NSSecureCoding, NSCopying, ClientAuthorization {
 
     // NEXT_MAJOR_VERSION (v7): properties exposed for Objective-C interoperability + Drop-in access.
     // Once the entire SDK is in Swift, determine if we want public properties to be internal and
@@ -87,6 +87,8 @@ import Foundation
     }
 
     // MARK: - NSCoding conformance
+    
+    public static var supportsSecureCoding: Bool = true
 
     public func encode(with coder: NSCoder) {
         coder.encode(originalValue, forKey: "originalValue")
@@ -94,7 +96,7 @@ import Foundation
 
     public required convenience init?(coder: NSCoder) {
         try? self.init(
-            clientToken: coder.decodeObject(forKey: "originalValue") as? String ?? ""
+            clientToken: coder.decodeObject(of: NSString.self, forKey: "originalValue") as? String ?? ""
         )
     }
 

--- a/Sources/BraintreeCore/Authorization/BTClientToken.swift
+++ b/Sources/BraintreeCore/Authorization/BTClientToken.swift
@@ -86,7 +86,7 @@ import Foundation
         return BTJSON(value: clientTokenJSON)
     }
 
-    // MARK: - NSCoding conformance
+    // MARK: - NSSecureCoding conformance
     
     public static var supportsSecureCoding: Bool = true
 


### PR DESCRIPTION
### Summary of changes

- Update to use `NSSecureCoding` protocol (fixes #1508)

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
