### PR TITLE
[v7] Move `/authenticate_from_jwt` POST to Encodable

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		62A659A42B98CB23008DFD67 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */; };
 		62A746412B9255AC003D32FF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62A746402B9255AC003D32FF /* PrivacyInfo.xcprivacy */; };
 		62B811882CC002470024A688 /* BTPayPalPhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */; };
+		62D5754A2D5299A700DCDAC1 /* BTThreeDSecureAuthenticateJWTPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D575492D5299A700DCDAC1 /* BTThreeDSecureAuthenticateJWTPOSTBody.swift */; };
 		62DE8FBF2B9656BF00F08F53 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62DE8FBE2B9656BF00F08F53 /* PrivacyInfo.xcprivacy */; };
 		62EA90492B63071800DD79BC /* BTEligiblePaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EA90482B63071800DD79BC /* BTEligiblePaymentMethods.swift */; };
 		800E78C429E0DD5300D1B0FC /* FPTIBatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E78C329E0DD5300D1B0FC /* FPTIBatchData.swift */; };
@@ -771,6 +772,7 @@
 		62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		62A746402B9255AC003D32FF /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalPhoneNumber.swift; sourceTree = "<group>"; };
+		62D575492D5299A700DCDAC1 /* BTThreeDSecureAuthenticateJWTPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAuthenticateJWTPOSTBody.swift; sourceTree = "<group>"; };
 		62DE8FBE2B9656BF00F08F53 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		62EA90482B63071800DD79BC /* BTEligiblePaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTEligiblePaymentMethods.swift; sourceTree = "<group>"; };
 		800E23DC22206A8300C5D22E /* BTThreeDSecureAuthenticateJWT_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureAuthenticateJWT_Tests.swift; sourceTree = "<group>"; };
@@ -1387,6 +1389,14 @@
 			path = BraintreeCore;
 			sourceTree = "<group>";
 		};
+		62D575482D52996B00DCDAC1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				62D575492D5299A700DCDAC1 /* BTThreeDSecureAuthenticateJWTPOSTBody.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		6A50887E9E10BEB122A9F45D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1831,6 +1841,7 @@
 				BEBF0C1F2B02793B0079DA74 /* BTThreeDSecureUIType.swift */,
 				BE01A83E29D32CA0000DFA24 /* BTThreeDSecureV2Provider.swift */,
 				80CD33FF2A6042FC009545F5 /* CardinalSessionTestable.swift */,
+				62D575482D52996B00DCDAC1 /* Models */,
 				801A0A1725890DF200DAF851 /* V2UICustomization */,
 				62236E192B98CFB000CDCC37 /* PrivacyInfo.xcprivacy */,
 			);
@@ -3349,6 +3360,7 @@
 				BE82E73F29C4A06B0059FE97 /* BTThreeDSecureV2ToolbarCustomization.swift in Sources */,
 				BE01A84129D32CE1000DFA24 /* BTThreeDSecureAuthenticateJWT.swift in Sources */,
 				80482F8229D39BF5007E5F50 /* BTThreeDSecureRequestDelegate.swift in Sources */,
+				62D5754A2D5299A700DCDAC1 /* BTThreeDSecureAuthenticateJWTPOSTBody.swift in Sources */,
 				BE82E73B29C49C050059FE97 /* BTThreeDSecureV2ButtonCustomization.swift in Sources */,
 				BE9834A02A041B0A00B6C3CC /* BTConfiguration+ThreeDSecure.swift in Sources */,
 				BE80C00329C549BE00793A6C /* BTThreeDSecureResult.swift in Sources */,

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureAuthenticateJWT.swift
@@ -23,12 +23,14 @@ enum BTThreeDSecureAuthenticateJWT {
             completion(nil, BTThreeDSecureError.failedAuthentication("Unable to percent encode nonce as a URL safe nonce."))
             return
         }
-    
-        let requestParameters = ["jwt": cardinalJWT, "paymentMethodNonce": nonce]
-
+        
+        let threeDSecureAuthenticateJWTRequest = BTThreeDSecureAuthenticateJWTPOSTBody(
+            jwt: cardinalJWT,
+            paymentMethodNonce: nonce
+        )
         apiClient.post(
             "v1/payment_methods/\(urlSafeNonce)/three_d_secure/authenticate_from_jwt",
-            parameters: requestParameters
+            parameters: threeDSecureAuthenticateJWTRequest
         ) { body, _, error in
             if let error {
                 apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.jwtAuthFailed)

--- a/Sources/BraintreeThreeDSecure/Models/BTThreeDSecureAuthenticateJWTPOSTBody.swift
+++ b/Sources/BraintreeThreeDSecure/Models/BTThreeDSecureAuthenticateJWTPOSTBody.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif
+
+// The POST body for /three_d_secure/authenticate_from_jwt
+struct BTThreeDSecureAuthenticateJWTPOSTBody: Encodable {
+    
+    // MARK: - Private Properties
+    
+    private let jwt: String
+    private let paymentMethodNonce: String
+    
+    enum CodingKeys: String, CodingKey {
+        case jwt
+        case paymentMethodNonce
+    }
+    
+    init(
+        jwt: String,
+        paymentMethodNonce: String
+    ) {
+        self.jwt = jwt
+        self.paymentMethodNonce = paymentMethodNonce
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Move the JSON dict of the POST body sent to this endpoint `/three_d_secure/authenticate_from_jwt`  into an Encodable Type

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
