### PR TITLE
Expose `isDeviceToken` on BTApplePayCardNonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeApplePay
+  * Add `isDeviceToken` to POST `v1/payment_methods/apple_payment_tokens`
+
 ## 6.28.0 (2025-02-05)
 * BraintreeVenmo
   * Allow universal links to be set without a return URL scheme (fixes #1505)

--- a/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
+++ b/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
@@ -10,11 +10,18 @@ import BraintreeCore
     /// The BIN data for the card number associated with this nonce.
     public let binData: BTBinData
 
+    /// This Boolean indicates whether this tokenized card is a device-specific account number (DPAN) or merchant/cloud token (MPAN).
+    /// If `isDeviceToken` is `false`, then token type is MPAN
+    public var isDeviceToken: Bool
+
     init?(json: BTJSON) {
         guard let nonce = json["nonce"].asString() else { return nil }
 
         let cardType = json["details"]["cardType"].asString() ?? "ApplePayCard"
         let isDefault = json["default"].isTrue
+        let isDeviceToken = json["details"]["isDeviceToken"].asBool() ?? false
+
+        self.isDeviceToken = isDeviceToken
 
         binData = BTBinData(json: json["binData"])
         super.init(nonce: nonce, type: cardType, isDefault: isDefault)

--- a/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
@@ -12,7 +12,8 @@ class BTApplePayCardNonce_Tests: XCTestCase {
                     "commercial": "yes"
                 ],
                 "details": [
-                    "cardType": "fake-card-type"
+                    "cardType": "fake-card-type",
+                    "isDeviceToken": true
                 ],
                 "nonce": "a-nonce"
             ] as [String: Any]
@@ -22,6 +23,7 @@ class BTApplePayCardNonce_Tests: XCTestCase {
         XCTAssertEqual(applePayNonce?.nonce, "a-nonce")
         XCTAssertEqual(applePayNonce?.binData.commercial, "yes")
         XCTAssertEqual(applePayNonce?.type, "fake-card-type")
+        XCTAssertEqual(applePayNonce?.isDeviceToken, true)
     }
 
     func testInitWithJSON_setsDefaultProperties() {

--- a/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePayCardNonce_Tests.swift
@@ -12,8 +12,7 @@ class BTApplePayCardNonce_Tests: XCTestCase {
                     "commercial": "yes"
                 ],
                 "details": [
-                    "cardType": "fake-card-type",
-                    "isDeviceToken": true
+                    "cardType": "fake-card-type"
                 ],
                 "nonce": "a-nonce"
             ] as [String: Any]
@@ -23,6 +22,43 @@ class BTApplePayCardNonce_Tests: XCTestCase {
         XCTAssertEqual(applePayNonce?.nonce, "a-nonce")
         XCTAssertEqual(applePayNonce?.binData.commercial, "yes")
         XCTAssertEqual(applePayNonce?.type, "fake-card-type")
+    }
+
+    func testInitWithJSON_whenApplePayTokenIsMPAN() {
+        let applePayCard = BTJSON(
+            value: [
+                "consumed": false,
+                "binData": [
+                    "commercial": "yes"
+                ],
+                "details": [
+                    "cardType": "fake-card-type",
+                    "isDeviceToken": false
+                ],
+                "nonce": "a-nonce"
+            ] as [String: Any]
+        )
+
+        let applePayNonce = BTApplePayCardNonce(json: applePayCard)
+        XCTAssertEqual(applePayNonce?.isDeviceToken, false)
+    }
+
+    func testInitWithJSON_whenApplePayTokenIsDPAN() {
+        let applePayCard = BTJSON(
+            value: [
+                "consumed": false,
+                "binData": [
+                    "commercial": "yes"
+                ],
+                "details": [
+                    "cardType": "fake-card-type",
+                    "isDeviceToken": true
+                ],
+                "nonce": "a-nonce"
+            ] as [String: Any]
+        )
+
+        let applePayNonce = BTApplePayCardNonce(json: applePayCard)
         XCTAssertEqual(applePayNonce?.isDeviceToken, true)
     }
 


### PR DESCRIPTION
With this PR, Merchants will have the ability to see if their ApplePay payment was tokenized as an MPAN or DPAN.

### Summary of changes

- Exposed `isDeviceToken`
- `false` == MPAN
- `true` == DPAN

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 
