### PR TITLE
Expose isDeviceToken on BTApplePayCardNonce [Duplicate]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeApplePay
-  * Add `isDeviceToken` to POST `v1/payment_methods/apple_payment_tokens`
+  * Add BTApplePayCardNonce.isDeviceToken for MPAN identification
 
 ## 6.28.0 (2025-02-05)
 * BraintreeVenmo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeApplePay
-  * Add BTApplePayCardNonce.isDeviceToken for MPAN identification
+  * Add `BTApplePayCardNonce.isDeviceToken` for MPAN identification
 
 ## 6.28.0 (2025-02-05)
 * BraintreeVenmo

--- a/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
+++ b/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
@@ -19,9 +19,8 @@ import BraintreeCore
 
         let cardType = json["details"]["cardType"].asString() ?? "ApplePayCard"
         let isDefault = json["default"].isTrue
-        let isDeviceToken = json["details"]["isDeviceToken"].asBool() ?? true
 
-        self.isDeviceToken = isDeviceToken
+        self.isDeviceToken = json["details"]["isDeviceToken"].asBool() ?? true
 
         binData = BTBinData(json: json["binData"])
         super.init(nonce: nonce, type: cardType, isDefault: isDefault)

--- a/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
+++ b/Sources/BraintreeApplePay/BTApplePayCardNonce.swift
@@ -10,7 +10,7 @@ import BraintreeCore
     /// The BIN data for the card number associated with this nonce.
     public let binData: BTBinData
 
-    /// This Boolean indicates whether this tokenized card is a device-specific account number (DPAN) or merchant/cloud token (MPAN).
+    /// This Boolean indicates whether this tokenized card is a device-specific account number (DPAN) or merchant/cloud token (MPAN). Available on iOS 16+.
     /// If `isDeviceToken` is `false`, then token type is MPAN
     public var isDeviceToken: Bool
 


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- 

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
