### PR TITLE
[DTINAPPXO-511] Implemented PayPal App Switch fallback to external browser

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		BEFE6DAA27E28A0B002BE9C8 /* MockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE6DA927E28A0B002BE9C8 /* MockViewController.swift */; };
 		BEFE9A3B29C8EC6B00BF69AB /* BTCardClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE9A3A29C8EC6B00BF69AB /* BTCardClient.swift */; };
 		BEFE9A3D29C8ECAA00BF69AB /* BTCardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */; };
+		C53568872D5184A20013BA5B /* BTPayPalClientAppLaunchConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53568862D5184A00013BA5B /* BTPayPalClientAppLaunchConfig.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1106,6 +1107,7 @@
 		BEFE6DA927E28A0B002BE9C8 /* MockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewController.swift; sourceTree = "<group>"; };
 		BEFE9A3A29C8EC6B00BF69AB /* BTCardClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient.swift; sourceTree = "<group>"; };
 		BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardError.swift; sourceTree = "<group>"; };
+		C53568862D5184A00013BA5B /* BTPayPalClientAppLaunchConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalClientAppLaunchConfig.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1389,6 +1391,7 @@
 		2D941D391B59C76A0016EFB4 /* BraintreePayPal */ = {
 			isa = PBXGroup;
 			children = (
+				C53568862D5184A00013BA5B /* BTPayPalClientAppLaunchConfig.swift */,
 				57544821294A3B6900DEB7B0 /* BTConfiguration+PayPal.swift */,
 				57544F5B295254A500DEB7B0 /* BTJSON+PayPal.swift */,
 				57544F572952298900DEB7B0 /* BTPayPalAccountNonce.swift */,
@@ -3283,6 +3286,7 @@
 				57544F5E295258AC00DEB7B0 /* BTPayPalError.swift in Sources */,
 				BEF5D2E6294A18B300FFD56D /* BTPayPalLineItem.swift in Sources */,
 				BE349113294B798300D2CF68 /* BTPayPalRequest.swift in Sources */,
+				C53568872D5184A20013BA5B /* BTPayPalClientAppLaunchConfig.swift in Sources */,
 				BE549F112BF5445F00B6F441 /* BTPayPalReturnURL.swift in Sources */,
 				57544F5C295254A500DEB7B0 /* BTJSON+PayPal.swift in Sources */,
 				BE549F122BF5449E00B6F441 /* BTPayPalVaultBaseRequest.swift in Sources */,

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -8,6 +8,8 @@ public protocol URLOpener {
 
     func canOpenURL(_ url: URL) -> Bool
     func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?)
+    // swiftlint:disable:next line_length
+    func open(_ url: URL, withOptions options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
     func isPayPalAppInstalled() -> Bool
     func isVenmoAppInstalled() -> Bool
 }
@@ -36,9 +38,16 @@ extension UIApplication: URLOpener {
 
     // TODO: once Xcode 16 is the minimum supported version remove this method and update the protocol to the default open signature from UIApplication
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    /// Indicates whether the PayPal App is installed.
+    /// Opens the specified URL and handles the completion.
     @_documentation(visibility: private)
     public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
-        UIApplication.shared.open(url, options: [:], completionHandler: completion)
+        open(url, withOptions: [:], completionHandler: completion)
+    }
+
+    /// Opens the specified URL with the provided options and handles the completion.
+    @_documentation(visibility: private)
+    // swiftlint:disable:next line_length
+    public func open(_ url: URL, withOptions options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
+        UIApplication.shared.open(url, options: options, completionHandler: completion)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -30,5 +30,7 @@ enum BTPayPalAnalytics {
 
     static let appSwitchStarted = "paypal:tokenize:app-switch:started"
     static let appSwitchSucceeded = "paypal:tokenize:app-switch:succeeded"
+    static let externalBrowserSwitchSucceeded = "paypal:tokenize:external-browser-switch:succeeded"
     static let appSwitchFailed = "paypal:tokenize:app-switch:failed"
+    static let externalBrowserSwitchFailed = "paypal:tokenize:external-browser-switch:failed"
 }

--- a/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
+++ b/Sources/BraintreePayPal/BTPayPalApprovalURLParser.swift
@@ -11,7 +11,7 @@ enum PayPalRedirectType: Equatable {
     case webBrowser(url: URL)
     
     /// The universal link flow, switching out of the merchant app into the native PayPal app
-    case payPalApp(url: URL)
+    case payPalApp(url: URL, fallbackUrl: URL?)
 }
 
 /// Parses response body from `/v1/paypal_hermes/*` POST requests to determine the `PayPalRedirectType`
@@ -46,11 +46,11 @@ struct BTPayPalApprovalURLParser {
     }
 
     init?(body: BTJSON) {
+        let fallbackUrl = body["agreementSetup"]["approvalUrl"].asURL()
         if let payPalAppRedirectURL = body["agreementSetup"]["paypalAppApprovalUrl"].asURL() {
-            redirectType = .payPalApp(url: payPalAppRedirectURL)
+            redirectType = .payPalApp(url: payPalAppRedirectURL, fallbackUrl: fallbackUrl)
             url = payPalAppRedirectURL
-        } else if let approvalURL = body["paymentResource"]["redirectUrl"].asURL() ??
-            body["agreementSetup"]["approvalUrl"].asURL() {
+        } else if let approvalURL = body["paymentResource"]["redirectUrl"].asURL() ?? fallbackUrl {
             redirectType = .webBrowser(url: approvalURL)
             url = approvalURL
         } else {

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -288,10 +288,10 @@ import BraintreeDataCollector
     func invokedOpenURLSuccessfully(_ url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.appSwitchSucceeded,
+            appSwitchURL: url,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID,
-            appSwitchURL: url
+            payPalContextID: payPalContextID
         )
         BTPayPalClient.payPalClient = self
         appSwitchCompletion = completion
@@ -300,10 +300,10 @@ import BraintreeDataCollector
     func openURLInExternalBrowserSuccessfully(_ url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.externalBrowserSwitchSucceeded,
+            appSwitchURL: url,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID,
-            appSwitchURL: url
+            payPalContextID: payPalContextID
         )
         BTPayPalClient.payPalClient = self
         appSwitchCompletion = completion
@@ -312,10 +312,10 @@ import BraintreeDataCollector
     func failedToInvokeOpenURL(_ url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.appSwitchFailed,
+            appSwitchURL: url,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID,
-            appSwitchURL: url
+            payPalContextID: payPalContextID
         )
         notifyFailure(with: BTPayPalError.appSwitchFailed, completion: completion)
     }
@@ -323,10 +323,10 @@ import BraintreeDataCollector
     func failedToOpenURLInExternalBrowser(_ url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.externalBrowserSwitchFailed,
+            appSwitchURL: url,
             isVaultRequest: isVaultRequest,
             linkType: linkType,
-            payPalContextID: payPalContextID,
-            appSwitchURL: url
+            payPalContextID: payPalContextID
         )
         notifyFailure(with: BTPayPalError.externalBrowserSwitchFailed, completion: completion)
     }

--- a/Sources/BraintreePayPal/BTPayPalClientAppLaunchConfig.swift
+++ b/Sources/BraintreePayPal/BTPayPalClientAppLaunchConfig.swift
@@ -1,0 +1,27 @@
+//
+//  BTPayPalClientAppLaunchConfig.swift
+//  Braintree
+//
+//  Created by Abhinay Balusu on 2/3/25.
+//
+
+import Foundation
+
+/// Used for switching to either PayPal app or open fallback url in external browser
+struct BTPayPalClientAppLaunchConfig {
+
+    // The universal link URL used to launch the PayPal client app.
+    let appSwitchUrl: URL
+
+    // The BA (Billing Agreement) token
+    let baToken: String
+
+    // An optional fallback URL used to open in a external browser if the universal link fails.
+    let fallbackUrl: URL?
+
+    init(appSwitchUrl: URL, baToken: String, fallbackUrl: URL? = nil) {
+        self.appSwitchUrl = appSwitchUrl
+        self.baToken = baToken
+        self.fallbackUrl = fallbackUrl
+    }
+}

--- a/Sources/BraintreePayPal/BTPayPalError.swift
+++ b/Sources/BraintreePayPal/BTPayPalError.swift
@@ -45,6 +45,9 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
     /// 13. Missing PayPal Request
     case missingPayPalRequest
 
+    /// 14. Failed to openURL in external browser when app switch failed
+    case externalBrowserSwitchFailed
+
     public static var errorDomain: String {
         "com.braintreepayments.BTPayPalErrorDomain"
     }
@@ -79,6 +82,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return 12
         case .missingPayPalRequest:
             return 13
+        case .externalBrowserSwitchFailed:
+            return 14
         }
     }
 
@@ -114,6 +119,8 @@ public enum BTPayPalError: Error, CustomNSError, LocalizedError, Equatable {
             return "Missing BA Token for PayPal App Switch."
         case .missingPayPalRequest:
             return "The PayPal Request was missing or invalid."
+        case .externalBrowserSwitchFailed:
+            return "UIApplication failed to open url in external browser when app switch failed"
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -22,7 +22,7 @@ struct BTPayPalReturnURL {
     /// - Parameter url: an incoming app switch or ASWebAuthenticationSession url
     init?(_ redirectType: PayPalRedirectType) {
         switch redirectType {
-        case .payPalApp(let url), .webBrowser(let url):
+        case .payPalApp(let url, _), .webBrowser(let url):
             if url.path.contains("success") {
                 state = .succeeded
             } else if url.path.contains("cancel") {

--- a/UnitTests/BraintreePayPalTests/BTPayPalReturnURL_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalReturnURL_Tests.swift
@@ -4,37 +4,37 @@ import XCTest
 final class BTPayPalReturnURL_Tests: XCTestCase {
 
     func testInitWithURL_whenSuccessReturnURL_setsSuccessState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/success?token=A_FAKE_EC_TOKEN&ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/success?token=A_FAKE_EC_TOKEN&ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .succeeded)
     }
 
     func testInitWithURL_whenSuccessReturnURLWithoutToken_setsSuccessState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/success?ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/success?ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .succeeded)
     }
 
     func testInitWithURL_whenCancelURLWithoutToken_setsCancelState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/cancel?ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/cancel?ba_token=A_FAKE_BA_TOKEN&switch_initiated_time=1234567890")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .canceled)
     }
 
     func testInitWithURL_whenUnknownURLWithoutToken_setsUnknownState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/garbage-url")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "https://www.merchant-app.com/merchant-path/garbage-url")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .unknownPath)
     }
 
     func testInitWithSchemeURL_whenSuccessReturnURL_setsSuccessState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/success?token=hermes_token")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/success?token=hermes_token")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .succeeded)
     }
 
     func testInitWithSchemeURL_whenCancelURLWithoutToken_setsCancelState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/cancel?token=hermes_token")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/cancel?token=hermes_token")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .canceled)
     }
 
     func testInitWithSchemeURL_whenUnknownURLWithoutToken_setsUnknownState() {
-        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/invalid")!))
+        let returnURL = BTPayPalReturnURL(.payPalApp(url: URL(string: "bar://onetouch/v1/invalid")!, fallbackUrl: nil))
         XCTAssertEqual(returnURL?.state, .unknownPath)
     }
 }

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -2,7 +2,7 @@ import UIKit
 import BraintreeCore
 
 public class FakeApplication: URLOpener {
-    
+
     public var lastOpenURL: URL? = nil
     public var openURLWasCalled: Bool = false
     var cannedOpenURLSuccess: Bool = true
@@ -10,6 +10,12 @@ public class FakeApplication: URLOpener {
     public var canOpenURLWhitelist: [URL] = []
 
     public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
+        lastOpenURL = url
+        openURLWasCalled = true
+        completion?(cannedOpenURLSuccess)
+    }
+
+    public func open(_ url: URL, withOptions options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
         lastOpenURL = url
         openURLWasCalled = true
         completion?(cannedOpenURLSuccess)


### PR DESCRIPTION
Bug ticket: DTINAPPXO-511

Bug Fix doc: "Top of Funnel App Switch Fail"

### Summary of changes

**Issue**: The PayPal app fails to open the app switch checkout URL, logging the error: "UIApplication failed to perform app switch to PayPal."

**Change**: Makes sure UIApplication only opens universal link only if the URL is a valid universal link and there is an installed app capable of opening that URL and Implemented a fallback mechanism to open the "approvalUrl" in an external browser

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
