### PR TITLE
[v5] Fix CI Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-14
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
-    runs-on: macOS-14
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
-    runs-on: macOS-14
+    runs-on: macOS-14-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
     name: UI
     runs-on: macOS-14
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 14,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-14
@@ -52,4 +52,4 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Integration Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 14,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'IntegrationTests' -destination 'name=iPhone 15,OS=17.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify

--- a/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
@@ -457,50 +457,6 @@ class BTSEPADirectDebitClient_Tests: XCTestCase {
         }
     }
     
-    func testTokenize_handleCreateMandateReturnsInvalidURL_returnsError_andSendsAnalytics() {
-        let mockWebAuthenticationSession = MockWebAuthenticationSession()
-        let mockSepaDirectDebitAPI = SEPADirectDebitAPI(apiClient: mockAPIClient)
-
-        mockAPIClient.cannedResponseBody = BTJSON(
-            value: [
-                "message": [
-                    "body": [
-                        "sepaDebitAccount": [
-                            "approvalUrl": "   ",
-                            "last4": "1234",
-                            "merchantOrPartnerCustomerId": "a-customer-id",
-                            "bankReferenceToken": "a-bank-reference-token",
-                            "mandateType": "ONE_OFF"
-                        ]
-                    ]
-                ]
-            ]
-        )
-
-        mockWebAuthenticationSession.cannedErrorResponse = NSError(
-            domain: SEPADirectDebitError.errorDomain,
-            code: SEPADirectDebitError.approvalURLInvalid.errorCode,
-            userInfo: ["Description": "Mock approvalURLInvalid error description."]
-        )
-
-        let sepaDirectDebitClient = BTSEPADirectDebitClient(
-            apiClient: mockAPIClient,
-            webAuthenticationSession: mockWebAuthenticationSession,
-            sepaDirectDebitAPI: mockSepaDirectDebitAPI
-        )
-
-        sepaDirectDebitClient.tokenize(request: sepaDirectDebitRequest) { nonce, error in
-            if error != nil, let error = error as NSError? {
-                XCTAssertEqual(error.domain, SEPADirectDebitError.errorDomain)
-                XCTAssertEqual(error.code, SEPADirectDebitError.approvalURLInvalid.errorCode)
-                XCTAssertEqual(error.localizedDescription, SEPADirectDebitError.approvalURLInvalid.localizedDescription)
-                XCTAssertEqual(self.mockAPIClient.postedAnalyticsEvents.last, "ios.sepa-direct-debit.create-mandate.failure")
-            } else if nonce != nil {
-                XCTFail("This request should return an error.")
-            }
-        }
-    }
-    
     func testTokenizeWithPresentationContext_handleWebAuthenticationSessionSuccessURLInvalid_returnsError_andSendsAnalytics() {
         let mockWebAuthenticationSession = MockWebAuthenticationSession()
         let mockSepaDirectDebitAPI = SEPADirectDebitAPI(apiClient: mockAPIClient)


### PR DESCRIPTION
### Summary of changes

- Set the destination to a runnable destination from the logs - specifically it looks like `OS=17.2` needs to be run on an `iPhone 15`

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
