### PR TITLE
[v7] Make APIClient Non-optional & Update `BTAmericanExpressClient` Init

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		BE80C00D29C8B4B900793A6C /* BTCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE80C00C29C8B4B900793A6C /* BTCard.swift */; };
 		BE82E73B29C49C050059FE97 /* BTThreeDSecureV2ButtonCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE82E73A29C49C050059FE97 /* BTThreeDSecureV2ButtonCustomization.swift */; };
 		BE82E73F29C4A06B0059FE97 /* BTThreeDSecureV2ToolbarCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE82E73E29C4A06B0059FE97 /* BTThreeDSecureV2ToolbarCustomization.swift */; };
+		BE849EED2D66908E005BD215 /* InvalidAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE849EEC2D669088005BD215 /* InvalidAuthorization.swift */; };
 		BE895C61299433FB008112AB /* BTApplePayCardNonce.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE895C60299433FB008112AB /* BTApplePayCardNonce.swift */; };
 		BE895C6329944BD3008112AB /* BTApplePayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE895C6229944BD3008112AB /* BTApplePayError.swift */; };
 		BE895C6529944BF5008112AB /* BTApplePayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE895C6429944BF5008112AB /* BTApplePayClient.swift */; };
@@ -966,6 +967,7 @@
 		BE82E73C29C49ECE0059FE97 /* BTThreeDSecureV2LabelCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2LabelCustomization.swift; sourceTree = "<group>"; };
 		BE82E73E29C4A06B0059FE97 /* BTThreeDSecureV2ToolbarCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2ToolbarCustomization.swift; sourceTree = "<group>"; };
 		BE82E74029C4A1330059FE97 /* BTThreeDSecureV2TextBoxCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTThreeDSecureV2TextBoxCustomization.swift; sourceTree = "<group>"; };
+		BE849EEC2D669088005BD215 /* InvalidAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidAuthorization.swift; sourceTree = "<group>"; };
 		BE895C60299433FB008112AB /* BTApplePayCardNonce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayCardNonce.swift; sourceTree = "<group>"; };
 		BE895C6229944BD3008112AB /* BTApplePayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayError.swift; sourceTree = "<group>"; };
 		BE895C6429944BF5008112AB /* BTApplePayClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTApplePayClient.swift; sourceTree = "<group>"; };
@@ -1583,6 +1585,7 @@
 		80B207342BF6D3B000787E37 /* Authorization */ = {
 			isa = PBXGroup;
 			children = (
+				BE849EEC2D669088005BD215 /* InvalidAuthorization.swift */,
 				BED00CAF28A579D700D74AEC /* BTClientToken.swift */,
 				BED00CB128A57AD400D74AEC /* BTClientTokenError.swift */,
 				BE24C67428E7491E0067B11A /* ClientAuthorization.swift */,
@@ -3207,6 +3210,7 @@
 				BE2F98D028A2BCCD008EF189 /* BTConfiguration.swift in Sources */,
 				804DC45D2B2D08FF00F17A15 /* BTConfigurationRequest.swift in Sources */,
 				BED00CB228A57AD400D74AEC /* BTClientTokenError.swift in Sources */,
+				BE849EED2D66908E005BD215 /* InvalidAuthorization.swift in Sources */,
 				BE24C67328E73E810067B11A /* BTAPIClientHTTPType.swift in Sources */,
 				457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */,
 				BE9EC0982899CF040022EC63 /* BTAPIPinnedCertificates.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   * BraintreePayPal
     * Update PayPal app URL query scheme from `paypal-app-switch-checkout` to `paypal`
   * BraintreeAmericanExpress
-    * Update initalizer to `BTAmericanExpressClient(authorization:)`
+    * Update initializer to `BTAmericanExpressClient(authorization:)`
 
 ## 6.27.0 (2025-01-23)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
     * Remove `fetchPaymentMethodNonces` methods and parser
   * BraintreePayPal
     * Update PayPal app URL query scheme from `paypal-app-switch-checkout` to `paypal`
+  * BraintreeAmericanExpress
+    * Update initalizer to `BTAmericanExpressClient(authorization:)`
 
 ## 6.27.0 (2025-01-23)
 * BraintreePayPal

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -3,6 +3,7 @@ import BraintreeCore
 
 class PaymentButtonBaseViewController: BaseViewController {
 
+    // TODO: remove API client in final PR
     let apiClient: BTAPIClient
     let authorization: String
 

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -4,6 +4,7 @@ import BraintreeCore
 class PaymentButtonBaseViewController: BaseViewController {
 
     let apiClient: BTAPIClient
+    let authorization: String
 
     var heightConstraint: CGFloat?
 
@@ -12,6 +13,7 @@ class PaymentButtonBaseViewController: BaseViewController {
     override init(authorization: String) {
         // swiftlint:disable:next force_unwrapping
         apiClient = BTAPIClient(authorization: authorization)!
+        self.authorization = authorization
         super.init(authorization: authorization)
     }
     

--- a/Demo/Application/Features/AmexViewController.swift
+++ b/Demo/Application/Features/AmexViewController.swift
@@ -4,7 +4,7 @@ import BraintreeCard
 
 class AmexViewController: PaymentButtonBaseViewController {
 
-    lazy var amexClient = BTAmericanExpressClient(apiClient: apiClient)
+    lazy var amexClient = BTAmericanExpressClient(authorization: authorization)
     lazy var cardClient = BTCardClient(apiClient: apiClient)
 
     override func viewDidLoad() {

--- a/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
+++ b/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
@@ -8,7 +8,7 @@ class BraintreeAmexExpress_IntegrationTests: XCTestCase {
     func testGetRewardsBalance_returnsResult() async {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)!
         let cardClient = BTCardClient(apiClient: apiClient)
-        let amexClient = BTAmericanExpressClient(apiClient: apiClient)
+        let amexClient = BTAmericanExpressClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         
         let card = BTCard(
             number: "371260714673002",

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
-        let amexClient = BTAmericanExpressClient(apiClient: apiClient)
+        let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let applePayClient = BTApplePayClient(apiClient: apiClient)
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -14,6 +14,7 @@ import BraintreeSEPADirectDebit
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
+        // TODO: remove in the final PR for making authorization internal
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
         let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
-        let amexClient = BTAmericanExpressClient(apiClient: apiClient)
+        let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let applePayClient = BTApplePayClient(apiClient: apiClient)
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -14,6 +14,7 @@ import BraintreeSEPADirectDebit
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
+        // TODO: remove in the final PR for making authorization internal
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
         let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -11,7 +11,7 @@ import BraintreeCore
     var apiClient: BTAPIClient
     
     ///  Creates an American Express client.
-    /// - Parameter authorization: Your client token or tokenization key
+    /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls
     @objc(initWithAPIClient:)
     public init(authorization: String) {
         self.apiClient = BTAPIClient(newAuthorization: authorization)

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -11,7 +11,7 @@ import BraintreeCore
     var apiClient: BTAPIClient
     
     ///  Creates an American Express client.
-    /// - Parameter authorization: A client token or tokenization key
+    /// - Parameter authorization: Your client token or tokenization key
     @objc(initWithAPIClient:)
     public init(authorization: String) {
         self.apiClient = BTAPIClient(newAuthorization: authorization)

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -10,10 +10,10 @@ import BraintreeCore
     private let apiClient: BTAPIClient
     
     ///  Creates an American Express client.
-    /// - Parameter apiClient: An instance of `BTAPIClient`
+    /// - Parameter authorization: A client token or tokenization key
     @objc(initWithAPIClient:)
-    public init(apiClient: BTAPIClient) {
-        self.apiClient = apiClient
+    public init(authorization: String) {
+        self.apiClient = BTAPIClient(newAuthorization: authorization)
     }
     
     ///  Gets the rewards balance associated with a Braintree nonce. Only for American Express cards.

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -7,7 +7,8 @@ import BraintreeCore
 ///  `BTAmericanExpressClient` enables you to look up the rewards balance of American Express cards.
 @objc public class BTAmericanExpressClient: NSObject {
     
-    private let apiClient: BTAPIClient
+    /// exposed for testing
+    var apiClient: BTAPIClient
     
     ///  Creates an American Express client.
     /// - Parameter authorization: A client token or tokenization key

--- a/Sources/BraintreeCore/Authorization/ClientAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/ClientAuthorization.swift
@@ -24,4 +24,5 @@ public protocol ClientAuthorization {
 public enum AuthorizationType {
     case tokenizationKey
     case clientToken
+    case invalidAuthorization
 }

--- a/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// An invalid authorization type
+class InvalidAuthorization: ClientAuthorization {
+    
+    let type = AuthorizationType.invalidAuthorization
+    let configURL: URL
+    let bearer: String
+    let originalValue: String
+    
+    init(_ rawValue: String) {
+        self.bearer = rawValue
+        self.originalValue = rawValue
+        self.configURL = URL(string: "https://example.com")!
+    }
+}

--- a/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
@@ -11,6 +11,8 @@ class InvalidAuthorization: ClientAuthorization {
     init(_ rawValue: String) {
         self.bearer = rawValue
         self.originalValue = rawValue
+        
+        // swiftlint:disable:next force_unwrapping
         self.configURL = URL(string: "https://example.com")!
     }
 }

--- a/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
@@ -13,6 +13,8 @@ class InvalidAuthorization: ClientAuthorization {
         self.originalValue = rawValue
         
         // swiftlint:disable:next force_unwrapping
-        self.configURL = URL(string: "https://example.com")!
+        /// This URL is never used in the SDK as we always return an error if the authorization type is `.invalidAuthorization`
+        /// before construting or using the `configURL` in any way
+        self.configURL = URL(string: "https://paypal.com")!
     }
 }

--- a/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
@@ -11,8 +11,8 @@ class InvalidAuthorization: ClientAuthorization {
     init(_ rawValue: String) {
         self.bearer = rawValue
         self.originalValue = rawValue
-        
-        // swiftlint:disable:next force_unwrapping
+      
+        // swiftlint:disable force_unwrapping
         /// This URL is never used in the SDK as we always return an error if the authorization type is `.invalidAuthorization`
         /// before construting or using the `configURL` in any way
         self.configURL = URL(string: "https://paypal.com")!

--- a/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
+++ b/Sources/BraintreeCore/Authorization/InvalidAuthorization.swift
@@ -11,10 +11,11 @@ class InvalidAuthorization: ClientAuthorization {
     init(_ rawValue: String) {
         self.bearer = rawValue
         self.originalValue = rawValue
-      
+  
+        // TODO: consider reworking this protocol logic in a future version
         // swiftlint:disable force_unwrapping
         /// This URL is never used in the SDK as we always return an error if the authorization type is `.invalidAuthorization`
-        /// before construting or using the `configURL` in any way
+        /// before construting or using the `configURL` in any way. This URL is currently required per the protocol.
         self.configURL = URL(string: "https://paypal.com")!
     }
 }

--- a/Sources/BraintreeCore/Authorization/TokenizationKey.swift
+++ b/Sources/BraintreeCore/Authorization/TokenizationKey.swift
@@ -17,6 +17,7 @@ class TokenizationKey: ClientAuthorization {
         guard let configURL = TokenizationKey.baseURLFromTokenizationKey(rawValue) else {
             throw TokenizationKeyError.invalid
         }
+        
         self.configURL = configURL
     }
     

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -69,26 +69,21 @@ import Foundation
     }
    
     // TODO: remove obj-c init once we can remove the old init
-    // TODO: remove default/optional nil, needed currently because otherwise there is and error that the signatures are the same
     // TODO: rename param to authorization in final PR
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token.
     @_documentation(visibility: private)
     @objc(initWithAuthorizationNew:)
-    public convenience init(newAuthorization: String? = nil) {
-        
-        // TODO: this will not be force unwrapped once we remove the other init
-        self.init(authorization: newAuthorization ?? "")!
-
+    public init(newAuthorization: String) {
+        self.authorization = Self.authorization(from: newAuthorization)
         self.metadata = BTClientMetadata()
-
-        // TODO: remove default and enforce authorization above
-        self.authorization = self.authorization(from: newAuthorization ?? "")
-        
+                
         let btHttp = BTHTTP(authorization: self.authorization)
         http = btHttp
         configurationLoader = ConfigurationLoader(http: btHttp)
+        
+        super.init()
         
         analyticsService.setAPIClient(self)
         http?.networkTimingDelegate = self
@@ -386,7 +381,7 @@ import Foundation
         }
     }
     
-    private func authorization(from authorization: String) -> ClientAuthorization {
+    private static func authorization(from authorization: String) -> ClientAuthorization {
         let authorizationType = Self.authorizationType(for: authorization)
 
         switch authorizationType {

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 /// This class acts as the entry point for accessing the Braintree APIs via common HTTP methods performed on API endpoints.
 /// - Note: It also manages authentication via tokenization key and provides access to a merchant's gateway configuration.
 @objcMembers public class BTAPIClient: NSObject, BTHTTPNetworkTiming {

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -29,6 +29,7 @@ import Foundation
 
     // MARK: - Initializers
 
+    // TODO: remove in final PR
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token. Passing an invalid value may return `nil`.
     @objc(initWithAuthorization:)

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftlint:disable type_body_length
 /// This class acts as the entry point for accessing the Braintree APIs via common HTTP methods performed on API endpoints.
 /// - Note: It also manages authentication via tokenization key and provides access to a merchant's gateway configuration.
 @objcMembers public class BTAPIClient: NSObject, BTHTTPNetworkTiming {
@@ -9,7 +10,7 @@ import Foundation
     public typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
 
     // MARK: - Public Properties
-    
+
     /// The TokenizationKey or ClientToken used to authorize the APIClient
     public var authorization: ClientAuthorization
 
@@ -68,20 +69,18 @@ import Foundation
         }
     }
    
-    // TODO: remove obj-c init once we can remove the old init
-    // TODO: rename param to authorization in final PR
+    // TODO: rename param to authorization in final PR - set as newAuthorization currently since otherwise the two inits have the same signature
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token.
     @_documentation(visibility: private)
-    @objc(initWithAuthorizationNew:)
     public init(newAuthorization: String) {
         self.authorization = Self.authorization(from: newAuthorization)
         self.metadata = BTClientMetadata()
                 
-        let btHttp = BTHTTP(authorization: self.authorization)
-        http = btHttp
-        configurationLoader = ConfigurationLoader(http: btHttp)
+        let btHTTP = BTHTTP(authorization: self.authorization)
+        http = btHTTP
+        configurationLoader = ConfigurationLoader(http: btHTTP)
         
         super.init()
         
@@ -330,9 +329,11 @@ import Foundation
 
     static func authorizationType(for authorization: String) -> AuthorizationType {
         let pattern: String = "([a-zA-Z0-9]+)_[a-zA-Z0-9]+_([a-zA-Z0-9_]+)"
-        let regularExpression = try? NSRegularExpression(pattern: pattern)
+        guard let regularExpression = try? NSRegularExpression(pattern: pattern) else {
+            return .invalidAuthorization
+        }
 
-        let tokenizationKeyMatch: NSTextCheckingResult? = regularExpression?.firstMatch(
+        let tokenizationKeyMatch: NSTextCheckingResult? = regularExpression.firstMatch(
             in: authorization,
             options: [],
             range: NSRange(location: 0, length: authorization.count)

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -121,28 +121,19 @@ import Foundation
     @_documentation(visibility: private)
     public func fetchOrReturnRemoteConfiguration(_ completion: @escaping (BTConfiguration?, Error?) -> Void) {
         // TODO: - Consider updating all feature clients to use async version of this method?
-        
-        if authorization.type == .invalidAuthorization {
-            completion(nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
-        } else {
-            Task { @MainActor in
-                do {
-                    let configuration = try await configurationLoader.getConfig()
-                    setupHTTPCredentials(configuration)
-                    completion(configuration, nil)
-                } catch {
-                    completion(nil, error)
-                }
+        Task { @MainActor in
+            do {
+                let configuration = try await configurationLoader.getConfig()
+                setupHTTPCredentials(configuration)
+                completion(configuration, nil)
+            } catch {
+                completion(nil, error)
             }
         }
     }
     
     @MainActor func fetchConfiguration() async throws -> BTConfiguration {
-        if authorization.type == .invalidAuthorization {
-            throw BTAPIClientError.invalidAuthorization(authorization.originalValue)
-        } else {
-            try await configurationLoader.getConfig()
-        }
+        try await configurationLoader.getConfig()
     }
     
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
@@ -163,6 +154,11 @@ import Foundation
         httpType: BTAPIClientHTTPService = .gateway,
         completion: @escaping RequestCompletion
     ) {
+        if authorization.type == .invalidAuthorization {
+            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
+            return
+        }
+
         fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
             guard let self else {
                 completion(nil, nil, BTAPIClientError.deallocated)
@@ -198,6 +194,11 @@ import Foundation
         httpType: BTAPIClientHTTPService = .gateway,
         completion: @escaping RequestCompletion
     ) {
+        if authorization.type == .invalidAuthorization {
+            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
+            return
+        }
+
         fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
             guard let self else {
                 completion(nil, nil, BTAPIClientError.deallocated)
@@ -233,6 +234,11 @@ import Foundation
         httpType: BTAPIClientHTTPService = .gateway,
         completion: @escaping RequestCompletion
     ) {
+        if authorization.type == .invalidAuthorization {
+            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
+            return
+        }
+
         fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
             guard let self else {
                 completion(nil, nil, BTAPIClientError.deallocated)

--- a/Sources/BraintreeCore/BTAPIClientError.swift
+++ b/Sources/BraintreeCore/BTAPIClientError.swift
@@ -53,7 +53,6 @@ public enum BTAPIClientError: Error, CustomNSError, LocalizedError, Equatable {
             
         case .invalidAuthorization(let authorization):
             return "Invalid authorization provided: \(authorization)."
-
         }
     }
 }

--- a/Sources/BraintreeCore/BTAPIClientError.swift
+++ b/Sources/BraintreeCore/BTAPIClientError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 ///  Error codes associated with a API Client.
-public enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError, Equatable {
+public enum BTAPIClientError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 0. Configuration fetch failed
     case configurationUnavailable
@@ -14,13 +14,27 @@ public enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError, Equatab
     
     /// 3. Failed to base64 encode an authorizationFingerprint or tokenizationKey, when used as a cacheKey
     case failedBase64Encoding
+    
+    /// 4. Invalid authorization
+    case invalidAuthorization(String)
 
     public static var errorDomain: String {
         "com.braintreepayments.BTAPIClientErrorDomain"
     }
 
     public var errorCode: Int {
-        rawValue
+        switch self {
+        case .configurationUnavailable:
+            return 0
+        case .notAuthorized:
+            return 1
+        case .deallocated:
+            return 2
+        case .failedBase64Encoding:
+            return 3
+        case .invalidAuthorization:
+            return 4
+        }
     }
 
     public var errorDescription: String? {
@@ -36,6 +50,10 @@ public enum BTAPIClientError: Int, Error, CustomNSError, LocalizedError, Equatab
             
         case .failedBase64Encoding:
             return "Unable to base64 encode the authorization string."
+            
+        case .invalidAuthorization(let authorization):
+            return "Invalid authorization provided: \(authorization)."
+
         }
     }
 }

--- a/Sources/BraintreeCore/BTAPIClientError.swift
+++ b/Sources/BraintreeCore/BTAPIClientError.swift
@@ -52,7 +52,7 @@ public enum BTAPIClientError: Error, CustomNSError, LocalizedError, Equatable {
             return "Unable to base64 encode the authorization string."
             
         case .invalidAuthorization(let authorization):
-            return "Invalid authorization provided: \(authorization)."
+            return "Invalid authorization provided: \(authorization). See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ios/v6#initialization for more info."
         }
     }
 }

--- a/Sources/BraintreeCore/BTHTTPError.swift
+++ b/Sources/BraintreeCore/BTHTTPError.swift
@@ -41,6 +41,9 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 12. Deallocated HTTPClient
     case deallocated(String)
+    
+    /// 13. Invalid authorization
+    case invalidAuthorization(String)
 
     public static var errorDomain: String {
         BTCoreConstants.httpErrorDomain
@@ -74,6 +77,8 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
             return 11
         case .deallocated:
             return 12
+        case .invalidAuthorization:
+            return 13
         }
     }
 
@@ -105,6 +110,8 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
             return [NSLocalizedDescriptionKey: errorDescription]
         case .deallocated(let httpType):
             return [NSLocalizedDescriptionKey: "\(httpType) has been deallocated."]
+        case .invalidAuthorization(let authorization):
+            return [NSLocalizedDescriptionKey: "Invalid authorization provided: \(authorization)."]
         }
     }
 

--- a/Sources/BraintreeCore/BTHTTPError.swift
+++ b/Sources/BraintreeCore/BTHTTPError.swift
@@ -41,9 +41,6 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
 
     /// 12. Deallocated HTTPClient
     case deallocated(String)
-    
-    /// 13. Invalid authorization
-    case invalidAuthorization(String)
 
     public static var errorDomain: String {
         BTCoreConstants.httpErrorDomain
@@ -77,8 +74,6 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
             return 11
         case .deallocated:
             return 12
-        case .invalidAuthorization:
-            return 13
         }
     }
 
@@ -110,8 +105,6 @@ public enum BTHTTPError: Error, CustomNSError, LocalizedError, Equatable {
             return [NSLocalizedDescriptionKey: errorDescription]
         case .deallocated(let httpType):
             return [NSLocalizedDescriptionKey: "\(httpType) has been deallocated."]
-        case .invalidAuthorization(let authorization):
-            return [NSLocalizedDescriptionKey: "Invalid authorization provided: \(authorization)."]
         }
     }
 

--- a/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
+++ b/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
@@ -105,7 +105,7 @@ class BTAmericanExpressClient_Tests: XCTestCase {
             XCTAssertNil(rewardsBalance)
             if let error = error as NSError? {
                 XCTAssertEqual(error.code, BTAPIClientError.invalidAuthorization("").errorCode)
-                XCTAssertEqual(error.localizedDescription, "Invalid authorization provided: badAuth.")
+                XCTAssertEqual(error.localizedDescription, "Invalid authorization provided: badAuth. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ios/v6#initialization for more info.")
                 XCTAssertEqual(error.domain, BTAPIClientError.errorDomain)
             }
             

--- a/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
+++ b/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
@@ -10,12 +10,12 @@ class BTAmericanExpressClient_Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
-        amexClient = BTAmericanExpressClient(apiClient: mockAPIClient)
+        amexClient = BTAmericanExpressClient(authorization: "development_tokenization_key")
+        amexClient?.apiClient = mockAPIClient
     }
     
     func testGetRewardsBalance_formatsGETRequest() async {
-        let result = try? await amexClient!.getRewardsBalance(forNonce: "fake-nonce", currencyISOCode: "fake-code")
+        let _ = try? await amexClient!.getRewardsBalance(forNonce: "fake-nonce", currencyISOCode: "fake-code")
         
         XCTAssertEqual(mockAPIClient.lastGETPath, "v1/payment_methods/amex_rewards_balance")
         
@@ -90,5 +90,28 @@ class BTAmericanExpressClient_Tests: XCTestCase {
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "amex:rewards-balance:started")
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, "amex:rewards-balance:failed")
+    }
+    
+    func testGetRewardsBalance_withInvalidAuthorization_returnsError() {
+        amexClient = BTAmericanExpressClient(authorization: "badAuth")
+        mockAPIClient.cannedResponseError = NSError(
+            domain: BTAPIClientError.errorDomain,
+            code: BTAPIClientError.invalidAuthorization("").errorCode,
+            userInfo: [NSLocalizedDescriptionKey: BTAPIClientError.invalidAuthorization("").errorDescription ?? ""]
+        )
+        
+        let expectation = expectation(description: "Amex reward balance should return invalid authorization error")
+        amexClient?.getRewardsBalance(forNonce: "", currencyISOCode: "") { rewardsBalance, error in
+            XCTAssertNil(rewardsBalance)
+            if let error = error as NSError? {
+                XCTAssertEqual(error.code, BTAPIClientError.invalidAuthorization("").errorCode)
+                XCTAssertEqual(error.localizedDescription, "Invalid authorization provided: badAuth.")
+                XCTAssertEqual(error.domain, BTAPIClientError.errorDomain)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2)
     }
 }

--- a/UnitTests/BraintreeCoreTests/Configuration/ConfigurationLoader_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Configuration/ConfigurationLoader_Tests.swift
@@ -75,7 +75,7 @@ class ConfigurationLoader_Tests: XCTestCase {
         } catch {
             guard let error = error as NSError? else { return }
             XCTAssertEqual(error.domain, BTAPIClientError.errorDomain)
-            XCTAssertEqual(error.code, BTAPIClientError.configurationUnavailable.rawValue)
+            XCTAssertEqual(error.code, BTAPIClientError.configurationUnavailable.errorCode)
             XCTAssertEqual(error.localizedDescription, "The operation couldn’t be completed. Unable to fetch remote configuration from Braintree API at this time.")
         }
     }

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -71,7 +71,7 @@ The PayPal Native Checkout integration is no longer supported. Please remove it 
 use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal/overview/ios/v6) integration.
 
 ## American Express
-Update initazlier for `BTAmericanExpressClient`:
+Update initializer for `BTAmericanExpressClient`:
 ```diff
 -  var amexClient = BTAmericanExpressClient(apiClient: apiClient)
 +   var amexClient = BTAmericanExpressClient(authorization: authorization)

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -14,6 +14,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [3D Secure](#3d-secure)]
 1. [PayPal](#paypal)
 1. [PayPal Native Checkout](#paypal-native-checkout)
+1. [American Express](#american-express)
 
 ## Supported Versions
 
@@ -68,3 +69,10 @@ For the App Switch flow, you must update your `info.plist` with a simplified URL
 ## PayPal Native Checkout
 The PayPal Native Checkout integration is no longer supported. Please remove it from your app and 
 use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal/overview/ios/v6) integration.
+
+## American Express
+Update initazlier for `BTAmericanExpressClient`:
+```diff
+-  var amexClient = BTAmericanExpressClient(apiClient: apiClient)
++   var amexClient = BTAmericanExpressClient(authorization: authorization)
+```


### PR DESCRIPTION
### Summary of changes

- Update initializer to `BTAmericanExpressClient(authorization:)`
- Add `InvalidAuthorization` type - this matches the [pattern used on Android](https://github.com/braintree/braintree_android/blob/main/BraintreeCore/src/main/java/com/braintreepayments/api/core/InvalidAuthorization.kt)
- Update `BTAPIClient` initializer to require an authorization string
- Add new `BTAPIClientError.invalidAuthorization`
- Update `PaymentButtonBaseViewController` with new authorization string
- Update `AmexViewController` demo app with new initializer
- Update unit and integration tests
- Add `TODO`s for final PR cleanup

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
