### PR TITLE
Api client update apple pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
     * Update PayPal app URL query scheme from `paypal-app-switch-checkout` to `paypal`
   * BraintreeAmericanExpress
     * Update initializer to `BTAmericanExpressClient(authorization:)`
+  * BraintreeApplePay
+    * Update initializer to `BTApplePayClient(authorization:)`
 
 ## 6.27.0 (2025-01-23)
 * BraintreePayPal

--- a/Demo/Application/Features/ApplePayViewController.swift
+++ b/Demo/Application/Features/ApplePayViewController.swift
@@ -4,7 +4,7 @@ import PassKit
 
 class ApplePayViewController: PaymentButtonBaseViewController {
 
-    lazy var applePayClient = BTApplePayClient(apiClient: apiClient)
+    lazy var applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Demo/Application/Features/ApplePayViewController.swift
+++ b/Demo/Application/Features/ApplePayViewController.swift
@@ -4,7 +4,7 @@ import PassKit
 
 class ApplePayViewController: PaymentButtonBaseViewController {
 
-    lazy var applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+    lazy var applePayClient = BTApplePayClient(authorization: authorization)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
@@ -7,7 +7,7 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
 
     func testTokenizeApplePayPayment_whenApplePayEnabledInControlPanel_returnsANonce() {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
-        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 
         applePayClient.tokenize(PKPayment()) { tokenizedApplePayAccount, error in
@@ -26,7 +26,7 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
 
     func testTokenizeApplePayPayment_whenApplePayDisabledInControlPanel_returnsError() {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)!
-        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 
         applePayClient.tokenize(PKPayment()) { nonce, error in

--- a/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
@@ -8,6 +8,9 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
     func testTokenizeApplePayPayment_whenApplePayEnabledInControlPanel_returnsANonce() {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
         let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+
+        applePayClient.apiClient = apiClient
+        
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 
         applePayClient.tokenize(PKPayment()) { tokenizedApplePayAccount, error in
@@ -27,6 +30,9 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
     func testTokenizeApplePayPayment_whenApplePayDisabledInControlPanel_returnsError() {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)!
         let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+
+        applePayClient.apiClient = apiClient
+
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 
         applePayClient.tokenize(PKPayment()) { nonce, error in

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
         let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
-        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
         let apiClient = BTAPIClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")!
 
         let amexClient = BTAmericanExpressClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
-        let applePayClient = BTApplePayClient(apiClient: apiClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let cardClient = BTCardClient(apiClient: apiClient)
         let dataCollector = BTDataCollector(apiClient: apiClient)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -12,8 +12,6 @@ import BraintreeCore
 
     /// Exposed for testing to get the instance of BTAPIClient
     var apiClient: BTAPIClient
-    
-    let authorization: String
 
     // MARK: - Initializer
 
@@ -21,8 +19,7 @@ import BraintreeCore
     /// - Parameter apiClient: An API client
     @objc(initWithAPIClient:)
     public init(authorization: String) {
-        apiClient = BTAPIClient(authorization: authorization)!
-        self.authorization = authorization
+        self.apiClient = BTAPIClient(newAuthorization: authorization)
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -16,8 +16,8 @@ import BraintreeCore
     // MARK: - Initializer
 
     /// Creates an Apple Pay client
-    /// - Parameter apiClient: An API client
-    @objc(initWithAPIClient:)
+    /// - Parameter authorization: A client token or tokenization key
+    @objc(initWithAuthorization:)
     public init(authorization: String) {
         self.apiClient = BTAPIClient(newAuthorization: authorization)
     }

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -12,14 +12,17 @@ import BraintreeCore
 
     /// Exposed for testing to get the instance of BTAPIClient
     var apiClient: BTAPIClient
+    
+    let authorization: String
 
     // MARK: - Initializer
 
     /// Creates an Apple Pay client
     /// - Parameter apiClient: An API client
     @objc(initWithAPIClient:)
-    public init(apiClient: BTAPIClient) {
-        self.apiClient = apiClient
+    public init(authorization: String) {
+        apiClient = BTAPIClient(authorization: authorization)!
+        self.authorization = authorization
     }
 
     // MARK: - Public Methods

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -20,7 +20,7 @@ class BTApplePay_Tests: XCTestCase {
                 "status" : "off"
             ]
         ])
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -36,7 +36,7 @@ class BTApplePay_Tests: XCTestCase {
 
     func testPaymentRequest_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any?])
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -60,7 +60,7 @@ class BTApplePay_Tests: XCTestCase {
                 "supportedNetworks": ["visa", "mastercard", "amex"]
             ] as [String: Any]
         ])
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -86,7 +86,7 @@ class BTApplePay_Tests: XCTestCase {
                 "status" : "production"
             ]
         ])
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -116,7 +116,7 @@ class BTApplePay_Tests: XCTestCase {
         ])
         let expectation = self.expectation(description: "Unsuccessful tokenization")
 
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             guard let error = error as NSError? else {return}
@@ -133,7 +133,7 @@ class BTApplePay_Tests: XCTestCase {
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
         let expectation = self.expectation(description: "Unsuccessful tokenization")
 
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             guard let error = error as NSError? else {return}
@@ -148,7 +148,7 @@ class BTApplePay_Tests: XCTestCase {
 
     func testTokenization_whenConfigurationFetchErrorOccurs_callsBackWithError() {
         mockClient.cannedConfigurationResponseError = NSError(domain: "MyError", code: 1, userInfo: nil)
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization error")
 
@@ -170,7 +170,7 @@ class BTApplePay_Tests: XCTestCase {
         ])
         mockClient.cannedHTTPURLResponse = HTTPURLResponse(url: URL(string: "any")!, statusCode: 503, httpVersion: nil, headerFields: nil)
         mockClient.cannedResponseError = NSError(domain: "foo", code: 100, userInfo: nil)
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization failure")
 
@@ -189,7 +189,7 @@ class BTApplePay_Tests: XCTestCase {
             ]
         ])
         mockClient.cannedResponseError = NSError(domain: "MyError", code: 1, userInfo: nil)
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization failure")
 
@@ -232,7 +232,7 @@ class BTApplePay_Tests: XCTestCase {
         )
         let expectation = self.expectation(description: "successful tokenization")
 
-        let client = BTApplePayClient(apiClient: mockClient)
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             XCTAssertNil(error)
@@ -259,7 +259,7 @@ class BTApplePay_Tests: XCTestCase {
         mockClient.cannedConfigurationResponseBody = BTJSON(value: ["applePay" : ["status" : "production"]])
         mockClient.cannedResponseBody = nil
 
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         let expectation = expectation(description: "Callback invoked")
 
@@ -280,7 +280,7 @@ class BTApplePay_Tests: XCTestCase {
         mockClient.cannedConfigurationResponseBody = BTJSON(value: ["applePay" : ["status" : "production"]])
         mockClient.cannedResponseBody = BTJSON(value: ["notApplePayCards": "badData"])
 
-        let applePayClient = BTApplePayClient(apiClient: mockClient)
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         let payment = MockPKPayment()
         let expectation = expectation(description: "Callback invoked")
 
@@ -306,7 +306,7 @@ class BTApplePay_Tests: XCTestCase {
                 "status" : "production"
             ]
         ])
-        let applePayClient = BTApplePayClient(apiClient: mockAPIClient)
+        let applePayClient = BTApplePayClient(authorization: "production_t2wns2y2_dfy45jdj3dxkmz5m")
         let payment = MockPKPayment()
 
         let expectation = self.expectation(description: "Tokenized card")

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -15,12 +15,15 @@ class BTApplePay_Tests: XCTestCase {
     // MARK: - Payment Request
 
     func testPaymentRequest_whenConfiguredOff_callsBackWithError() {
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "off"
             ]
         ])
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        applePayClient.apiClient = mockClient
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -35,8 +38,10 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testPaymentRequest_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
-        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any?])
         let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any?])
+        
+        applePayClient.apiClient = mockClient
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -51,6 +56,8 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testPaymentRequest_returnsPaymentRequestUsingConfiguration() {
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production",
@@ -60,7 +67,8 @@ class BTApplePay_Tests: XCTestCase {
                 "supportedNetworks": ["visa", "mastercard", "amex"]
             ] as [String: Any]
         ])
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        applePayClient.apiClient = mockClient
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -81,12 +89,15 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testPaymentRequest_whenConfigurationIsMissingValues_returnsPaymentRequestWithValuesUndefined() {
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"
             ]
         ])
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        applePayClient.apiClient = mockClient
 
         let expectation = self.expectation(description: "Callback invoked")
         applePayClient.makePaymentRequest { (paymentRequest, error) in
@@ -109,14 +120,18 @@ class BTApplePay_Tests: XCTestCase {
     // MARK: - Tokenization
 
     func testTokenization_whenConfiguredOff_callsBackWithError() {
+        let expectation = self.expectation(description: "Unsuccessful tokenization")
+
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "off"
             ]
         ])
-        let expectation = self.expectation(description: "Unsuccessful tokenization")
-
-        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        client.apiClient = mockClient
+        
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             guard let error = error as NSError? else {return}
@@ -130,10 +145,14 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenConfigurationIsMissingApplePayStatus_callsBackWithError() {
-        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
         let expectation = self.expectation(description: "Unsuccessful tokenization")
 
         let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        mockClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [AnyHashable: Any])
+        
+        client.apiClient = mockClient
+        
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             guard let error = error as NSError? else {return}
@@ -147,8 +166,10 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenConfigurationFetchErrorOccurs_callsBackWithError() {
-        mockClient.cannedConfigurationResponseError = NSError(domain: "MyError", code: 1, userInfo: nil)
         let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        mockClient.cannedConfigurationResponseError = NSError(domain: "MyError", code: 1, userInfo: nil)
+        client.apiClient = mockClient
+        
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization error")
 
@@ -163,6 +184,8 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenTokenizationErrorOccurs_callsBackWithError() {
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"
@@ -170,7 +193,9 @@ class BTApplePay_Tests: XCTestCase {
         ])
         mockClient.cannedHTTPURLResponse = HTTPURLResponse(url: URL(string: "any")!, statusCode: 503, httpVersion: nil, headerFields: nil)
         mockClient.cannedResponseError = NSError(domain: "foo", code: 100, userInfo: nil)
-        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        client.apiClient = mockClient
+        
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization failure")
 
@@ -183,13 +208,17 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenTokenizationFailureOccurs_callsBackWithError() {
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"
             ]
         ])
         mockClient.cannedResponseError = NSError(domain: "MyError", code: 1, userInfo: nil)
-        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        client.apiClient = mockClient
+        
         let payment = MockPKPayment()
         let expectation = self.expectation(description: "tokenization failure")
 
@@ -204,6 +233,9 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenization_whenSuccessfulTokenizationInProduction_callsBackWithTokenizedPayment() {
+        let expectation = self.expectation(description: "successful tokenization")
+
+        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
         mockClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"
@@ -230,9 +262,8 @@ class BTApplePay_Tests: XCTestCase {
                 ] as [[String: Any]]
             ]
         )
-        let expectation = self.expectation(description: "successful tokenization")
-
-        let client = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        client.apiClient = mockClient
         let payment = MockPKPayment()
         client.tokenize(payment) { (tokenizedPayment, error) -> Void in
             XCTAssertNil(error)
@@ -256,10 +287,13 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenize_whenBodyIsMissingData_returnsError() {
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
         mockClient.cannedConfigurationResponseBody = BTJSON(value: ["applePay" : ["status" : "production"]])
         mockClient.cannedResponseBody = nil
-
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        
+        applePayClient.apiClient = mockClient
+        
         let payment = MockPKPayment()
         let expectation = expectation(description: "Callback invoked")
 
@@ -277,10 +311,13 @@ class BTApplePay_Tests: XCTestCase {
     }
 
     func testTokenize_bodyDoesNotContainApplePayCards_returnsError() {
+        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+
         mockClient.cannedConfigurationResponseBody = BTJSON(value: ["applePay" : ["status" : "production"]])
         mockClient.cannedResponseBody = BTJSON(value: ["notApplePayCards": "badData"])
 
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
+        applePayClient.apiClient = mockClient
+
         let payment = MockPKPayment()
         let expectation = expectation(description: "Callback invoked")
 
@@ -300,13 +337,17 @@ class BTApplePay_Tests: XCTestCase {
     // MARK: - Metadata
 
     func testMetaParameter_whenTokenizationIsSuccessful_isPOSTedToServer() {
+        let applePayClient = BTApplePayClient(authorization: "production_t2wns2y2_dfy45jdj3dxkmz5m")
+                
         let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"
             ]
         ])
-        let applePayClient = BTApplePayClient(authorization: "production_t2wns2y2_dfy45jdj3dxkmz5m")
+        
+        applePayClient.apiClient = mockAPIClient
+                
         let payment = MockPKPayment()
 
         let expectation = self.expectation(description: "Tokenized card")

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -73,14 +73,14 @@ use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal
 
 ## American Express
 Update initializer for `BTAmericanExpressClient`:
-```
+```diff
 -  var amexClient = BTAmericanExpressClient(apiClient: apiClient)
 +  var amexClient = BTAmericanExpressClient(authorization: "<CLIENT_AUTHORIZATION>")
 ```
 
 ## Apple Pay
 Update initializer for `BTApplePayClient`:
-```
+```diff
 -  var applePayClient = BTApplePayClient(apiClient: apiClient)
 +  var applePayClient = BTApplePayClient(authorization: "<CLIENT_AUTHORIZATION>")
 ```

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -15,6 +15,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [PayPal](#paypal)
 1. [PayPal Native Checkout](#paypal-native-checkout)
 1. [American Express](#american-express)
+1. [Apple Pay](#american-express)
 
 ## Supported Versions
 
@@ -72,6 +73,10 @@ use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal
 
 ## American Express
 Update initializer for `BTAmericanExpressClient`:
-```diff
 -  var amexClient = BTAmericanExpressClient(apiClient: apiClient)
-+   var amexClient = BTAmericanExpressClient(authorization: "<CLIENT_AUTHORIZATION>")
++  var amexClient = BTAmericanExpressClient(authorization: "<CLIENT_AUTHORIZATION>")
+
+## Apple Pay
+Update initializer for `BTApplePayClient`:
+-  var applePayClient = BTApplePayClient(apiClient: apiClient)
++  var applePayClient = BTApplePayClient(authorization: "<CLIENT_AUTHORIZATION>")

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -73,10 +73,14 @@ use the [PayPal (web)](https://developer.paypal.com/braintree/docs/guides/paypal
 
 ## American Express
 Update initializer for `BTAmericanExpressClient`:
+```
 -  var amexClient = BTAmericanExpressClient(apiClient: apiClient)
 +  var amexClient = BTAmericanExpressClient(authorization: "<CLIENT_AUTHORIZATION>")
+```
 
 ## Apple Pay
 Update initializer for `BTApplePayClient`:
+```
 -  var applePayClient = BTApplePayClient(apiClient: apiClient)
 +  var applePayClient = BTApplePayClient(authorization: "<CLIENT_AUTHORIZATION>")
+```

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -15,7 +15,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [PayPal](#paypal)
 1. [PayPal Native Checkout](#paypal-native-checkout)
 1. [American Express](#american-express)
-1. [Apple Pay](#american-express)
+1. [Apple Pay](#apple-pay)
 
 ## Supported Versions
 


### PR DESCRIPTION
### Summary of changes

Update BTApplePayClient init to BTApplePayClient(authorization: String) ✅ 
Update unit tests ✅ 
Update demo app ✅ 
Add CHANGELOG entry ✅ 
Add migration guide entry ✅ 

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@jwarmkessel @warmkesselj 