### PR TITLE
Update Cocoapods to End of Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,11 +88,6 @@ jobs:
           asset_name: Braintree.xcframework.zip
           asset_content_type: application/zip
 
-      - name: Publish to CocoaPods
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push Braintree.podspec
-
       - name: Publish reference docs
         run: |
           gem install jazzy
@@ -129,3 +124,8 @@ jobs:
           git add current ${{ github.event.inputs.version }}
           git commit -m "Publish ${{ github.event.inputs.version }} docs to github pages"
           git push
+
+      - name: Publish to CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push Braintree.podspec


### PR DESCRIPTION
### Summary of changes

Move the cocoapods portion of the release to the last step. We’ve been seeing failures with this step recently and the reference docs are the step after. The reference docs are one of the mere tedious steps to release manually. Due to cocoapods being deprecated we can likely expect the cocapods portion of the release to fail more often (as we have seen). This allows us to hopefully have the least amount of steps to do manually if the release fails as cocoapods is often our failing step. We can then release cocoapods via the command line when we see these failures without also needing to do the reference docs.

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 