### PR TITLE
Bug Fix: Universal Links in Same View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Fix bug where instantiating multiple feature clients with  universal links in the same view causes `handleOpen` to return in the wrong feature client
+
 ## 6.29.0 (2025-02-24)
 * BraintreePayPal
   * Add PayPal App Switch checkout flow (BETA)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -93,7 +93,10 @@ import BraintreeDataCollector
     @objc(initWithAPIClient:universalLink:)
     public convenience init(apiClient: BTAPIClient, universalLink: URL) {
         self.init(apiClient: apiClient)
-        self.universalLink = universalLink.appendingPathComponent("payPal")
+        
+        /// appending a PayPal app switch specific path to verify we are in the correct flow when
+        /// `canHandleReturnURL` is called
+        self.universalLink = universalLink.appendingPathComponent("braintreeAppSwitchPayPal")
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -93,7 +93,7 @@ import BraintreeDataCollector
     @objc(initWithAPIClient:universalLink:)
     public convenience init(apiClient: BTAPIClient, universalLink: URL) {
         self.init(apiClient: apiClient)
-        self.universalLink = universalLink
+        self.universalLink = universalLink.appendingPathComponent("payPal")
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -39,9 +39,7 @@ struct BTPayPalReturnURL {
     /// - Parameter url: an app switch or ASWebAuthenticationSession return URL
     /// - Returns: `true` if the url represents a valid PayPal app switch return
     static func isValid(_ url: URL) -> Bool {
-        url.scheme == "https"
-        && (url.path.contains("success") && (url.absoluteString.contains("token") || url.absoluteString.contains("ba_token")))
-        || (url.path.contains("cancel"))
+        url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success")) && url.path.contains("payPal")
     }
 
     static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -39,7 +39,9 @@ struct BTPayPalReturnURL {
     /// - Parameter url: an app switch or ASWebAuthenticationSession return URL
     /// - Returns: `true` if the url represents a valid PayPal app switch return
     static func isValid(_ url: URL) -> Bool {
-        url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success"))
+        url.scheme == "https"
+        && (url.absoluteString.contains("token") || url.absoluteString.contains("ba_token"))
+        && (url.path.contains("cancel") || url.path.contains("success"))
     }
 
     static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -39,7 +39,9 @@ struct BTPayPalReturnURL {
     /// - Parameter url: an app switch or ASWebAuthenticationSession return URL
     /// - Returns: `true` if the url represents a valid PayPal app switch return
     static func isValid(_ url: URL) -> Bool {
-        url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success")) && url.path.contains("payPal")
+        url.scheme == "https"
+        && (url.path.contains("cancel") || url.path.contains("success"))
+        && url.path.contains("braintreeAppSwitchPayPal")
     }
 
     static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -40,8 +40,8 @@ struct BTPayPalReturnURL {
     /// - Returns: `true` if the url represents a valid PayPal app switch return
     static func isValid(_ url: URL) -> Bool {
         url.scheme == "https"
-        && (url.absoluteString.contains("token") || url.absoluteString.contains("ba_token"))
-        && (url.path.contains("cancel") || url.path.contains("success"))
+        && (url.path.contains("success") && (url.absoluteString.contains("token") || url.absoluteString.contains("ba_token")))
+        || (url.path.contains("cancel"))
     }
 
     static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {

--- a/Sources/BraintreePayPal/BTPayPalReturnURL.swift
+++ b/Sources/BraintreePayPal/BTPayPalReturnURL.swift
@@ -39,9 +39,12 @@ struct BTPayPalReturnURL {
     /// - Parameter url: an app switch or ASWebAuthenticationSession return URL
     /// - Returns: `true` if the url represents a valid PayPal app switch return
     static func isValid(_ url: URL) -> Bool {
-        url.scheme == "https"
-        && (url.path.contains("cancel") || url.path.contains("success"))
-        && url.path.contains("braintreeAppSwitchPayPal")
+        let isHTTPSScheme = url.scheme == "https"
+        let containsAppSwitchPath = url.path.contains("braintreeAppSwitchPayPal")
+        let containsExpectedPath = url.path.contains("cancel") || url.path.contains("success")
+        let isValidAppSwitchURL = isHTTPSScheme && containsAppSwitchPath && containsExpectedPath
+        
+        return isValidAppSwitchURL
     }
 
     static func isValidURLAction(url: URL, linkType: LinkType?) -> Bool {

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -68,16 +68,9 @@ struct BTVenmoAppSwitchReturnURL {
     /// - Parameter url: an app switch return URL
     /// - Returns: `true` if the url represents a Venmo Touch app switch return
     static func isValid(url: URL) -> Bool {
-        (
-            url.scheme == "https"
-            && (url.path.contains("cancel")
-                || url.path.contains("success")
-                && (url.absoluteString.contains("resource_id")
-                    || url.absoluteString.contains("paymentMethodNonce")
-                    || url.absoluteString.contains("payment_method_nonce"))
-                || url.path.contains("error")
-                && (url.absoluteString.contains("errorMessage") || url.absoluteString.contains("error_message"))
-        ))
+        (url.scheme == "https"
+            && url.path.contains("venmo")
+            && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")))
         || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -64,13 +64,19 @@ struct BTVenmoAppSwitchReturnURL {
 
     // MARK: - Internal Methods
 
-    /// Evaluates whether the url represents a valid Venmo Touch return.
+    /// Evaluates whether the url represents a valid Venmo return.
     /// - Parameter url: an app switch return URL
-    /// - Returns: `true` if the url represents a Venmo Touch app switch return
+    /// - Returns: `true` if the url represents a Venmo app switch return
     static func isValid(url: URL) -> Bool {
-        (url.scheme == "https"
-            && url.path.contains("braintreeAppSwitchVenmo")
-            && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")))
-        || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
+        /// universal link path components
+        let isHTTPSScheme = url.scheme == "https"
+        let containsAppSwitchPath = url.path.contains("braintreeAppSwitchVenmo")
+        let containsExpectedPath = url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")
+        let isValidAppSwitchURL = isHTTPSScheme && containsAppSwitchPath && containsExpectedPath
+        
+        /// url scheme expected host and path components
+        let isValidURLSchemeURL = url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/")
+
+        return isValidURLSchemeURL || isValidAppSwitchURL
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -69,7 +69,7 @@ struct BTVenmoAppSwitchReturnURL {
     /// - Returns: `true` if the url represents a Venmo Touch app switch return
     static func isValid(url: URL) -> Bool {
         (url.scheme == "https"
-            && url.path.contains("venmo")
+            && url.path.contains("braintreeAppSwitchVenmo")
             && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")))
         || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
     }

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -70,11 +70,14 @@ struct BTVenmoAppSwitchReturnURL {
     static func isValid(url: URL) -> Bool {
         (
             url.scheme == "https"
-            && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error"))
-            && (url.absoluteString.contains("resource_id")
-                || url.absoluteString.contains("paymentMethodNonce")
-                || url.absoluteString.contains("payment_method_nonce"))
-        )
+            && (url.path.contains("cancel")
+                || url.path.contains("success")
+                && (url.absoluteString.contains("resource_id")
+                    || url.absoluteString.contains("paymentMethodNonce")
+                    || url.absoluteString.contains("payment_method_nonce"))
+                || url.path.contains("error")
+                && (url.absoluteString.contains("errorMessage") || url.absoluteString.contains("error_message"))
+        ))
         || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAppSwitchReturnURL.swift
@@ -68,7 +68,13 @@ struct BTVenmoAppSwitchReturnURL {
     /// - Parameter url: an app switch return URL
     /// - Returns: `true` if the url represents a Venmo Touch app switch return
     static func isValid(url: URL) -> Bool {
-        (url.scheme == "https" && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error")))
+        (
+            url.scheme == "https"
+            && (url.path.contains("cancel") || url.path.contains("success") || url.path.contains("error"))
+            && (url.absoluteString.contains("resource_id")
+                || url.absoluteString.contains("paymentMethodNonce")
+                || url.absoluteString.contains("payment_method_nonce"))
+        )
         || (url.host == "x-callback-url" && url.path.hasPrefix("/vzero/auth/venmo/"))
     }
 }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -65,7 +65,10 @@ import BraintreeCore
     @objc(initWithAPIClient:universalLink:)
     public convenience init(apiClient: BTAPIClient, universalLink: URL) {
         self.init(apiClient: apiClient)
-        self.universalLink = universalLink.appendingPathComponent("venmo")
+        
+        /// appending a PayPal app switch specific path to verify we are in the correct flow when
+        /// `canHandleReturnURL` is called
+        self.universalLink = universalLink.appendingPathComponent("braintreeAppSwitchVenmo")
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -65,7 +65,7 @@ import BraintreeCore
     @objc(initWithAPIClient:universalLink:)
     public convenience init(apiClient: BTAPIClient, universalLink: URL) {
         self.init(apiClient: apiClient)
-        self.universalLink = universalLink
+        self.universalLink = universalLink.appendingPathComponent("venmo")
     }
 
     // MARK: - Public Methods

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -726,7 +726,7 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testCanHandleReturnURL_whenPathIsValidSuccess_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success?token=1234abc")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -726,17 +726,17 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testCanHandleReturnURL_whenPathIsValidSuccess_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success/payPal")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/braintreeAppSwitchPayPal/success")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
     func testCanHandleReturnURL_whenPathIsValidCancel_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/cancel/payPal")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/braintreeAppSwitchPayPal/cancel")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
     func testCanHandleReturnURL_whenPathIsValidWithQueryParameters_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success/payPal?token=112233")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/braintreeAppSwitchPayPal/success?token=112233")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
@@ -1019,7 +1019,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(lastPostParameters["launch_paypal_app"] as? Bool, true)
         XCTAssertTrue((lastPostParameters["os_version"] as! String).matches("\\d+\\.\\d+"))
         XCTAssertTrue((lastPostParameters["os_type"] as! String).matches("iOS|iPadOS"))
-        XCTAssertEqual(lastPostParameters["merchant_app_return_url"] as? String, "https://www.paypal.com/payPal")
+        XCTAssertEqual(lastPostParameters["merchant_app_return_url"] as? String, "https://www.paypal.com/braintreeAppSwitchPayPal")
     }
 
     func testIsiOSAppSwitchAvailable_whenApplicationCantOpenPayPalInAppURL_returnsFalseAndSendsAnalytics() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -726,17 +726,17 @@ class BTPayPalClient_Tests: XCTestCase {
     }
 
     func testCanHandleReturnURL_whenPathIsValidSuccess_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success?token=1234abc")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success/payPal")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
     func testCanHandleReturnURL_whenPathIsValidCancel_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/cancel")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/cancel/payPal")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
     func testCanHandleReturnURL_whenPathIsValidWithQueryParameters_returnsTrue() {
-        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success?token=112233")!
+        let url = URL(string: "https://mycoolwebsite.com/braintree-payments/success/payPal?token=112233")!
         XCTAssertTrue(BTPayPalClient.canHandleReturnURL(url))
     }
 
@@ -1019,7 +1019,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(lastPostParameters["launch_paypal_app"] as? Bool, true)
         XCTAssertTrue((lastPostParameters["os_version"] as! String).matches("\\d+\\.\\d+"))
         XCTAssertTrue((lastPostParameters["os_type"] as! String).matches("iOS|iPadOS"))
-        XCTAssertEqual(lastPostParameters["merchant_app_return_url"] as? String, "https://www.paypal.com")
+        XCTAssertEqual(lastPostParameters["merchant_app_return_url"] as? String, "https://www.paypal.com/payPal")
     }
 
     func testIsiOSAppSwitchAvailable_whenApplicationCantOpenPayPalInAppURL_returnsFalseAndSendsAnalytics() {


### PR DESCRIPTION
### Summary of changes

- Fix bug where instantiating multiple feature clients with  universal links in the same view causes `handleOpen` to return in the wrong feature client

#### Testing
On main you can see this bug by adding the following in `PayPalWebCheckoutViewController` and tapping the app switch flow:
```swift
/// add under `lazy var payPalClient`
var venmoClient: BTVenmoClient?

/// add to `tappedPayPalAppSwitchForVault`
venmoClient = BTVenmoClient(
    apiClient: apiClient,
    // swiftlint:disable:next force_unwrapping
    universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
)

payPalClient.tokenize(request) { nonce, error in
...
```

If you add a breakpoint to `canHandleReturnURL` in `BTVenmoClient` you will see we hit that breakpoint but not the one in `BTPayPalClient`. This is because our logic in `BTAppContextSwitcher.handleOpen()` checks `canHandleReturnURL` first and then proceeds with only checking this on the first client if `true` - since we are currently only checking `https` and `cancel/success/error` it returns `true` and attempts to proceed with `handleReturnURL` in the wrong feature client. 

To resolve this we can add either `braintreeAppSwitchPayPal` or `braintreeAppSwitchVenmo` to the universal link for the respective flows and check for that as part of the `isValid` check run when `canHandleReturnURL` is called. Since merchants are instructed to wildcard the URLs this should not break existing flows. The full URL with our paths will also be passed to upstream services.

### Checklist

- [x] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
