### PR TITLE
[v7] Update `BTPayPalMessagingView` with new `APIClient` pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
     * Update initializer to `BTApplePayClient(authorization:)`
   * BraintreeDataCollector
     * Update initializer to `BTDataCollector(authorization:)`
+  * BraintreePayPalMessaging (BETA)
+    * Update initializer to `BTPayPalMessagingView(authorization:)`
 
 ## 6.29.0 (2025-02-24)
 * BraintreePayPal

--- a/Demo/Application/Features/PayPalMessagingViewController.swift
+++ b/Demo/Application/Features/PayPalMessagingViewController.swift
@@ -3,7 +3,7 @@ import BraintreePayPalMessaging
 
 class PayPalMessagingViewController: PaymentButtonBaseViewController {
 
-    lazy var payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
+    lazy var payPalMessagingView = BTPayPalMessagingView(authorization: authorization)
 
     let request = BTPayPalMessagingRequest(
         amount: 2.00,

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         let dataCollector = BTDataCollector(authorization: authorization)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)
         let payPalClient = BTPayPalClient(authorization: authorization)
-        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
+        let payPalMessagingView = BTPayPalMessagingView(authorization: authorization)
         let threeDSecureClient = BTThreeDSecureClient(authorization: authorization)
         let venmoClient = BTVenmoClient(
             authorization: authorization,

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         let dataCollector = BTDataCollector(authorization: authorization)
         let localPaymentClient = BTLocalPaymentClient(apiClient: apiClient)
         let payPalClient = BTPayPalClient(authorization: authorization)
-        let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
+        let payPalMessagingView = BTPayPalMessagingView(authorization: authorization)
         let threeDSecureClient = BTThreeDSecureClient(authorization: authorization)
         let venmoClient = BTVenmoClient(
             authorization: authorization,

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -20,9 +20,9 @@ public class BTPayPalMessagingView: UIView {
     // MARK: - Initializers
 
     ///  Initializes a `BTPayPalMessagingView`.
-    /// - Parameter apiClient: The Braintree API client
-    public init(apiClient: BTAPIClient) {
-        self.apiClient = apiClient
+    /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
+    public init(authorization: String) {
+        self.apiClient = BTAPIClient(newAuthorization: authorization)
 
         super.init(frame: .zero)
     }
@@ -121,15 +121,15 @@ public extension BTPayPalMessagingView {
         
         ///  Initializes a `BTPayPalMessagingView`.
         /// - Parameters:
-        ///   - apiClient: The Braintree API client
+        ///   - authorization: A valid client token or tokenization key used to authorize API calls.
         ///   - request: an optional `BTPayPalMessagingRequest`
         ///   - delegate: an optional `BTPayPalMessagingDelegate`
         public init(
-            apiClient: BTAPIClient,
+            authorization: String,
             request: BTPayPalMessagingRequest = BTPayPalMessagingRequest(),
             delegate: BTPayPalMessagingDelegate? = nil
         ) {
-            self.apiClient = apiClient
+            self.apiClient = BTAPIClient(newAuthorization: authorization)
             self.request = request
             self.delegate = delegate
         }
@@ -137,7 +137,7 @@ public extension BTPayPalMessagingView {
         // MARK: - UIViewRepresentable Methods
 
         public func makeUIView(context: Context) -> BTPayPalMessagingView {
-            let payPalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
+            let payPalMessagingView = BTPayPalMessagingView(authorization: apiClient.authorization.originalValue)
             payPalMessagingView.start(request)
             payPalMessagingView.delegate = delegate
             return payPalMessagingView

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -13,6 +13,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "SomeError", code: 999)
 
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
+        payPalMessageView.apiClient = mockAPIClient
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.start()
 
@@ -23,6 +24,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
     func testStart_withNilConfiguration_callsDelegateWithErrorAndSendsAnalytics() {
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
+        payPalMessageView.apiClient = mockAPIClient
         payPalMessageView.start()
 
         XCTAssertEqual(mockDelegate.error as? BTPayPalMessagingError, BTPayPalMessagingError.fetchConfigurationFailed)
@@ -41,6 +43,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
 
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
+        payPalMessageView.apiClient = mockAPIClient
         payPalMessageView.start()
 
         XCTAssertEqual(mockDelegate.error as? BTPayPalMessagingError, BTPayPalMessagingError.payPalClientIDNotFound)
@@ -58,6 +61,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
 
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
+        payPalMessageView.apiClient = mockAPIClient
         payPalMessageView.start()
 
         XCTAssertTrue(mockDelegate.willAppear)
@@ -73,6 +77,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
+        payPalMessageView.apiClient = mockAPIClient
         XCTAssertEqual(payPalMessageView.subviews.count, 0)
         
         payPalMessageView.start()

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -7,11 +7,12 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
 
     var mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
     var mockDelegate = MockBTPayPalMessagingDelegate()
+    let mockTokenizationKey = "development_tokenization_key"
 
     func testStart_withConfigurationError_callsDelegateWithError() {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "SomeError", code: 999)
 
-        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.start()
 
@@ -20,7 +21,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
     }
 
     func testStart_withNilConfiguration_callsDelegateWithErrorAndSendsAnalytics() {
-        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.start()
 
@@ -38,7 +39,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
             ] as [String: Any?]
         )
 
-        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.start()
 
@@ -55,7 +56,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
             ] as [String: Any?]
         )
 
-        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.start()
 
@@ -70,7 +71,7 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
             ] as [String: Any?]
         )
         
-        let payPalMessageView = BTPayPalMessagingView(apiClient: mockAPIClient)
+        let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         XCTAssertEqual(payPalMessageView.subviews.count, 0)
         

--- a/V7_MIGRATION.md
+++ b/V7_MIGRATION.md
@@ -17,6 +17,7 @@ _Documentation for v7 will be published to https://developer.paypal.com/braintre
 1. [American Express](#american-express)
 1. [Apple Pay](#apple-pay)
 1. [Data Collector](#data-collector)
+1. [PayPal Messaging View](#paypal-messaging-view)
 
 ## Supported Versions
 
@@ -122,4 +123,11 @@ Update initializer for `BTDataCollector`:
 ```diff
 - var dataCollector = BTDataCollector(apiClient: apiClient)
 + var dataCollector = BTDataCollector(authorization: "<CLIENT_AUTHORIZATION>")
+```
+
+## PayPal Messaging View
+Update initializer for `BTPayPalMessagingView`:
+```diff
+- var paypalMessagingView = BTPayPalMessagingView(apiClient: apiClient)
++ var paypalMessagingView = BTPayPalMessagingView(authorization: "<CLIENT_AUTHORIZATION>")
 ```


### PR DESCRIPTION
### Summary of changes

- Update `BTPayPalMessagingView` with new `APIClient` pattern 

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
