### PR TITLE
[v7] Remove Old Integration Pattern and Update APIClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
     * Update initializer to `BTThreeDSecureClient(authorization:)`
   * BraintreeCore
     * Remove `fetchPaymentMethodNonces` methods and parser
-    * Make `BTAPIClient` non-optional and update its initializer to require an `authorization` string
   * BraintreeAmericanExpress
     * Update initializer to `BTAmericanExpressClient(authorization:)`
   * BraintreeApplePay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     * Update initializer to `BTThreeDSecureClient(authorization:)`
   * BraintreeCore
     * Remove `fetchPaymentMethodNonces` methods and parser
+    * Make `BTAPIClient` non-optional and update its initializer to require an `authorization` string
   * BraintreeAmericanExpress
     * Update initializer to `BTAmericanExpressClient(authorization:)`
   * BraintreeApplePay

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -3,8 +3,6 @@ import BraintreeCore
 
 class PaymentButtonBaseViewController: BaseViewController {
 
-    // TODO: remove API client in final PR
-    let apiClient: BTAPIClient
     let authorization: String
 
     var heightConstraint: CGFloat?
@@ -12,7 +10,6 @@ class PaymentButtonBaseViewController: BaseViewController {
     private var paymentButton = UIView()
 
     override init(authorization: String) {
-        apiClient = BTAPIClient(authorization: authorization)
         self.authorization = authorization
         super.init(authorization: authorization)
     }

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -12,8 +12,7 @@ class PaymentButtonBaseViewController: BaseViewController {
     private var paymentButton = UIView()
 
     override init(authorization: String) {
-        // swiftlint:disable:next force_unwrapping
-        apiClient = BTAPIClient(authorization: authorization)!
+        apiClient = BTAPIClient(authorization: authorization)
         self.authorization = authorization
         super.init(authorization: authorization)
     }

--- a/IntegrationTests/BTCardClient_IntegrationTests.swift
+++ b/IntegrationTests/BTCardClient_IntegrationTests.swift
@@ -5,9 +5,7 @@ import XCTest
 class BTCardClient_IntegrationTests: XCTestCase {
 
     func testTokenizeCard_whenCardHasValidationDisabledAndCardIsInvalid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        cardClient.apiClient = apiClient
         
         let expectation = expectation(description: "Tokenize card")
         let card = BTCard(
@@ -33,9 +31,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenCardIsInvalidAndValidationIsEnabled_failsWithExpectedValidationError() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
-        cardClient.apiClient = apiClient
         
         let card = BTCard(
             number: "123",
@@ -65,9 +61,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenCardHasValidationDisabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        cardClient.apiClient = apiClient
         
         let expectation = expectation(description: "Tokenize card")
         let card = BTCard(
@@ -108,9 +102,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingTokenizationKeyAndCardHasValidationEnabled_failsWithAuthorizationError() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        cardClient.apiClient = apiClient
         
         let card = BTCard(
             number: "123123",
@@ -140,9 +132,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingClientTokenAndCardHasValidationEnabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
-        cardClient.apiClient = apiClient
         
         let card = BTCard(
             number: "4111111111111111",
@@ -171,9 +161,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingVersionThreeClientTokenAndCardHasValidationEnabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
-        cardClient.apiClient = apiClient
         
         let card = BTCard(
             number: "4111111111111111",

--- a/IntegrationTests/BTCardClient_IntegrationTests.swift
+++ b/IntegrationTests/BTCardClient_IntegrationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class BTCardClient_IntegrationTests: XCTestCase {
 
     func testTokenizeCard_whenCardHasValidationDisabledAndCardIsInvalid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         cardClient.apiClient = apiClient
         
@@ -33,7 +33,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenCardIsInvalidAndValidationIsEnabled_failsWithExpectedValidationError() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         cardClient.apiClient = apiClient
         
@@ -65,7 +65,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenCardHasValidationDisabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         cardClient.apiClient = apiClient
         
@@ -108,7 +108,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingTokenizationKeyAndCardHasValidationEnabled_failsWithAuthorizationError() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         cardClient.apiClient = apiClient
         
@@ -140,7 +140,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingClientTokenAndCardHasValidationEnabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         cardClient.apiClient = apiClient
         
@@ -171,7 +171,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeCard_whenUsingVersionThreeClientTokenAndCardHasValidationEnabledAndCardIsValid_tokenizesSuccessfully() {
-        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)!
+        var apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         var cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         cardClient.apiClient = apiClient
         

--- a/IntegrationTests/Braintree-API-Integration-Specs/BTAPIClient_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTAPIClient_IntegrationTests.swift
@@ -7,7 +7,7 @@ final class BTAPIClient_IntegrationTests: XCTestCase {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         let expectation = expectation(description: "Fetch configuration")
 
-        apiClient?.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             XCTAssertEqual(configuration?.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")
             expectation.fulfill()
         }
@@ -19,7 +19,7 @@ final class BTAPIClient_IntegrationTests: XCTestCase {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         let expectation = expectation(description: "Fetch configuration")
 
-        apiClient?.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             // Note: client token uses a different merchant ID than the merchant whose tokenization key
             // we use in the other test
             XCTAssertEqual(configuration?.json?["merchantId"].asString(), "348pk9cgf3bgyw2b")
@@ -33,7 +33,7 @@ final class BTAPIClient_IntegrationTests: XCTestCase {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         let expectation = expectation(description: "Fetch configuration")
 
-        apiClient?.fetchOrReturnRemoteConfiguration { configuration, error in
+        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
             // Note: client token uses a different merchant ID than the merchant whose tokenization key
             // we use in the other test
             XCTAssertEqual(configuration?.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")

--- a/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
@@ -6,7 +6,7 @@ import PassKit
 class BraintreeApplePay_IntegrationTests: XCTestCase {
 
     func testTokenizeApplePayPayment_whenApplePayEnabledInControlPanel_returnsANonce() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         applePayClient.apiClient = apiClient
@@ -28,7 +28,7 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeApplePayPayment_whenApplePayDisabledInControlPanel_returnsError() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)!
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)
         let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
 
         applePayClient.apiClient = apiClient

--- a/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BraintreeApplePay_IntegrationTests.swift
@@ -6,10 +6,7 @@ import PassKit
 class BraintreeApplePay_IntegrationTests: XCTestCase {
 
     func testTokenizeApplePayPayment_whenApplePayEnabledInControlPanel_returnsANonce() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
-
-        applePayClient.apiClient = apiClient
+        let applePayClient = BTApplePayClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 
@@ -28,10 +25,7 @@ class BraintreeApplePay_IntegrationTests: XCTestCase {
     }
 
     func testTokenizeApplePayPayment_whenApplePayDisabledInControlPanel_returnsError() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)
-        let applePayClient = BTApplePayClient(authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn")
-
-        applePayClient.apiClient = apiClient
+        let applePayClient = BTApplePayClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKeyApplePayDisabled)
 
         let expectation = expectation(description: "Tokenize Apple Pay payment")
 

--- a/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
+++ b/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
@@ -6,7 +6,6 @@ import XCTest
 class BraintreeAmexExpress_IntegrationTests: XCTestCase {
     
     func testGetRewardsBalance_returnsResult() async {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         let cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         let amexClient = BTAmericanExpressClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         

--- a/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
+++ b/IntegrationTests/BraintreeAmexExpress_IntegrationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class BraintreeAmexExpress_IntegrationTests: XCTestCase {
     
     func testGetRewardsBalance_returnsResult() async {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)!
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         let cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         let amexClient = BTAmericanExpressClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
         

--- a/IntegrationTests/BraintreeDataCollector_IntegrationTests.swift
+++ b/IntegrationTests/BraintreeDataCollector_IntegrationTests.swift
@@ -5,12 +5,10 @@ import XCTest
 class BraintreeDataCollector_IntegrationTests: XCTestCase {
 
     var dataCollector: BTDataCollector?
-    let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
-
+    
     override func setUp() {
         super.setUp()
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        dataCollector = BTDataCollector(authorization: authorization)
+        dataCollector = BTDataCollector(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
     }
 
     override func tearDown() {

--- a/IntegrationTests/BraintreeDataCollector_IntegrationTests.swift
+++ b/IntegrationTests/BraintreeDataCollector_IntegrationTests.swift
@@ -9,7 +9,7 @@ class BraintreeDataCollector_IntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)!
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         dataCollector = BTDataCollector(authorization: authorization)
     }
 

--- a/IntegrationTests/BraintreePayPal_IntegrationTests.swift
+++ b/IntegrationTests/BraintreePayPal_IntegrationTests.swift
@@ -10,10 +10,8 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
 
     // MARK: - Checkout Flow Tests
     
-    func testCheckoutFlow_withTokenizationKey_tokenizesPayPalAccount() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        
-        let payPalClient = BTPayPalClient(authorization: authorization)
+    func testCheckoutFlow_withTokenizationKey_tokenizesPayPalAccount() {        
+        let payPalClient = BTPayPalClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
         
         let tokenizationExpectation = expectation(description: "Tokenize one-time payment")
@@ -34,9 +32,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testCheckoutFlow_withClientToken_tokenizesPayPalAccount() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
-
-        let payPalClient = BTPayPalClient(authorization: authorization)
+        let payPalClient = BTPayPalClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
 
         let tokenizationExpectation = expectation(description: "Tokenize one-time payment")
@@ -57,9 +53,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testCheckoutFlow_withoutPayPalRequest_returnsError() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-
-        let payPalClient = BTPayPalClient(authorization: authorization)
+        let payPalClient = BTPayPalClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
 
         let tokenizationExpectation = expectation(description: "Tokenize one-time payment")
         let returnURL = URL(string: oneTouchCoreAppSwitchSuccessURLFixture)
@@ -76,9 +70,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     // MARK: - Vault Flow Tests
     
     func testVaultFlow_withTokenizationKey_tokenizesPayPalAccount() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-
-        let payPalClient = BTPayPalClient(authorization: authorization)
+        let payPalClient = BTPayPalClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
 
         let tokenizationExpectation = expectation(description: "Tokenize billing agreement payment")
@@ -99,9 +91,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testVaultFlow_withClientToken_tokenizedPayPalAccount() {
-        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
-
-        let payPalClient = BTPayPalClient(authorization: authorization)
+        let payPalClient = BTPayPalClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
         
         let tokenizationExpectation = expectation(description: "Tokenize billing agreement payment")

--- a/IntegrationTests/BraintreePayPal_IntegrationTests.swift
+++ b/IntegrationTests/BraintreePayPal_IntegrationTests.swift
@@ -11,12 +11,8 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     // MARK: - Checkout Flow Tests
     
     func testCheckoutFlow_withTokenizationKey_tokenizesPayPalAccount() {
-        guard let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey) else {
-            XCTFail("Failed to initialize BTAPIClient with sandbox tokenization key.")
-            return
-        }
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
         
-
         let payPalClient = BTPayPalClient(authorization: authorization)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
         
@@ -38,11 +34,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testCheckoutFlow_withClientToken_tokenizesPayPalAccount() {
-        guard let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken) else {
-            XCTFail("Failed to initialize BTAPIClient with sandbox tokenization key.")
-            return
-        }
-        
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
 
         let payPalClient = BTPayPalClient(authorization: authorization)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
@@ -65,10 +57,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testCheckoutFlow_withoutPayPalRequest_returnsError() {
-        guard let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey) else {
-            XCTFail("Failed to initialize BTAPIClient with sandbox tokenization key.")
-            return
-        }
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
 
         let payPalClient = BTPayPalClient(authorization: authorization)
 
@@ -87,11 +76,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     // MARK: - Vault Flow Tests
     
     func testVaultFlow_withTokenizationKey_tokenizesPayPalAccount() {
-        guard let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey) else {
-            XCTFail("Failed to initialize BTAPIClient with sandbox tokenization key.")
-            return
-        }
-        
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
 
         let payPalClient = BTPayPalClient(authorization: authorization)
         payPalClient.payPalRequest = BTPayPalVaultRequest()
@@ -114,11 +99,7 @@ class BraintreePayPal_IntegrationTests: XCTestCase {
     }
     
     func testVaultFlow_withClientToken_tokenizedPayPalAccount() {
-        guard let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken) else {
-            XCTFail("Failed to initialize BTAPIClient with sandbox tokenization key.")
-            return
-        }
-        
+        let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
 
         let payPalClient = BTPayPalClient(authorization: authorization)
         payPalClient.payPalRequest = BTPayPalVaultRequest()

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -16,8 +16,6 @@ class ViewController: UIViewController {
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
 
     override func viewDidLoad() {
-        let apiClient = BTAPIClient(authorization: authorization)
-
         let amexClient = BTAmericanExpressClient(authorization: authorization)
         let applePayClient = BTApplePayClient(authorization: authorization)
         let cardClient = BTCardClient(authorization: authorization)

--- a/SampleApps/CarthageTest/CarthageTest/ViewController.swift
+++ b/SampleApps/CarthageTest/CarthageTest/ViewController.swift
@@ -16,8 +16,7 @@ class ViewController: UIViewController {
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
 
     override func viewDidLoad() {
-        // TODO: remove in the final PR for making authorization internal
-        let apiClient = BTAPIClient(authorization: authorization)!
+        let apiClient = BTAPIClient(authorization: authorization)
 
         let amexClient = BTAmericanExpressClient(authorization: authorization)
         let applePayClient = BTApplePayClient(authorization: authorization)

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -16,8 +16,6 @@ class ViewController: UIViewController {
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
 
     override func viewDidLoad() {
-        let apiClient = BTAPIClient(authorization: authorization)
-
         let amexClient = BTAmericanExpressClient(authorization: authorization)
         let applePayClient = BTApplePayClient(authorization: authorization)
         let cardClient = BTCardClient(authorization: authorization)

--- a/SampleApps/SPMTest/SPMTest/ViewController.swift
+++ b/SampleApps/SPMTest/SPMTest/ViewController.swift
@@ -16,8 +16,7 @@ class ViewController: UIViewController {
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
 
     override func viewDidLoad() {
-        // TODO: remove in the final PR for making authorization internal
-        let apiClient = BTAPIClient(authorization: authorization)!
+        let apiClient = BTAPIClient(authorization: authorization)
 
         let amexClient = BTAmericanExpressClient(authorization: authorization)
         let applePayClient = BTApplePayClient(authorization: authorization)

--- a/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
+++ b/Sources/BraintreeAmericanExpress/BTAmericanExpressClient.swift
@@ -14,7 +14,7 @@ import BraintreeCore
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
     }
     
     ///  Gets the rewards balance associated with a Braintree nonce. Only for American Express cards.

--- a/Sources/BraintreeApplePay/BTApplePayClient.swift
+++ b/Sources/BraintreeApplePay/BTApplePayClient.swift
@@ -19,7 +19,7 @@ import BraintreeCore
     /// - Parameter authorization: A client token or tokenization key
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreeCard/BTCardClient.swift
+++ b/Sources/BraintreeCard/BTCardClient.swift
@@ -20,7 +20,7 @@ import BraintreeCore
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
     }
 
     // MARK: - Public Methods

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -28,55 +28,13 @@ import Foundation
     var analyticsService: AnalyticsSendable = BTAnalyticsService.shared
 
     // MARK: - Initializers
-
-    // TODO: remove in final PR
-    /// Initialize a new API client.
-    /// - Parameter authorization: Your tokenization key or client token. Passing an invalid value may return `nil`.
-    @objc(initWithAuthorization:)
-    public init?(authorization: String) {
-        self.metadata = BTClientMetadata()
-
-        let authorizationType = Self.authorizationType(for: authorization)
-
-        switch authorizationType {
-        case .tokenizationKey:
-            do {
-                self.authorization = try TokenizationKey(authorization)
-            } catch {
-                return nil
-            }
-        case .clientToken:
-            do {
-                let clientToken = try BTClientToken(clientToken: authorization)
-                self.authorization = clientToken
-            } catch {
-                return nil
-            }
-        case .invalidAuthorization:
-            return nil
-        }
-        
-        let btHttp = BTHTTP(authorization: self.authorization)
-        http = btHttp
-        configurationLoader = ConfigurationLoader(http: btHttp)
-        
-        super.init()
-        analyticsService.setAPIClient(self)
-        http?.networkTimingDelegate = self
-
-        // Kickoff the background request to fetch the config
-        fetchOrReturnRemoteConfiguration { _, _ in
-            // No-op
-        }
-    }
    
-    // TODO: rename param to authorization in final PR - set as newAuthorization currently since otherwise the two inits have the same signature
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token.
     @_documentation(visibility: private)
-    public init(newAuthorization: String) {
-        self.authorization = Self.authorization(from: newAuthorization)
+    @objc(initWithAuthorization:)
+    public init(authorization: String) {
+        self.authorization = Self.authorization(from: authorization)
         self.metadata = BTClientMetadata()
                 
         let btHTTP = BTHTTP(authorization: self.authorization)

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -29,10 +29,10 @@ import Foundation
 
     // MARK: - Initializers
    
+    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token.
     @_documentation(visibility: private)
-    @objc(initWithAuthorization:)
     public init(authorization: String) {
         self.authorization = Self.authorization(from: authorization)
         self.metadata = BTClientMetadata()

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -18,7 +18,7 @@ import BraintreeCore
     /// - Parameter  authorization: A valid client token or tokenization key used to authorize API calls.
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
     }
     
     // MARK: Public methods

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -39,7 +39,7 @@ import BraintreeDataCollector
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         self.webAuthenticationSession = BTWebAuthenticationSession()
         super.init()
         NotificationCenter.default.addObserver(

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -74,7 +74,7 @@ import BraintreeDataCollector
     public init(authorization: String) {
         BTAppContextSwitcher.sharedInstance.register(BTPayPalClient.self)
 
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         self.webAuthenticationSession = BTWebAuthenticationSession()
 
         super.init()

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -22,7 +22,7 @@ public class BTPayPalMessagingView: UIView {
     ///  Initializes a `BTPayPalMessagingView`.
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
 
         super.init(frame: .zero)
     }
@@ -129,7 +129,7 @@ public extension BTPayPalMessagingView {
             request: BTPayPalMessagingRequest = BTPayPalMessagingRequest(),
             delegate: BTPayPalMessagingDelegate? = nil
         ) {
-            self.apiClient = BTAPIClient(newAuthorization: authorization)
+            self.apiClient = BTAPIClient(authorization: authorization)
             self.request = request
             self.delegate = delegate
         }

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
@@ -23,7 +23,7 @@ import BraintreeCore
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         self.sepaDirectDebitAPI = SEPADirectDebitAPI(apiClient: apiClient)
         self.webAuthenticationSession = BTWebAuthenticationSession()
 
@@ -33,7 +33,7 @@ import BraintreeCore
     
     /// Internal for testing.
     init(authorization: String, webAuthenticationSession: BTWebAuthenticationSession, sepaDirectDebitAPI: SEPADirectDebitAPI) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         self.webAuthenticationSession = webAuthenticationSession
         self.sepaDirectDebitAPI = sepaDirectDebitAPI
     }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClient.swift
@@ -29,7 +29,7 @@ public class BTShopperInsightsClient {
     ///     - shopperSessionID: Optional: This value should be the shopper session ID returned from your server SDK request
     /// - Warning: This init is beta. It's public API may change or be removed in future releases. This feature only works with a client token.
     public init(authorization: String, shopperSessionID: String? = nil) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         self.authorization = authorization
         self.shopperSessionID = shopperSessionID
     }

--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -27,7 +27,7 @@ import BraintreeCore
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
     @objc(initWithAuthorization:)
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
     }
     
     // MARK: - Public Methods

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -58,7 +58,7 @@ import BraintreeCore
     public init(authorization: String, universalLink: URL) {
         BTAppContextSwitcher.sharedInstance.register(BTVenmoClient.self)
 
-        self.apiClient = BTAPIClient(newAuthorization: authorization)
+        self.apiClient = BTAPIClient(authorization: authorization)
         
         /// appending a PayPal app switch specific path to verify we are in the correct flow when
         /// `canHandleReturnURL` is called

--- a/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
+++ b/UnitTests/BraintreeAmericanExpressTests/BTAmericanExpressClient_Tests.swift
@@ -5,7 +5,7 @@ import BraintreeCore
 
 class BTAmericanExpressClient_Tests: XCTestCase {
 
-    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")!
+    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")
     var amexClient : BTAmericanExpressClient? = nil
 
     override func setUp() {

--- a/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTApplePay_Tests.swift
@@ -5,11 +5,11 @@ import PassKit
 @testable import BraintreeApplePay
 
 class BTApplePay_Tests: XCTestCase {
-    var mockClient : MockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+    var mockClient : MockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
 
     override func setUp() {
         super.setUp()
-        mockClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockClient = MockAPIClient(authorization: "development_tokenization_key")
     }
 
     // MARK: - Payment Request
@@ -339,7 +339,7 @@ class BTApplePay_Tests: XCTestCase {
     func testMetaParameter_whenTokenizationIsSuccessful_isPOSTedToServer() {
         let applePayClient = BTApplePayClient(authorization: "production_t2wns2y2_dfy45jdj3dxkmz5m")
                 
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "applePay" : [
                 "status" : "production"

--- a/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
@@ -5,7 +5,7 @@ import PassKit
 @testable import BraintreeTestShared
 
 class BTConfiguration_ApplePay_Tests : XCTestCase {
-    var mockAPIClient = MockAPIClient.init(authorization: "development_tokenization_key")!
+    var mockAPIClient = MockAPIClient.init(authorization: "development_tokenization_key")
 
     func testIsApplePayEnabled_whenApplePayStatusFromConfigurationJSONIsAString_returnsTrue() {
         for applePayStatus in ["mock", "production", "asdfasdf"] {

--- a/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCardClient_Tests.swift
@@ -16,7 +16,7 @@ class BTCardClient_Tests: XCTestCase {
     func testTokenization_postsCardDataToClientAPI() {
         let expectation = self.expectation(description: "Tokenize Card")
 
-        let mockAPIClient = MockAPIClient(authorization: authorization)!
+        let mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
 
         var cardClient = BTCardClient(authorization: authorization)
@@ -61,7 +61,7 @@ class BTCardClient_Tests: XCTestCase {
     func testTokenization_whenAuthInsightIsNotRequested_postsCardDataWithoutAuthInsight() {
         let expectation = self.expectation(description: "Tokenize Card")
 
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         
         var cardClient = BTCardClient(authorization: authorization)
@@ -108,7 +108,7 @@ class BTCardClient_Tests: XCTestCase {
             ]
         ]
 
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         mockAPIClient.cannedResponseBody = BTJSON(value: mockTokenizeResponse)
 
@@ -142,7 +142,7 @@ class BTCardClient_Tests: XCTestCase {
 
         let mockError = NSError(domain: "TestErrorDomain", code: 1, userInfo: nil)
 
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         mockAPIClient.cannedResponseError = mockError
 
@@ -166,7 +166,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testTokenization_whenTokenizationEndpointReturns422_callCompletionWithValidationError() {
-        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
+        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)
         stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         let stubJSONResponse = BTJSON(
             value: [
@@ -225,7 +225,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testTokenization_whenTokenizationEndpointReturns422AndCode81724_callCompletionWithValidationError() {
-        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
+        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)
         stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         let stubJSONResponse = BTJSON(
             value: [
@@ -284,7 +284,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testTokenization_whenGraphQLTokenizationEndpointReturns422AndCode81724_callsCompletionWithValidationError() {
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -360,7 +360,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testTokenization_whenTokenizationEndpointReturnsAnyNon422Error_callCompletionWithError() {
-        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)!
+        var stubAPIClient = MockAPIClient(authorization: TestClientTokenFactory.validClientToken)
         stubAPIClient.cannedResponseError = NSError(domain: BTHTTPError.errorDomain, code: BTHTTPError.clientError([:]).errorCode, userInfo: nil)
         stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         var cardClient = BTCardClient(authorization: authorization)
@@ -386,7 +386,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testMetaParameter_whenTokenizationIsSuccessful_isPOSTedToServer() {
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         var cardClient = BTCardClient(authorization: authorization)
         cardClient.apiClient = mockAPIClient
         
@@ -418,7 +418,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testAnalyticsEvent_whenTokenizationSucceeds_isSent() {
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
 
         var cardClient = BTCardClient(authorization: authorization)
@@ -442,7 +442,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testAnalyticsEvent_whenTokenizationFails_isSent() {
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         let stubJSONResponse = BTJSON(
             value: [
                 "error" : [
@@ -491,7 +491,7 @@ class BTCardClient_Tests: XCTestCase {
     // MARK: - GraphQL API
 
     func testTokenization_whenAuthInsightRequestedIsTrue_andMerchantAccountIDIsNil_returnsError() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -524,7 +524,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testTokenization_whenGraphQLIsEnabled_postsCardDataToGraphQLAPI() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -564,7 +564,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testTokenization_whenGraphQLIsDisabled_postsCardDataToGatewayAPI() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [] as [Any?])
         
         var cardClient = BTCardClient(authorization: authorization)
@@ -599,7 +599,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testTokenization_whenGraphQLFeatureIsNotEnabled_postsCardDataToGatewayAPI() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -630,7 +630,7 @@ class BTCardClient_Tests: XCTestCase {
     }
     
     func testTokenization_whenGraphQLIsEnabledAndTokenizationIsSuccessful_returnsACardNonce() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -702,7 +702,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testAnalyticsEvent_whenTokenizationSucceedsWithGraphQL_isSent() {
-        var mockApiClient = MockAPIClient(authorization: authorization)!
+        var mockApiClient = MockAPIClient(authorization: authorization)
         mockApiClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",
@@ -755,7 +755,7 @@ class BTCardClient_Tests: XCTestCase {
     }
 
     func testAnalyticsEvent_whenTokenizationFailsWithGraphQL_isSent() {
-        var mockAPIClient = MockAPIClient(authorization: authorization)!
+        var mockAPIClient = MockAPIClient(authorization: authorization)
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "graphQL": [
                 "url": "graphql://graphql",

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -72,17 +72,17 @@ final class BTAnalyticsService_Tests: XCTestCase {
         let stubAPIClient = MockAPIClient(authorization: "development_tokenization_key")
 
         if analyticsURL != nil {
-            stubAPIClient?.cannedConfigurationResponseBody = BTJSON(
+            stubAPIClient.cannedConfigurationResponseBody = BTJSON(
                 value: [
                     "analytics": ["url": analyticsURL],
                     "merchantId": "a-fake-merchantID"
                 ]
             )
         } else {
-            stubAPIClient?.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
+            stubAPIClient.cannedConfigurationResponseBody = BTJSON(value: [:] as [String?: Any])
         }
 
-        return stubAPIClient!
+        return stubAPIClient
     }
 
     func validateMetadataParameters(_ postParameters: [String: Any]?) {

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -11,7 +11,7 @@ class BTDataCollector_Tests: XCTestCase {
     func testCollectDeviceData_collectsAllData() {
         let config: [String: Any] = ["environment": "development"]
         
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
         
         let dataCollector = BTDataCollector(authorization: authorization)
@@ -40,7 +40,7 @@ class BTDataCollector_Tests: XCTestCase {
             "environment":"sandbox"
         ]
 
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
 
         let dataCollector = BTDataCollector(authorization: authorization)
@@ -66,7 +66,7 @@ class BTDataCollector_Tests: XCTestCase {
         
         let configuration = BTConfiguration(json: BTJSON(value: config))
         let pairingID = "random pairing id"
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let dataCollector = BTDataCollector(authorization: authorization)
         dataCollector.apiClient = mockAPIClient
 
@@ -81,7 +81,7 @@ class BTDataCollector_Tests: XCTestCase {
         ]
         
         let configuration = BTConfiguration(json: BTJSON(value: config))
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let dataCollector = BTDataCollector(authorization: authorization)
         dataCollector.apiClient = mockAPIClient
 
@@ -96,7 +96,7 @@ class BTDataCollector_Tests: XCTestCase {
         ]
         
         let configuration = BTConfiguration(json: BTJSON(value: config))
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let dataCollector = BTDataCollector(authorization: authorization)
         dataCollector.apiClient = mockAPIClient
 
@@ -110,7 +110,7 @@ class BTDataCollector_Tests: XCTestCase {
         ]
         
         let configuration = BTConfiguration(json: BTJSON(value: config))
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let dataCollector = BTDataCollector(authorization: authorization)
         dataCollector.apiClient = mockAPIClient
 
@@ -124,7 +124,7 @@ class BTDataCollector_Tests: XCTestCase {
         ]
         
         let configuration = BTConfiguration(json: BTJSON(value: config))
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let dataCollector = BTDataCollector(authorization: authorization)
         dataCollector.apiClient = mockAPIClient
 
@@ -133,7 +133,7 @@ class BTDataCollector_Tests: XCTestCase {
     }
     
     func testCollectDeviceData_fetchConfigurationReturnsError_returnError() {
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let mockDataCollector = MockBTDataCollector(authorization: authorization)
         mockDataCollector.apiClient = mockAPIClient
 
@@ -155,7 +155,7 @@ class BTDataCollector_Tests: XCTestCase {
     }
     
     func testCollectDeviceData_invalidJSON_returnError() {
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let mockDataCollector = MockBTDataCollector(authorization: authorization)
         mockDataCollector.apiClient = mockAPIClient
         
@@ -177,7 +177,7 @@ class BTDataCollector_Tests: XCTestCase {
     }
     
     func testCollectDeviceData_encodingError_returnError() {
-        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         let mockDataCollector = MockBTDataCollector(authorization: authorization)
         mockDataCollector.apiClient = mockAPIClient
         

--- a/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
+++ b/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
@@ -19,7 +19,7 @@ class BTLocalPaymentClient_UnitTests: XCTestCase {
             currencyCode: "EUR"
         )
         localPaymentRequest.localPaymentFlowDelegate = mockLocalPaymentRequestDelegate
-        mockAPIClient = MockAPIClient(authorization: tempClientToken)!
+        mockAPIClient = MockAPIClient(authorization: tempClientToken)
     }
     
     func testStartPayment_returnsErrorWhenConfigurationNil() {

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class BTPayPalMessagingView_Tests: XCTestCase {
 
-    var mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+    var mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
     var mockDelegate = MockBTPayPalMessagingDelegate()
     let mockTokenizationKey = "development_tokenization_key"
 

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1104,7 +1104,6 @@ class BTPayPalClient_Tests: XCTestCase {
     // MARK: - Analytics
 
     func testAPIClientMetadata_hasIntegrationSetToCustom() {
-        let apiClient = BTAPIClient(authorization: authorization)
         let payPalClient = BTPayPalClient(authorization: authorization)
 
         XCTAssertEqual(payPalClient.apiClient.metadata.integration, BTClientMetadataIntegration.custom)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -12,7 +12,7 @@ class BTPayPalClient_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": true,
             "paypal": ["environment": "offline"]
@@ -1104,7 +1104,7 @@ class BTPayPalClient_Tests: XCTestCase {
     // MARK: - Analytics
 
     func testAPIClientMetadata_hasIntegrationSetToCustom() {
-        let apiClient = BTAPIClient(authorization: authorization)!
+        let apiClient = BTAPIClient(authorization: authorization)
         let payPalClient = BTPayPalClient(authorization: authorization)
 
         XCTAssertEqual(payPalClient.apiClient.metadata.integration, BTClientMetadataIntegration.custom)

--- a/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/BTSEPADirectDebitClient_Tests.swift
@@ -8,11 +8,11 @@ class BTSEPADirectDebitClient_Tests: XCTestCase {
     
     var billingAddress = BTPostalAddress()
     var sepaDirectDebitRequest = BTSEPADirectDebitRequest()
-    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")!
+    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
 
     override func setUp() {
-        mockAPIClient = MockAPIClient(authorization: authorization)!
+        mockAPIClient = MockAPIClient(authorization: authorization)
 
         billingAddress.streetAddress = "Kantstraße 70"
         billingAddress.extendedAddress = "#170"

--- a/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
+++ b/UnitTests/BraintreeSEPADirectDebitTests/SEPADirectDebitAPI_Tests.swift
@@ -7,7 +7,7 @@ class SEPADirectDebitAPI_Tests: XCTestCase {
     var billingAddress = BTPostalAddress()
     var sepaDirectDebitRequest = BTSEPADirectDebitRequest()
     var successApprovalURL: String = ""
-    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")!
+    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_client_key")
     let authorization: String = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
     var mockCreateMandateResult = CreateMandateResult(json:
         BTJSON(

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureAuthenticateJWT_Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import BraintreeThreeDSecure
 
 class BTThreeDSecureAuthenticateJWT_Tests: XCTestCase {
-    var mockAPIClient = MockAPIClient(authorization: TestClientTokenFactory.token(withVersion: 3))!
+    var mockAPIClient = MockAPIClient(authorization: TestClientTokenFactory.token(withVersion: 3))
     var threeDSecureLookupResult: BTThreeDSecureResult!
 
     override func setUp() {

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class BTThreeDSecureClient_Tests: XCTestCase {
 
-    var mockAPIClient = MockAPIClient(authorization: TestClientTokenFactory.token(withVersion: 3))!
+    var mockAPIClient = MockAPIClient(authorization: TestClientTokenFactory.token(withVersion: 3))
     var threeDSecureRequest: BTThreeDSecureRequest!
     var client: BTThreeDSecureClient!
     var mockThreeDSecureRequestDelegate : MockThreeDSecureRequestDelegate!
@@ -655,7 +655,7 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         mockAPIClient.cannedConfigurationResponseBody = mockConfiguration
         
         let client = BTThreeDSecureClient(authorization: authorization)
-        client.apiClient = MockAPIClient(authorization: authorization)!
+        client.apiClient = MockAPIClient(authorization: authorization)
         let expectation = expectation(description: "willCallCompletion")
 
         threeDSecureRequest.dfReferenceID = "fake-df-reference-id"

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -5,13 +5,13 @@ import UIKit
 @testable import BraintreeTestShared
 
 class BTVenmoClient_Tests: XCTestCase {
-    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+    var mockAPIClient : MockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
     var venmoRequest: BTVenmoRequest = BTVenmoRequest(paymentMethodUsage: .multiUse)
     var venmoClient: BTVenmoClient!
 
     override func setUp() {
         super.setUp()
-        mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
+        mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "payWithVenmo" : [
                 "environment": "sandbox",


### PR DESCRIPTION
### Summary of changes

- Remove old integration pattern and make `BTAPIClient` non-optional
- Update its initializer to require an `authorization` string
- Update related unit tests

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
