### PR TITLE
[v7] Update `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,18 +133,18 @@ jobs:
           brew install sourcekitten
 
           # run sourcekitten on each Swift module individually
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeCore -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-core.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeSEPADirectDebit -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-sepa-direct-debit.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeAmericanExpress -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-american-express.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeDataCollector -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-data-collector.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeApplePay -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-apple-pay.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeLocalPayment -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-local-payment.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeThreeDSecure -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-three-d-secure.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeCard -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-card.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPal -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-paypal.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeVenmo -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-venmo.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPalMessaging -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-paypal-messaging.json
-          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeShopperInsights -destination 'name=iPhone 14,platform=iOS Simulator' > braintree-shopper-insights.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeCore -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-core.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeSEPADirectDebit -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-sepa-direct-debit.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeAmericanExpress -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-american-express.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeDataCollector -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-data-collector.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeApplePay -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-apple-pay.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeLocalPayment -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-local-payment.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeThreeDSecure -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-three-d-secure.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeCard -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-card.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPal -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-paypal.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeVenmo -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-venmo.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreePayPalMessaging -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-paypal-messaging.json
+          sourcekitten doc -- -workspace Braintree.xcworkspace -scheme BraintreeShopperInsights -destination 'name=iPhone 16,platform=iOS Simulator' > braintree-shopper-insights.json
 
           # merge sourcekitten output
           jq -s '.[0] + .[1] + .[2] + .[3] + .[4] + .[5] + .[6] + .[7] + .[8] + .[9] + .[10] + .[11]' braintree-core.json braintree-sepa-direct-debit.json braintree-american-express.json braintree-data-collector.json braintree-apple-pay.json braintree-local-payment.json braintree-three-d-secure.json braintree-card.json braintree-paypal.json braintree-venmo.json braintree-paypal-messaging.json braintree-shopper-insights.json > swiftDoc.json


### PR DESCRIPTION
### Summary of changes

- The release for v7 failed on the reference docs step because the GitHub action runner did not have the iPhone type being specified. This bumps to an iPhone 16 which is [supported on the runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#installed-simulators) we are using.

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
