### PR TITLE
Analytics Not-Batching V7

### DIFF
--- a/Sources/BraintreeCore/Analytics/AnalyticsSendable.swift
+++ b/Sources/BraintreeCore/Analytics/AnalyticsSendable.swift
@@ -2,6 +2,13 @@
 /// - Note: Specifically created to mock the `BTAnalyticsService` singleton.
 protocol AnalyticsSendable: AnyObject {
     
-    func sendAnalyticsEvent(_ event: FPTIBatchData.Event)
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool)
     func setAPIClient(_ apiClient: BTAPIClient)
+}
+
+extension AnalyticsSendable {
+    
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool = true) {
+        sendAnalyticsEvent(event, sendImmediately: sendImmediately)
+    }
 }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -58,10 +58,11 @@ final class BTAnalyticsService: AnalyticsSendable {
     /// - Parameter event: A single `FPTIBatchData.Event`
     func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool = true) {
         Task(priority: .background) {
-            print("😲 12345 event \(event.eventName)")
             if sendImmediately {
+                print("🆕 12345 event \(event.eventName)")
                 await sendImmediatelyEvent(event: event)
             } else {
+                print("🥶 12345 event \(event.eventName)")
                 await performEventRequest(with: event)
             }
         }
@@ -121,6 +122,8 @@ final class BTAnalyticsService: AnalyticsSendable {
             } catch {
                 return
             }
+        } else {
+            print("💀 12345 APIClient doesnt exist")
         }
     }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -115,7 +115,7 @@ final class BTAnalyticsService: AnalyticsSendable {
                     )
                     
                     _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-                    print("🥳 12345 event sended \(eventsPerSessionID.compactMap { $0.eventName } )")
+                    print("🥳 12345 event sended \(eventsPerSessionID.compactMap { $0.eventName })")
                     await events.removeFor(sessionID: sessionID)
                 }
             } catch {

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -59,10 +59,10 @@ final class BTAnalyticsService: AnalyticsSendable {
     func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool = true) {
         Task(priority: .background) {
             if sendImmediately {
-                print("🆕 12345 event \(event.eventName)")
+                print("🆕 12345 event \(event.eventName) to be send")
                 await sendImmediatelyEvent(event: event)
             } else {
-                print("🥶 12345 event \(event.eventName)")
+                print("🥶 12345 event \(event.eventName) to be send")
                 await performEventRequest(with: event)
             }
         }
@@ -95,7 +95,7 @@ final class BTAnalyticsService: AnalyticsSendable {
             )
             
             _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-            print("🚀 12345 event sended \(event.eventName)")
+            print("🚀 12345 event \(event.eventName) sent")
         } catch {
             return
         }
@@ -116,14 +116,16 @@ final class BTAnalyticsService: AnalyticsSendable {
                     )
                     
                     _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-                    print("🥳 12345 event sended \(eventsPerSessionID.compactMap { $0.eventName })")
+                    print("🥳 12345 event \(eventsPerSessionID.compactMap { $0.eventName }) sent")
                     await events.removeFor(sessionID: sessionID)
                 }
             } catch {
                 return
             }
         } else {
-            print("💀 12345 APIClient doesnt exist")
+            if apiClient == nil {
+                print("💀 12345 APIClient doesnt exist (Queue)")
+            }
         }
     }
 

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -94,7 +94,7 @@ final class BTAnalyticsService: AnalyticsSendable {
             )
             
             _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-            print("🚀 12345 evento sended \(event.eventName)")
+            print("🚀 12345 event sended \(event.eventName)")
         } catch {
             return
         }
@@ -115,7 +115,7 @@ final class BTAnalyticsService: AnalyticsSendable {
                     )
                     
                     _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-                    print("🥳 12345 evento sended \(eventsPerSessionID.compactMap { $0.eventName } )")
+                    print("🥳 12345 event sended \(eventsPerSessionID.compactMap { $0.eventName } )")
                     await events.removeFor(sessionID: sessionID)
                 }
             } catch {

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -62,7 +62,7 @@ final class BTAnalyticsService: AnalyticsSendable {
                 print("🆕 12345 event \(event.eventName) to be send")
                 await sendImmediatelyEvent(event: event)
             } else {
-                print("🥶 12345 event \(event.eventName) to be send")
+                print("🥶 1234 event \(event.eventName) to be send")
                 await performEventRequest(with: event)
             }
         }
@@ -116,7 +116,7 @@ final class BTAnalyticsService: AnalyticsSendable {
                     )
                     
                     _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-                    print("🥳 12345 event \(eventsPerSessionID.compactMap { $0.eventName }) sent")
+                    print("🥳 1234 event \(eventsPerSessionID.compactMap { $0.eventName }) sent")
                     await events.removeFor(sessionID: sessionID)
                 }
             } catch {
@@ -124,7 +124,7 @@ final class BTAnalyticsService: AnalyticsSendable {
             }
         } else {
             if apiClient == nil {
-                print("💀 12345 APIClient doesnt exist (Queue)")
+                print("💀 1234 APIClient doesnt exist (Queue)")
             }
         }
     }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -49,6 +49,8 @@ final class BTAnalyticsService: AnalyticsSendable {
     // MARK: - Deinit
 
     deinit {
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("🚨 12345 Analytics deinit \(instance)")
         timer.suspend()
     }
 

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -43,6 +43,9 @@ import Foundation
         
         super.init()
         
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("🌶️ 12345 API Client init \(instance)")
+        
         analyticsService.setAPIClient(self)
         http?.networkTimingDelegate = self
 
@@ -56,6 +59,8 @@ import Foundation
     // MARK: - Deinit
 
     deinit {
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("👻 12345 APIClient deinit \(instance)")
         if http != nil && http?.session != nil {
             http?.session.finishTasksAndInvalidate()
         }
@@ -396,8 +401,11 @@ import Foundation
                     eventName: BTCoreAnalytics.apiRequestLatency,
                     requestStartTime: requestStartTime,
                     startTime: startTime
-                )
+                ),
+                sendImmediately: false
             )
+        } else {
+            print("🔮 12345 Event log")
         }
     }
 }

--- a/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
+++ b/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
@@ -20,10 +20,13 @@ class ConfigurationLoader {
     
     init(http: BTHTTP) {
         self.http = http
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("🌮 12345 Configuration init \(instance)")
     }
     
     deinit {
-        print("🥸 12345 Configuration deinit")
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("🍟 12345 Configuration deinit \(instance)")
         http.session.finishTasksAndInvalidate()
     }
     

--- a/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
+++ b/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
@@ -23,6 +23,7 @@ class ConfigurationLoader {
     }
     
     deinit {
+        print("🥸 12345 Configuration deinit")
         http.session.finishTasksAndInvalidate()
     }
     

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -12,7 +12,7 @@ import BraintreeCore
     
     var config: BTConfiguration?
 
-    var apiClient: BTAPIClient
+    public var apiClient: BTAPIClient
 
     ///  Initializes a `BTDataCollector` instance with a `BTAPIClient`.
     /// - Parameter  authorization: A valid client token or tokenization key used to authorize API calls.

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -77,6 +77,9 @@ import BraintreeDataCollector
         self.apiClient = BTAPIClient(authorization: authorization)
         self.webAuthenticationSession = BTWebAuthenticationSession()
 
+        let instance = Unmanaged.passUnretained(Self.apiClient).toOpaque()
+        print("⭐️ 12345 \(instance)")
+        
         super.init()
         NotificationCenter.default.addObserver(
             self,
@@ -470,7 +473,7 @@ import BraintreeDataCollector
             }
         } sessionDidAppear: { [self] didAppear in
             if didAppear {
-                apiClient.sendAnalyticsEvent(
+                self.apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationSucceeded,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -480,7 +483,7 @@ import BraintreeDataCollector
                     shopperSessionID: payPalRequest?.shopperSessionID
                 )
             } else {
-                apiClient.sendAnalyticsEvent(
+                self.apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationFailed,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -492,7 +495,7 @@ import BraintreeDataCollector
         } sessionDidCancel: { [self] in
             if !webSessionReturned {
                 // User tapped system cancel button on permission alert
-                apiClient.sendAnalyticsEvent(
+                self.apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserLoginAlertCanceled,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -541,7 +544,7 @@ import BraintreeDataCollector
     }
 
     private func notifyCancel(completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
-        self.apiClient.sendAnalyticsEvent(
+        apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.browserLoginCanceled,
             correlationID: clientMetadataID,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -383,8 +383,8 @@ import BraintreeDataCollector
                 
                 self.payPalContextID = approvalURL.baToken ?? approvalURL.ecToken
 
-                let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
-                self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.payPalContextID)
+//                let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
+                self.clientMetadataID = self.payPalRequest?.riskCorrelationID // ?? dataCollector.clientMetadataID(self.payPalContextID)
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
@@ -563,7 +563,7 @@ extension BTPayPalClient: BTAppContextSwitchClient {
     @_documentation(visibility: private)
     @objc public static func handleReturnURL(_ url: URL) {
         payPalClient?.handleReturnURL(url)
-        BTPayPalClient.payPalClient = nil
+//        BTPayPalClient.payPalClient = nil
     }
 
     /// :nodoc:

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -77,7 +77,7 @@ import BraintreeDataCollector
         self.apiClient = BTAPIClient(authorization: authorization)
         self.webAuthenticationSession = BTWebAuthenticationSession()
 
-        let instance = Unmanaged.passUnretained(Self.apiClient).toOpaque()
+        let instance = Unmanaged.passUnretained(self.apiClient).toOpaque()
         print("⭐️ 12345 \(instance)")
         
         super.init()

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -103,6 +103,11 @@ import BraintreeDataCollector
         self.universalLink = universalLink.appendingPathComponent("braintreeAppSwitchPayPal")
     }
 
+    deinit {
+        let instance = Unmanaged.passUnretained(self).toOpaque()
+        print("🚧 12345 PayPalClient deinit \(instance)")
+    }
+    
     // MARK: - Public Methods
 
     /// Tokenize a PayPal request to be used with the PayPal Vault flow.

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -368,7 +368,7 @@ import BraintreeDataCollector
                         self.notifyFailure(with: error, completion: completion)
                         return
                     }
-                    
+
                     let errorDetailsIssue = jsonResponseBody["paymentResource"]["errorDetails"][0]["issue"]
                     var dictionary = error.userInfo
                     dictionary[NSLocalizedDescriptionKey] = errorDetailsIssue
@@ -477,7 +477,7 @@ import BraintreeDataCollector
             }
         } sessionDidAppear: { [self] didAppear in
             if didAppear {
-                self.apiClient.sendAnalyticsEvent(
+                apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationSucceeded,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -487,7 +487,7 @@ import BraintreeDataCollector
                     shopperSessionID: payPalRequest?.shopperSessionID
                 )
             } else {
-                self.apiClient.sendAnalyticsEvent(
+                apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationFailed,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -499,7 +499,7 @@ import BraintreeDataCollector
         } sessionDidCancel: { [self] in
             if !webSessionReturned {
                 // User tapped system cancel button on permission alert
-                self.apiClient.sendAnalyticsEvent(
+                apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserLoginAlertCanceled,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -567,7 +567,7 @@ extension BTPayPalClient: BTAppContextSwitchClient {
     @_documentation(visibility: private)
     @objc public static func handleReturnURL(_ url: URL) {
         payPalClient?.handleReturnURL(url)
-//        BTPayPalClient.payPalClient = nil
+        BTPayPalClient.payPalClient = nil
     }
 
     /// :nodoc:

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -368,7 +368,7 @@ import BraintreeDataCollector
                         self.notifyFailure(with: error, completion: completion)
                         return
                     }
-
+                    
                     let errorDetailsIssue = jsonResponseBody["paymentResource"]["errorDetails"][0]["issue"]
                     var dictionary = error.userInfo
                     dictionary[NSLocalizedDescriptionKey] = errorDetailsIssue
@@ -382,9 +382,13 @@ import BraintreeDataCollector
                 }
                 
                 self.payPalContextID = approvalURL.baToken ?? approvalURL.ecToken
-
-//                let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
-                self.clientMetadataID = self.payPalRequest?.riskCorrelationID // ?? dataCollector.clientMetadataID(self.payPalContextID)
+                
+                let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
+                // Replace apiClient with a direct reference, since BTAnalyticsService was using dataCollector.apiClient,
+                // and dataCollector is a weak reference. This could cause analytics events to fail to send if dataCollector gets deallocated.
+                self.apiClient = dataCollector.apiClient
+                
+                self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.payPalContextID)
 
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -78,7 +78,7 @@ import BraintreeDataCollector
         self.webAuthenticationSession = BTWebAuthenticationSession()
 
         let instance = Unmanaged.passUnretained(self.apiClient).toOpaque()
-        print("⭐️ 12345 \(instance)")
+        print("⭐️ 12345 PayPalClient init, APIClient instance \(instance)")
         
         super.init()
         NotificationCenter.default.addObserver(


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

TODO:
- BTPayPalClien is not being deinitialized as expected
- `BTPayPalClient.tokenize`: `BTDataCollector` creates a new instance of `BTAPIClient`, which gets injected as a dependency into `BTAnalyticsService`.
Since `BTDataCollector` is a weak reference, `BTDataCollector.BTAPIClient` is also weak — which ends up causing the events not to be sent.


### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
