### PR TITLE
[v7] Venmo GraphQL Encodable

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -94,7 +94,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "Venmo" do |s|
-    s.source_files = "Sources/BraintreeVenmo/*.swift"
+    s.source_files = "Sources/BraintreeVenmo/**/*.swift"
     s.dependency "Braintree/Core"
     s.resource_bundle = { "BraintreeVenmo_PrivacyInfo" => "Sources/BraintreeVenmo/PrivacyInfo.xcprivacy" }
   end

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -347,6 +347,9 @@
 		BEF137E22B3359B000B9B225 /* MockBTPayPalMessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF137E12B3359B000B9B225 /* MockBTPayPalMessagingDelegate.swift */; };
 		BEF177A62B51C7ED004F0F35 /* SEPADebitAccountsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF177A52B51C7ED004F0F35 /* SEPADebitAccountsRequest.swift */; };
 		BEF177A82B51D6A7004F0F35 /* SEPADebitRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF177A72B51D6A7004F0F35 /* SEPADebitRequest.swift */; };
+		BEF2F50F2DCE7AF000FF0E90 /* VenmoAccountsPOSTBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF2F50C2DCE7AF000FF0E90 /* VenmoAccountsPOSTBody.swift */; };
+		BEF2F5102DCE7AF000FF0E90 /* VenmoCreatePaymentContextGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF2F50D2DCE7AF000FF0E90 /* VenmoCreatePaymentContextGraphQLBody.swift */; };
+		BEF2F5112DCE7AF000FF0E90 /* VenmoQueryPaymentContextGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF2F50E2DCE7AF000FF0E90 /* VenmoQueryPaymentContextGraphQLBody.swift */; };
 		BEF388C12BE52CD2000965C8 /* BTCoreAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF388C02BE52CD2000965C8 /* BTCoreAnalytics.swift */; };
 		BEF388C32BE9340C000965C8 /* BTAPITimingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF388C22BE9340C000965C8 /* BTAPITimingDelegate.swift */; };
 		BEF3F17E27CE9EDF00072467 /* BTSEPADirectDebitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */; };
@@ -1040,6 +1043,9 @@
 		BEF137E12B3359B000B9B225 /* MockBTPayPalMessagingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBTPayPalMessagingDelegate.swift; sourceTree = "<group>"; };
 		BEF177A52B51C7ED004F0F35 /* SEPADebitAccountsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADebitAccountsRequest.swift; sourceTree = "<group>"; };
 		BEF177A72B51D6A7004F0F35 /* SEPADebitRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADebitRequest.swift; sourceTree = "<group>"; };
+		BEF2F50C2DCE7AF000FF0E90 /* VenmoAccountsPOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VenmoAccountsPOSTBody.swift; sourceTree = "<group>"; };
+		BEF2F50D2DCE7AF000FF0E90 /* VenmoCreatePaymentContextGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VenmoCreatePaymentContextGraphQLBody.swift; sourceTree = "<group>"; };
+		BEF2F50E2DCE7AF000FF0E90 /* VenmoQueryPaymentContextGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VenmoQueryPaymentContextGraphQLBody.swift; sourceTree = "<group>"; };
 		BEF388C02BE52CD2000965C8 /* BTCoreAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCoreAnalytics.swift; sourceTree = "<group>"; };
 		BEF388C22BE9340C000965C8 /* BTAPITimingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAPITimingDelegate.swift; sourceTree = "<group>"; };
 		BEF3F17127CE9E6C00072467 /* BTSEPADirectDebitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSEPADirectDebitClient.swift; sourceTree = "<group>"; };
@@ -1050,10 +1056,6 @@
 		BEFE9A3A29C8EC6B00BF69AB /* BTCardClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient.swift; sourceTree = "<group>"; };
 		BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		BECEF7982DCD20E800181C83 /* Models */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Models; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		03502C801E9C0A1700F15EE6 /* Frameworks */ = {
@@ -1764,7 +1766,7 @@
 				BE0AF6BA29AFD53300245C2C /* BTVenmoError.swift */,
 				096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */,
 				BE0AF6BE29AFF13200245C2C /* BTVenmoRequest.swift */,
-				BECEF7982DCD20E800181C83 /* Models */,
+				BEF2F5122DCE7FD900FF0E90 /* Models */,
 				3BE7386E2BA171A300598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			path = BraintreeVenmo;
@@ -2016,6 +2018,16 @@
 				BE24C66528D906090067B11A /* CardinalMobile.xcframework */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		BEF2F5122DCE7FD900FF0E90 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				BEF2F50C2DCE7AF000FF0E90 /* VenmoAccountsPOSTBody.swift */,
+				BEF2F50D2DCE7AF000FF0E90 /* VenmoCreatePaymentContextGraphQLBody.swift */,
+				BEF2F50E2DCE7AF000FF0E90 /* VenmoQueryPaymentContextGraphQLBody.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		BEF3F17027CE9E2600072467 /* BraintreeSEPADirectDebit */ = {
@@ -2282,9 +2294,6 @@
 			);
 			dependencies = (
 				BE10B8D5287DC1F700F7B3B2 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				BECEF7982DCD20E800181C83 /* Models */,
 			);
 			name = BraintreeVenmo;
 			productName = BraintreeVenmo;
@@ -3267,6 +3276,9 @@
 				3B1C529429D5EB4E00B68A58 /* BTVenmoAnalytics.swift in Sources */,
 				BE0AF6BF29AFF13200245C2C /* BTVenmoRequest.swift in Sources */,
 				BEDB820A29B7A9E600075AF3 /* BTVenmoClient.swift in Sources */,
+				BEF2F50F2DCE7AF000FF0E90 /* VenmoAccountsPOSTBody.swift in Sources */,
+				BEF2F5102DCE7AF000FF0E90 /* VenmoCreatePaymentContextGraphQLBody.swift in Sources */,
+				BEF2F5112DCE7AF000FF0E90 /* VenmoQueryPaymentContextGraphQLBody.swift in Sources */,
 				BE0AF6B929AFD50500245C2C /* BTVenmoAppSwitchReturnURL.swift in Sources */,
 				BE0AF6BB29AFD53300245C2C /* BTVenmoError.swift in Sources */,
 				BE0AF6BD29AFDCD100245C2C /* BTVenmoAppSwitchRedirectURL.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1051,6 +1051,10 @@
 		BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		BECEF7982DCD20E800181C83 /* Models */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Models; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		03502C801E9C0A1700F15EE6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -1760,6 +1764,7 @@
 				BE0AF6BA29AFD53300245C2C /* BTVenmoError.swift */,
 				096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */,
 				BE0AF6BE29AFF13200245C2C /* BTVenmoRequest.swift */,
+				BECEF7982DCD20E800181C83 /* Models */,
 				3BE7386E2BA171A300598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			path = BraintreeVenmo;
@@ -2277,6 +2282,9 @@
 			);
 			dependencies = (
 				BE10B8D5287DC1F700F7B3B2 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				BECEF7982DCD20E800181C83 /* Models */,
 			);
 			name = BraintreeVenmo;
 			productName = BraintreeVenmo;

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -213,7 +213,7 @@ import BraintreeCore
 
         switch returnURL.state {
         case .succeededWithPaymentContext:
-            let graphQLParameters = VenmoQueryPaymentContextGraphQLBody(paymentContextID:   returnURL.paymentContextID)
+            let graphQLParameters = VenmoQueryPaymentContextGraphQLBody(paymentContextID: returnURL.paymentContextID)
 
             apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, _, error in
                 if let error {

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -109,7 +109,10 @@ import BraintreeCore
             let metadata = self.apiClient.metadata
             metadata.source = .venmoApp
             
-            let graphQLParameters = self.buildGraphQLDictionary(with: request, merchantProfileID: merchantProfileID)
+            let graphQLParameters = VenmoCreatePaymentContextGraphQLBody(
+                request: request,
+                merchantProfileID: merchantProfileID
+            )
 
             self.apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, _, error in
                 if let error = error as? NSError {
@@ -188,74 +191,6 @@ import BraintreeCore
         application.open(appStoreURL, completionHandler: nil)
     }
 
-    // MARK: - Internal Methods
-
-    func buildGraphQLDictionary(with request: BTVenmoRequest, merchantProfileID: String?) -> [String: Any] {
-        var inputParameters: [String: Any?] = [
-            "paymentMethodUsage": request.paymentMethodUsage.stringValue,
-            "merchantProfileId": merchantProfileID,
-            "customerClient": "MOBILE_APP",
-            "intent": "CONTINUE",
-            "isFinalAmount": "\(request.isFinalAmount)"
-        ]
-
-        if let displayName = request.displayName {
-            inputParameters["displayName"] = displayName
-        }
-
-        var paysheetDetails: [String: Any] = [
-            "collectCustomerBillingAddress": "\(request.collectCustomerBillingAddress)",
-            "collectCustomerShippingAddress": "\(request.collectCustomerShippingAddress)"
-        ]
-
-        var transactionDetails: [String: Any] = [:]
-        if let subTotalAmount = request.subTotalAmount {
-            transactionDetails["subTotalAmount"] = subTotalAmount
-        }
-
-        if let discountAmount = request.discountAmount {
-            transactionDetails["discountAmount"] = discountAmount
-        }
-
-        if let taxAmount = request.taxAmount {
-            transactionDetails["taxAmount"] = taxAmount
-        }
-
-        if let shippingAmount = request.shippingAmount {
-            transactionDetails["shippingAmount"] = shippingAmount
-        }
-
-        if let totalAmount = request.totalAmount {
-            transactionDetails["totalAmount"] = totalAmount
-        }
-
-        if let lineItems = request.lineItems, !lineItems.isEmpty {
-            for item in lineItems {
-                if item.unitTaxAmount == nil || item.unitTaxAmount?.isEmpty == true {
-                    item.unitTaxAmount = "0"
-                }
-            }
-            let lineItemsArray = lineItems.compactMap { $0.requestParameters() }
-            transactionDetails["lineItems"] = lineItemsArray
-        }
-
-        if !transactionDetails.isEmpty {
-            paysheetDetails["transactionDetails"] = transactionDetails
-        }
-
-        inputParameters["paysheetDetails"] = paysheetDetails
-
-        let inputDictionary: [String: Any] = ["input": inputParameters]
-
-        let graphQLParameters: [String: Any] = [
-            // swiftlint:disable:next line_length
-            "query": "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }",
-            "variables": inputDictionary
-        ]
-
-        return graphQLParameters
-    }
-
     // MARK: - App Switch Methods
 
     // swiftlint:disable:next function_body_length
@@ -278,12 +213,7 @@ import BraintreeCore
 
         switch returnURL.state {
         case .succeededWithPaymentContext:
-            let variablesDictionary: [String: String?] = ["id": returnURL.paymentContextID]
-            let graphQLParameters: [String: Any] = [
-                // swiftlint:disable:next line_length
-                "query": "query PaymentContext($id: ID!) { node(id: $id) { ... on VenmoPaymentContext { paymentMethodId userName payerInfo { firstName lastName phoneNumber email externalId userName shippingAddress { fullName addressLine1 addressLine2 adminArea1 adminArea2 postalCode countryCode } billingAddress { fullName addressLine1 addressLine2 adminArea1 adminArea2 postalCode countryCode } } } } }",
-                "variables": variablesDictionary
-            ]
+            let graphQLParameters = VenmoQueryPaymentContextGraphQLBody(paymentContextID:   returnURL.paymentContextID)
 
             apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI) { body, _, error in
                 if let error {
@@ -387,8 +317,7 @@ import BraintreeCore
     // MARK: - Vaulting Methods
 
     func vault(_ nonce: String) {
-        let venmoAccount: [String: String] = ["nonce": nonce]
-        let parameters: [String: Any] = ["venmoAccount": venmoAccount]
+        let parameters = VenmoAccountsPOSTBody(nonce: nonce)
 
         apiClient.post("v1/payment_methods/venmo_accounts", parameters: parameters) { body, _, error in
             if let error {

--- a/Sources/BraintreeVenmo/Models/VenmoAccountsPOSTBody.swift
+++ b/Sources/BraintreeVenmo/Models/VenmoAccountsPOSTBody.swift
@@ -1,0 +1,14 @@
+/// The POST body for `v1/payment_methods/venmo_accounts`
+struct VenmoAccountsPOSTBody: Encodable {
+
+    var venmoAccount: Nonce
+
+    init(nonce: String) {
+        self.venmoAccount = Nonce(nonce: nonce)
+    }
+
+    struct Nonce: Encodable {
+
+        var nonce: String
+    }
+}

--- a/Sources/BraintreeVenmo/Models/VenmoCreatePaymentContextGraphQLBody.swift
+++ b/Sources/BraintreeVenmo/Models/VenmoCreatePaymentContextGraphQLBody.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+// swiftlint:disable nesting
+/// The POST body for graph QL `mutation CreateVenmoPaymentContext`
+struct VenmoCreatePaymentContextGraphQLBody: Encodable {
+    
+    var query: String
+    var variables: Variables
+    
+    init(request: BTVenmoRequest, merchantProfileID: String?) {
+        // swiftlint:disable:next line_length
+        self.query = "mutation CreateVenmoPaymentContext($input: CreateVenmoPaymentContextInput!) { createVenmoPaymentContext(input: $input) { venmoPaymentContext { id } } }"
+        self.variables = Variables(request: request, merchantProfileID: merchantProfileID)
+    }
+    
+    
+    struct Variables: Encodable {
+        
+        let input: InputParameters
+        
+        init(request: BTVenmoRequest, merchantProfileID: String?) {
+            self.input = InputParameters(
+                paymentMethodUsage: request.paymentMethodUsage.stringValue,
+                merchantProfileID: merchantProfileID,
+                customerClient: "MOBILE_APP",
+                intent: "CONTINUE",
+                isFinalAmount: request.isFinalAmount.description,
+                displayName: request.displayName,
+                paysheetDetails: Variables.InputParameters.PaysheetDetails(
+                    collectCustomerBillingAddress: request.collectCustomerBillingAddress,
+                    collectCustomerShippingAddress: request.collectCustomerShippingAddress,
+                    transactionDetails: Variables.InputParameters.PaysheetDetails.TransactionDetails(
+                        lineItems: request.lineItems?.map { item in
+                            Variables.InputParameters.PaysheetDetails.LineItem(
+                                quantity: item.quantity,
+                                unitAmount: item.unitAmount,
+                                name: item.name,
+                                kind: item.kind.rawValue,
+                                unitTaxAmount: item.unitTaxAmount ?? "0",
+                                itemDescription: item.itemDescription,
+                                productCode: item.productCode,
+                                url: item.url
+                            )
+                        }
+                    )
+                )
+            )
+        }
+        
+        struct InputParameters: Encodable {
+            
+            var paymentMethodUsage: String?
+            var merchantProfileID: String?
+            var customerClient: String = "MOBILE_APP"
+            var intent: String = "intent"
+            var isFinalAmount: String?
+            var displayName: String?
+            var paysheetDetails: PaysheetDetails?
+            
+            enum CodingKeys: String, CodingKey {
+                case paymentMethodUsage
+                case merchantProfileID = "merchantProfileId"
+                case customerClient
+                case intent
+                case isFinalAmount
+                case displayName
+                case paysheetDetails
+            }
+            
+            struct PaysheetDetails: Encodable {
+                
+                var collectCustomerBillingAddress: Bool?
+                var collectCustomerShippingAddress: Bool?
+                var transactionDetails: TransactionDetails?
+                
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    
+                    try container.encodeIfPresent(collectCustomerBillingAddress, forKey: .collectCustomerBillingAddress)
+                    try container.encodeIfPresent(collectCustomerShippingAddress, forKey: .collectCustomerShippingAddress)
+                    
+                    if let transactionDetails = transactionDetails {
+                        let properties = [
+                            transactionDetails.subTotalAmount,
+                            transactionDetails.discountAmount,
+                            transactionDetails.taxAmount,
+                            transactionDetails.shippingAmount,
+                            transactionDetails.totalAmount
+                        ]
+                        
+                        if !properties.allSatisfy({ $0?.isEmpty ?? true }) || !(transactionDetails.lineItems?.isEmpty ?? true) {
+                            try container.encode(transactionDetails, forKey: .transactionDetails)
+                        }
+                    }
+                }
+                
+                enum CodingKeys: String, CodingKey {
+                    case collectCustomerBillingAddress
+                    case collectCustomerShippingAddress
+                    case transactionDetails
+                }
+                
+                struct TransactionDetails: Encodable {
+                    
+                    var subTotalAmount: String?
+                    var discountAmount: String?
+                    var taxAmount: String?
+                    var shippingAmount: String?
+                    var totalAmount: String?
+                    let lineItems: [LineItem]?
+                    
+                    func encode(to encoder: Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        
+                        try container.encodeIfPresent(subTotalAmount, forKey: .subTotalAmount)
+                        try container.encodeIfPresent(discountAmount, forKey: .discountAmount)
+                        try container.encodeIfPresent(taxAmount, forKey: .taxAmount)
+                        try container.encodeIfPresent(shippingAmount, forKey: .shippingAmount)
+                        try container.encodeIfPresent(totalAmount, forKey: .totalAmount)
+                        if let lineItems, !lineItems.isEmpty {
+                            try container.encode(lineItems, forKey: .lineItems)
+                        }
+                    }
+                    
+                    enum CodingKeys: String, CodingKey {
+                        case subTotalAmount
+                        case discountAmount
+                        case taxAmount
+                        case shippingAmount
+                        case totalAmount
+                        case lineItems
+                    }
+                }
+                
+                struct LineItem: Encodable {
+                    
+                    let quantity: Int
+                    let unitAmount: String
+                    let name: String
+                    let kind: Int
+                    let unitTaxAmount: String?
+                    let itemDescription: String?
+                    let productCode: String?
+                    let url: URL?
+                }
+            }
+        }
+    }
+}

--- a/Sources/BraintreeVenmo/Models/VenmoCreatePaymentContextGraphQLBody.swift
+++ b/Sources/BraintreeVenmo/Models/VenmoCreatePaymentContextGraphQLBody.swift
@@ -52,7 +52,7 @@ struct VenmoCreatePaymentContextGraphQLBody: Encodable {
             var paymentMethodUsage: String?
             var merchantProfileID: String?
             var customerClient: String = "MOBILE_APP"
-            var intent: String = "intent"
+            var intent: String = "CONTINUE"
             var isFinalAmount: String?
             var displayName: String?
             var paysheetDetails: PaysheetDetails?

--- a/Sources/BraintreeVenmo/Models/VenmoQueryPaymentContextGraphQLBody.swift
+++ b/Sources/BraintreeVenmo/Models/VenmoQueryPaymentContextGraphQLBody.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable nesting
 /// The POST body for graph QL `query PaymentContext`
 struct VenmoQueryPaymentContextGraphQLBody: Encodable {
 
@@ -13,5 +14,9 @@ struct VenmoQueryPaymentContextGraphQLBody: Encodable {
     struct Variables: Encodable {
 
         var paymentContextID: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case paymentContextID = "id"
+        }
     }
 }

--- a/Sources/BraintreeVenmo/Models/VenmoQueryPaymentContextGraphQLBody.swift
+++ b/Sources/BraintreeVenmo/Models/VenmoQueryPaymentContextGraphQLBody.swift
@@ -1,0 +1,17 @@
+/// The POST body for graph QL `query PaymentContext`
+struct VenmoQueryPaymentContextGraphQLBody: Encodable {
+
+    var query: String
+    var variables: Variables
+
+    init(paymentContextID: String?) {
+        // swiftlint:disable:next line_length
+        self.query = "query PaymentContext($id: ID!) { node(id: $id) { ... on VenmoPaymentContext { paymentMethodId userName payerInfo { firstName lastName phoneNumber email externalId userName shippingAddress { fullName addressLine1 addressLine2 adminArea1 adminArea2 postalCode countryCode } billingAddress { fullName addressLine1 addressLine2 adminArea1 adminArea2 postalCode countryCode } } } } }"
+        self.variables = Variables(paymentContextID: paymentContextID)
+    }
+
+    struct Variables: Encodable {
+
+        var paymentContextID: String?
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Convert the following POST requests to Encodable for the Venmo flow:
    - `VenmoAccountsPOSTBody`
    - `VenmoCreatePaymentContextGraphQLBody`
    - `VenmoQueryPaymentContextGraphQLBody`

🚀  **Note:** I used GitHub Copilot to help with some of this logic. While I did need to update some things to match our patterns and the expected Graph QL keys, it was helpful in generating some of the encodable boilerplate.

**Testing:** I have tested both the app switch and universal link fallback flow on device with these changes

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
