### PR TITLE
Remove analytics batching

### DIFF
--- a/Sources/BraintreeCore/Analytics/AnalyticsSendable.swift
+++ b/Sources/BraintreeCore/Analytics/AnalyticsSendable.swift
@@ -2,6 +2,13 @@
 /// - Note: Specifically created to mock the `BTAnalyticsService` singleton.
 protocol AnalyticsSendable: AnyObject {
     
-    func sendAnalyticsEvent(_ event: FPTIBatchData.Event)
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool)
     func setAPIClient(_ apiClient: BTAPIClient)
+}
+
+extension AnalyticsSendable {
+    
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool = true) {
+        sendAnalyticsEvent(event, sendImmediately: sendImmediately)
+    }
 }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -55,11 +55,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     /// - Parameter event: A single `FPTIBatchData.Event`
     func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool) {
         Task(priority: .background) {
-            if sendImmediately {
-                await sendAnalyticsEvents(with: event)
-            } else {
-                await performEventRequest(with: event)
-            }
+            sendImmediately ? await sendAnalyticsEvents(with: event) : await performEventRequest(with: event)
         }
     }
     
@@ -102,7 +98,8 @@ final class BTAnalyticsService: AnalyticsSendable {
                 try await postAnalyticsEvents(
                     configuration: configuration,
                     sessionID: sessionID,
-                    events: eventsPerSessionID)
+                    events: eventsPerSessionID
+                )
                 await events.removeFor(sessionID: sessionID)
             }
         } catch {

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -86,9 +86,9 @@ final class BTAnalyticsService: AnalyticsSendable {
     private func beginBackgroundTaskIfNeeded() -> UIBackgroundTaskIdentifier {
         var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
         
-        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
+        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") { [weak self] in
             DispatchQueue.main.async {
-                self.endBackgroundTask(identifier: backgroundTaskID)
+                self?.endBackgroundTask(identifier: backgroundTaskID)
             }
         }
         

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -55,7 +55,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     /// - Parameter event: A single `FPTIBatchData.Event`
     func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool) {
         Task(priority: .background) {
-            sendImmediately ? await sendAnalyticsEventsImmediately(event: event) : await performEventRequest(with: event)
+            sendImmediately ? sendAnalyticsEventsImmediately(event: event) : await performEventRequest(with: event)
         }
     }
     
@@ -77,7 +77,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     /// The background task is safely ended both in the expiration handler and after the event is sent.
     ///
     /// Exposed to be able to execute this function synchronously in unit tests
-    func sendAnalyticsEventsImmediately(event: FPTIBatchData.Event) async {
+    func sendAnalyticsEventsImmediately(event: FPTIBatchData.Event) {
         guard let apiClient else { return }
         
         var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
@@ -88,17 +88,19 @@ final class BTAnalyticsService: AnalyticsSendable {
         // The expirationHandler is called if the system’s maximum background execution time
         // (typically around 30 seconds) is reached before the task completes.
         // If we don't explicitly end the task here, the app may be forcefully terminated by the system.
-        backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
-            // We end the task here to avoid the app being terminated.
-            UIApplication.shared.endBackgroundTask(backgroundTaskID)
+        Task {
+            backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
+                // We end the task here to avoid the app being terminated.
+                UIApplication.shared.endBackgroundTask(backgroundTaskID)
+                backgroundTaskID = .invalid
+            }
+            
+            await sendAnalyticEvent(event, apiClient: apiClient)
+            
+            // Explicitly end the background task after the work is completed
+            await UIApplication.shared.endBackgroundTask(backgroundTaskID)
             backgroundTaskID = .invalid
         }
-        
-        await sendAnalyticEvent(event, apiClient: apiClient)
-        
-        // Explicitly end the background task after the work is completed
-        await UIApplication.shared.endBackgroundTask(backgroundTaskID)
-        backgroundTaskID = .invalid
     }
 
     // MARK: - Private Methods

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -102,7 +102,7 @@ final class BTAnalyticsService: AnalyticsSendable {
             await sendAnalyticEvent(event, apiClient: apiClient)
             
             // Explicitly end the background task after the work is completed
-            await UIApplication.shared.endBackgroundTask(backgroundTaskID)
+            UIApplication.shared.endBackgroundTask(backgroundTaskID)
             backgroundTaskID = .invalid
         }
     }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -1,4 +1,3 @@
-import Foundation
 import UIKit
 
 final class BTAnalyticsService: AnalyticsSendable {

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -53,7 +53,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     
     /// Sends analytics event to https://api.paypal.com/v1/tracking/batch/events/ via a background task.
     /// - Parameter event: A single `FPTIBatchData.Event`
-    func sendAnalyticsEvent(_ event: FPTIBatchData.Event) {
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool) {
         Task(priority: .background) {
             await performEventRequest(with: event)
         }
@@ -73,23 +73,6 @@ final class BTAnalyticsService: AnalyticsSendable {
     // MARK: - Private Methods
 
     private func sendQueuedAnalyticsEvents() async {
-        if await !events.isEmpty, let apiClient {
-            do {
-                let configuration = try await apiClient.fetchConfiguration()
-                
-                for (sessionID, eventsPerSessionID) in await events.allValues {
-                    let postParameters = createAnalyticsEvent(
-                        config: configuration,
-                        sessionID: sessionID,
-                        events: eventsPerSessionID
-                    )
-                    
-                    _ = try? await http?.post("v1/tracking/batch/events", parameters: postParameters)
-                    
-                    await events.removeFor(sessionID: sessionID)
-                }
-            } catch {
-                return
             }
         }
     }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -23,7 +23,6 @@ final class BTAnalyticsService: AnalyticsSendable {
     private let events = BTAnalyticsEventsStorage()
     private let timer = RepeatingTimer()
 
-    private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     private var apiClient: BTAPIClient?
             
     // MARK: - Initializer

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -78,7 +78,7 @@ final class BTAnalyticsService: AnalyticsSendable {
      
         beginBackgroundTaskIfNeeded()
         
-        await sendEventToServer(with: event, apiClient: apiClient)
+        await sendAnalyticEvent(event, apiClient: apiClient)
         endBackgroundTask()
     }
     
@@ -96,7 +96,7 @@ final class BTAnalyticsService: AnalyticsSendable {
         backgroundTaskID = .invalid
     }
     
-    private func sendEventToServer(with event: FPTIBatchData.Event, apiClient: BTAPIClient) async {
+    private func sendAnalyticEvent(_ event: FPTIBatchData.Event, apiClient: BTAPIClient) async {
         do {
             let configuration = try await apiClient.fetchConfiguration()
             try await postAnalyticsEvents(

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -54,8 +54,12 @@ final class BTAnalyticsService: AnalyticsSendable {
     /// Sends analytics event to https://api.paypal.com/v1/tracking/batch/events/ via a background task.
     /// - Parameter event: A single `FPTIBatchData.Event`
     func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool) {
-        Task(priority: .background) {
-            sendImmediately ? await sendAnalyticsEventsImmediately(event: event) : await performEventRequest(with: event)
+        if sendImmediately {
+            sendAnalyticsEventsImmediately(event: event)
+        } else {
+            Task(priority: .background) {
+                await performEventRequest(with: event)
+            }
         }
     }
     
@@ -71,34 +75,23 @@ final class BTAnalyticsService: AnalyticsSendable {
     }
     
     /// Exposed to be able to execute this function synchronously in unit tests
-    func sendAnalyticsEventsImmediately(event: FPTIBatchData.Event) async {
+    func sendAnalyticsEventsImmediately(event: FPTIBatchData.Event) {
         guard let apiClient else { return }
         
-        let backgroundTaskID = beginBackgroundTaskIfNeeded()
+        var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
         
-        await sendAnalyticEvent(event, apiClient: apiClient)
+        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") { [backgroundTaskID] in
+            UIApplication.shared.endBackgroundTask(backgroundTaskID)
+        }
         
-        endBackgroundTask(identifier: backgroundTaskID)
+        Task {
+            await sendAnalyticEvent(event, apiClient: apiClient)
+        }
+        
+        UIApplication.shared.endBackgroundTask(backgroundTaskID)
     }
     
     // MARK: - Private Methods
-    
-    private func beginBackgroundTaskIfNeeded() -> UIBackgroundTaskIdentifier {
-        var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
-        
-        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") { [weak self] in
-            DispatchQueue.main.async {
-                self?.endBackgroundTask(identifier: backgroundTaskID)
-            }
-        }
-        
-        return backgroundTaskID
-    }
-    
-    private func endBackgroundTask(identifier: UIBackgroundTaskIdentifier) {
-        guard identifier != .invalid else { return }
-        UIApplication.shared.endBackgroundTask(identifier)
-    }
     
     private func sendAnalyticEvent(_ event: FPTIBatchData.Event, apiClient: BTAPIClient) async {
         do {

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -22,7 +22,7 @@ final class BTAnalyticsService: AnalyticsSendable {
     private let events = BTAnalyticsEventsStorage()
     private let timer = RepeatingTimer()
 
-    private weak var apiClient: BTAPIClient?
+    private var apiClient: BTAPIClient?
             
     // MARK: - Initializer
     

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -100,11 +100,11 @@ final class BTAnalyticsService: AnalyticsSendable {
         
         Task(priority: .background) {
             await sendAnalyticEvent(event, apiClient: apiClient)
+            
+            // Explicitly end the background task after the work is completed
+            await UIApplication.shared.endBackgroundTask(backgroundTaskID)
+            backgroundTaskID = .invalid
         }
-
-        // Explicitly end the background task after the work is completed
-        UIApplication.shared.endBackgroundTask(backgroundTaskID)
-        backgroundTaskID = .invalid
     }
 
     /// Exposed to be able to execute this function synchronously in unit tests

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -101,10 +101,9 @@ final class BTAnalyticsService: AnalyticsSendable {
         }
     }
 
-    // MARK: - Private Methods
-
-    private func sendAnalyticEvent(_ event: FPTIBatchData.Event, apiClient: BTAPIClient, completion: @escaping () -> Void) {
-        Task(priority: .background) {
+    /// Exposed to be able to execute this function synchronously in unit tests
+    func sendAnalyticEvent(_ event: FPTIBatchData.Event, apiClient: BTAPIClient, completion: @escaping () -> Void) {
+        Task {
             do {
                 let configuration = try await apiClient.fetchConfiguration()
                 try await postAnalyticsEvents(
@@ -119,6 +118,8 @@ final class BTAnalyticsService: AnalyticsSendable {
             }
         }
     }
+
+    // MARK: - Private Methods
 
     private func sendQueuedAnalyticsEvents() async {
         guard await !events.isEmpty, let apiClient else { return }

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -90,15 +90,15 @@ final class BTAnalyticsService: AnalyticsSendable {
         // If we don't explicitly end the task here, the app may be forcefully terminated by the system.
         backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
             // We end the task here to avoid the app being terminated.
-            MainActor.assumeIsolated {
-                UIApplication.shared.endBackgroundTask(backgroundTaskID)
-            }
+            UIApplication.shared.endBackgroundTask(backgroundTaskID)
+            backgroundTaskID = .invalid
         }
         
         await sendAnalyticEvent(event, apiClient: apiClient)
         
         // Explicitly end the background task after the work is completed
         await UIApplication.shared.endBackgroundTask(backgroundTaskID)
+        backgroundTaskID = .invalid
     }
     
     // MARK: - Private Methods

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -76,8 +76,10 @@ final class BTAnalyticsService: AnalyticsSendable {
         
         var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
         
-        backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") { [backgroundTaskID] in
-            UIApplication.shared.endBackgroundTask(backgroundTaskID)
+        backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
+            MainActor.assumeIsolated {
+                UIApplication.shared.endBackgroundTask(backgroundTaskID)
+            }
         }
         
         await sendAnalyticEvent(event, apiClient: apiClient)

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -88,7 +88,7 @@ final class BTAnalyticsService: AnalyticsSendable {
         // The expirationHandler is called if the system’s maximum background execution time
         // (typically around 30 seconds) is reached before the task completes.
         // If we don't explicitly end the task here, the app may be forcefully terminated by the system.
-        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
+        backgroundTaskID = await UIApplication.shared.beginBackgroundTask(withName: "BTSendAnalyticEvent") {
             // We end the task here to avoid the app being terminated.
             UIApplication.shared.endBackgroundTask(backgroundTaskID)
             backgroundTaskID = .invalid
@@ -97,7 +97,7 @@ final class BTAnalyticsService: AnalyticsSendable {
         await sendAnalyticEvent(event, apiClient: apiClient)
         
         // Explicitly end the background task after the work is completed
-        UIApplication.shared.endBackgroundTask(backgroundTaskID)
+        await UIApplication.shared.endBackgroundTask(backgroundTaskID)
         backgroundTaskID = .invalid
     }
 

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -427,7 +427,8 @@ import Foundation
                     eventName: BTCoreAnalytics.apiRequestLatency,
                     requestStartTime: requestStartTime,
                     startTime: startTime
-                )
+                ),
+                sendImmediately: false
             )
         }
     }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -25,7 +25,7 @@ import Foundation
     var configurationLoader: ConfigurationLoader
     
     /// Exposed for testing analytics
-    var analyticsService: AnalyticsSendable = BTAnalyticsService.shared
+    weak var analyticsService: AnalyticsSendable? = BTAnalyticsService.shared
 
     // MARK: - Initializers
 
@@ -58,7 +58,7 @@ import Foundation
         configurationLoader = ConfigurationLoader(http: btHttp)
         
         super.init()
-        analyticsService.setAPIClient(self)
+        analyticsService?.setAPIClient(self)
         http?.networkTimingDelegate = self
 
         // Kickoff the background request to fetch the config
@@ -318,7 +318,7 @@ import Foundation
         payPalContextID: String? = nil,
         shopperSessionID: String? = nil
     ) {
-        analyticsService.sendAnalyticsEvent(
+        analyticsService?.sendAnalyticsEvent(
             FPTIBatchData.Event(
                 appSwitchURL: appSwitchURL,
                 buttonOrder: buttonOrder,
@@ -419,7 +419,7 @@ import Foundation
         )
         
         if cleanedPath != "/v1/tracking/batch/events" {
-            analyticsService.sendAnalyticsEvent(
+            analyticsService?.sendAnalyticsEvent(
                 FPTIBatchData.Event(
                     connectionStartTime: connectionStartTime,
                     endpoint: cleanedPath,

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -76,9 +76,9 @@ final class BTAnalyticsService_Tests: XCTestCase {
         let event1 = FPTIBatchData.Event(eventName: "event1")
         let event2 = FPTIBatchData.Event(eventName: "event2")
         let event3 = FPTIBatchData.Event(eventName: "event3")
-        await sut.sendAnalyticsEventsImmediately(event: event1)
-        await sut.sendAnalyticsEventsImmediately(event: event2)
-        await sut.sendAnalyticsEventsImmediately(event: event3)
+        await sut.sendAnalyticEvent(event1, apiClient: stubAPIClient)
+        await sut.sendAnalyticEvent(event2, apiClient: stubAPIClient)
+        await sut.sendAnalyticEvent(event3, apiClient: stubAPIClient)
 
         let eventName = parseEventName(mockAnalyticsHTTP.lastRequestParameters)
         

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -76,9 +76,9 @@ final class BTAnalyticsService_Tests: XCTestCase {
         let event1 = FPTIBatchData.Event(eventName: "event1")
         let event2 = FPTIBatchData.Event(eventName: "event2")
         let event3 = FPTIBatchData.Event(eventName: "event3")
-        await sut.sendAnalyticsEvents(with: event1)
-        await sut.sendAnalyticsEvents(with: event2)
-        await sut.sendAnalyticsEvents(with: event3)
+        await sut.sendAnalyticsEventsImmediately(event: event1)
+        await sut.sendAnalyticsEventsImmediately(event: event2)
+        await sut.sendAnalyticsEventsImmediately(event: event3)
 
         let eventName = parseEventName(mockAnalyticsHTTP.lastRequestParameters)
         

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -66,23 +66,32 @@ final class BTAnalyticsService_Tests: XCTestCase {
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 2)
     }
 
-    func testSendAnalyticsEvents_whenMultipleEventsSent_tracksLatestEventName_andNumberOfPOSTRequests() async {
+    func testSendAnalyticsEvents_whenMultipleEventsSent_tracksLatestEventName_andNumberOfPOSTRequests() {
         let stubAPIClient: MockAPIClient = stubbedAPIClientWithAnalyticsURL("test://do-not-send.url")
         let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
         let sut = BTAnalyticsService.shared
         sut.setAPIClient(stubAPIClient)
         sut.http = mockAnalyticsHTTP
-
+        
+        let expectation1 = expectation(description: "event 1 sent")
+        let expectation2 = expectation(description: "event 2 sent")
+        let expectation3 = expectation(description: "event 3 sent")
         let event1 = FPTIBatchData.Event(eventName: "event1")
         let event2 = FPTIBatchData.Event(eventName: "event2")
         let event3 = FPTIBatchData.Event(eventName: "event3")
-        await sut.sendAnalyticsEventsImmediately(event: event1)
-        await sut.sendAnalyticsEventsImmediately(event: event2)
-        await sut.sendAnalyticsEventsImmediately(event: event3)
-
-        let eventName = parseEventName(mockAnalyticsHTTP.lastRequestParameters)
+            
+        sut.sendAnalyticEvent(event1, apiClient: stubAPIClient) {
+            expectation1.fulfill()
+        }
+        sut.sendAnalyticEvent(event2, apiClient: stubAPIClient) {
+            expectation2.fulfill()
+        }
+        sut.sendAnalyticEvent(event3, apiClient: stubAPIClient) {
+            expectation3.fulfill()
+        }
         
-        XCTAssertEqual(eventName!, "event3")
+        wait(for: [expectation1, expectation2, expectation3], timeout: 3)
+        
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 3)
         XCTAssertEqual(mockAnalyticsHTTP.lastRequestEndpoint, "v1/tracking/batch/events")
     }

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -65,6 +65,27 @@ final class BTAnalyticsService_Tests: XCTestCase {
         
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 2)
     }
+
+    func testSendAnalyticsEvents_whenMultipleEventsSent_tracksLatestEventName_andNumberOfPOSTRequests() async {
+        let stubAPIClient: MockAPIClient = stubbedAPIClientWithAnalyticsURL("test://do-not-send.url")
+        let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
+        let sut = BTAnalyticsService.shared
+        sut.setAPIClient(stubAPIClient)
+        sut.http = mockAnalyticsHTTP
+
+        let event1 = FPTIBatchData.Event(eventName: "event1")
+        let event2 = FPTIBatchData.Event(eventName: "event2")
+        let event3 = FPTIBatchData.Event(eventName: "event3")
+        await sut.sendAnalyticsEvents(with: event1)
+        await sut.sendAnalyticsEvents(with: event2)
+        await sut.sendAnalyticsEvents(with: event3)
+
+        let eventName = parseEventName(mockAnalyticsHTTP.lastRequestParameters)
+        
+        XCTAssertEqual(eventName!, "event3")
+        XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 3)
+        XCTAssertEqual(mockAnalyticsHTTP.lastRequestEndpoint, "v1/tracking/batch/events")
+    }
     
     // MARK: - Helper Functions
 

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -76,9 +76,9 @@ final class BTAnalyticsService_Tests: XCTestCase {
         let event1 = FPTIBatchData.Event(eventName: "event1")
         let event2 = FPTIBatchData.Event(eventName: "event2")
         let event3 = FPTIBatchData.Event(eventName: "event3")
-        await sut.sendAnalyticEvent(event1, apiClient: stubAPIClient)
-        await sut.sendAnalyticEvent(event2, apiClient: stubAPIClient)
-        await sut.sendAnalyticEvent(event3, apiClient: stubAPIClient)
+        await sut.sendAnalyticsEventsImmediately(event: event1)
+        await sut.sendAnalyticsEventsImmediately(event: event2)
+        await sut.sendAnalyticsEventsImmediately(event: event3)
 
         let eventName = parseEventName(mockAnalyticsHTTP.lastRequestParameters)
         

--- a/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FakeAnalyticsService.swift
@@ -10,7 +10,7 @@ class FakeAnalyticsService: AnalyticsSendable {
         // No-Op
     }
 
-    func sendAnalyticsEvent(_ event: FPTIBatchData.Event) {
+    func sendAnalyticsEvent(_ event: FPTIBatchData.Event, sendImmediately: Bool = true) {
         self.lastEvent = event.eventName
         self.endpoint = event.endpoint
     }


### PR DESCRIPTION
### Summary of changes

Updates the sendAnalyticsEventsImmediately method to leverage UIApplication.shared.beginBackgroundTask in order to ensure that analytics events are successfully delivered even if the app is transitioning to the background.

Key changes:
Wrapped the call to sendAnalyticEvent in a background task to extend the app’s execution time beyond the default 30 seconds allowed by the OS.

Ensured the background task is properly ended in all execution paths to avoid potential app termination.

The update follows Apple’s recommended pattern for background task usage and includes a fallback with MainActor.assumeIsolated to safely call endBackgroundTask.

This change improves the reliability of analytics delivery, especially in critical scenarios like app switch events that may occur just as the app is backgrounded.

Specifically:

The background task is properly ended both via the expirationHandler and after the async operation completes, preventing the OS from terminating the app prematurely.

![Screenshot 2025-05-20 at 9 14 35 a m](https://github.com/user-attachments/assets/205db673-df17-44fc-bc37-2b29422807be)


### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
