### PR TITLE
[OPEN DEV] Fix RBA Metadata in Demo App

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -204,12 +204,11 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         if rbaDataToggle.isOn {
             let billingPricing = BTPayPalBillingPricing(
                 pricingModel: .fixed,
-                amount: "9.99",
-                reloadThresholdAmount: "99.99"
+                amount: "9.99"
             )
             
             let billingCycle = BTPayPalBillingCycle(
-                isTrial: true,
+                isTrial: false,
                 numberOfExecutions: 1,
                 interval: .month,
                 intervalCount: 1,


### PR DESCRIPTION
### Summary of changes

- Update demo app for RBA metadata to work as expected when toggled on, we were previously getting an error because:
    - `reloadThresholdAmount` cannot be used with the `. subscription` plan type
    - we need at least 1 billing cycle for `. subscription` plan type so setting `isTrial` to false allows us to have one

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
