### PR TITLE
Test background task

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		4585707A2C34B1E1009CEF7A /* MockClientAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */; };
 		4585707C2C34B7B5009CEF7A /* MockConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */; };
 		45EFC3972C2DBF32005E7F5B /* ConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */; };
+		45F766F62DE622640079016E /* BackgroundTaskManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F766F52DE622640079016E /* BackgroundTaskManaging.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
 		5708E0A828809BC6007946B9 /* BTJSONError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A728809BC6007946B9 /* BTJSONError.swift */; };
@@ -809,6 +810,7 @@
 		458570792C34B1E1009CEF7A /* MockClientAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClientAuthorization.swift; sourceTree = "<group>"; };
 		4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationLoader.swift; sourceTree = "<group>"; };
 		45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader.swift; sourceTree = "<group>"; };
+		45F766F52DE622640079016E /* BackgroundTaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManaging.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5708E0A528809AD9007946B9 /* BTJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON.swift; sourceTree = "<group>"; };
@@ -1638,6 +1640,7 @@
 		80F4F4D529F8A628003EACB1 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				45F766F52DE622640079016E /* BackgroundTaskManaging.swift */,
 				808E4A152C581CD40006A737 /* AnalyticsSendable.swift */,
 				BE549F132BF6576300B6F441 /* BTAnalyticsEventsStorage.swift */,
 				BEE2E4E329007FF100C03FDD /* BTAnalyticsService.swift */,
@@ -3359,6 +3362,7 @@
 				570B93D92853C6180041BAFE /* BTLogLevel.swift in Sources */,
 				80A6C6192B21205900416D50 /* UIApplication+URLOpener.swift in Sources */,
 				579DAEC5286E04A700FCE87F /* BTAppContextSwitcher.swift in Sources */,
+				45F766F62DE622640079016E /* BackgroundTaskManaging.swift in Sources */,
 				570B93D72853C29A0041BAFE /* BTLogLevelDescription.swift in Sources */,
 				57CBBCE828B033760037F4EE /* BTGraphQLHTTP.swift in Sources */,
 				80AD35F22BFBB1DD00BF890E /* TokenizationKeyError.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		4585707C2C34B7B5009CEF7A /* MockConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */; };
 		45EFC3972C2DBF32005E7F5B /* ConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */; };
 		45F766F62DE622640079016E /* BackgroundTaskManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F766F52DE622640079016E /* BackgroundTaskManaging.swift */; };
+		45F766F82DE8E1CE0079016E /* MockBackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F766F72DE8E1C10079016E /* MockBackgroundTaskManager.swift */; };
 		460C0C220F594AE8EE205E57 /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
 		5708E0A628809AD9007946B9 /* BTJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A528809AD9007946B9 /* BTJSON.swift */; };
 		5708E0A828809BC6007946B9 /* BTJSONError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708E0A728809BC6007946B9 /* BTJSONError.swift */; };
@@ -811,6 +812,7 @@
 		4585707B2C34B7B5009CEF7A /* MockConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationLoader.swift; sourceTree = "<group>"; };
 		45EFC3962C2DBF32005E7F5B /* ConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoader.swift; sourceTree = "<group>"; };
 		45F766F52DE622640079016E /* BackgroundTaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManaging.swift; sourceTree = "<group>"; };
+		45F766F72DE8E1C10079016E /* MockBackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackgroundTaskManager.swift; sourceTree = "<group>"; };
 		463DED22C0F426A474E6D7E2 /* Pods-Tests-BraintreeCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		541AEE40A1F01913E0638CC9 /* Pods-Tests-BraintreeCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BraintreeCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-BraintreeCoreTests/Pods-Tests-BraintreeCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5708E0A528809AD9007946B9 /* BTJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON.swift; sourceTree = "<group>"; };
@@ -1568,6 +1570,7 @@
 				BEE2E4A628FDB64400C03FDD /* BTAnalyticsService_Tests.swift */,
 				BEDA919F28EDDE64007441D9 /* FakeAnalyticsService.swift */,
 				8053F05329FAB6B00076F988 /* FPTIBatchData_Tests.swift */,
+				45F766F72DE8E1C10079016E /* MockBackgroundTaskManager.swift */,
 				457D7FC92C2A250E00EF6523 /* RepeatingTimer_Tests.swift */,
 			);
 			path = Analytics;
@@ -3686,6 +3689,7 @@
 			files = (
 				80BA3C292B23892700900BBB /* FakeRequest.swift in Sources */,
 				A95229C524FD8F15006F7D25 /* BTVersion_Tests.swift in Sources */,
+				45F766F82DE8E1CE0079016E /* MockBackgroundTaskManager.swift in Sources */,
 				BE54C0332912B68E009C6CEE /* BTHTTP_Tests.swift in Sources */,
 				A908437124FD8BB0004134CA /* BTPostalAddress_Tests.swift in Sources */,
 				BEBC6F3229380B82004E25A0 /* BTExceptionCatcher.m in Sources */,

--- a/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
+++ b/Sources/BraintreeCore/Analytics/BTAnalyticsService.swift
@@ -92,7 +92,7 @@ final class BTAnalyticsService: AnalyticsSendable {
         // (typically around 30 seconds) is reached before the task completes.
         // If we don't explicitly end the task here, the app may be forcefully terminated by the system.
         backgroundTaskID = application.beginBackgroundTask(withName: "BTSendAnalyticEvent") { [weak self] in
-            guard let self else { return }
+            guard let self, backgroundTaskID != .invalid else { return }
             // We end the task here to avoid the app being terminated.
             self.application.endBackgroundTask(backgroundTaskID)
             backgroundTaskID = .invalid
@@ -100,6 +100,7 @@ final class BTAnalyticsService: AnalyticsSendable {
 
         await sendAnalyticEvent(event, apiClient: apiClient)
 
+        guard backgroundTaskID != .invalid else { return }
         application.endBackgroundTask(backgroundTaskID)
         backgroundTaskID = .invalid
     }

--- a/Sources/BraintreeCore/Analytics/BackgroundTaskManaging.swift
+++ b/Sources/BraintreeCore/Analytics/BackgroundTaskManaging.swift
@@ -1,7 +1,10 @@
 import UIKit
 
 protocol BackgroundTaskManaging {
-    nonisolated func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (@MainActor @Sendable () -> Void)?) -> UIBackgroundTaskIdentifier
+    nonisolated func beginBackgroundTask(
+        withName taskName: String?,
+        expirationHandler handler: (@MainActor @Sendable () -> Void)?
+    ) -> UIBackgroundTaskIdentifier
     nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
 }
 

--- a/Sources/BraintreeCore/Analytics/BackgroundTaskManaging.swift
+++ b/Sources/BraintreeCore/Analytics/BackgroundTaskManaging.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+protocol BackgroundTaskManaging {
+    nonisolated func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (@MainActor @Sendable () -> Void)?) -> UIBackgroundTaskIdentifier
+    nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+}
+
+extension UIApplication: BackgroundTaskManaging { }

--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -66,31 +66,20 @@ final class BTAnalyticsService_Tests: XCTestCase {
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 2)
     }
 
-    func testSendAnalyticsEvents_whenMultipleEventsSent_tracksLatestEventName_andNumberOfPOSTRequests() {
+    func testSendAnalyticsEvents_whenMultipleEventsSent_tracksLatestEventName_andNumberOfPOSTRequests() async {
         let stubAPIClient: MockAPIClient = stubbedAPIClientWithAnalyticsURL("test://do-not-send.url")
         let mockAnalyticsHTTP = FakeHTTP.fakeHTTP()
         let sut = BTAnalyticsService.shared
         sut.setAPIClient(stubAPIClient)
         sut.http = mockAnalyticsHTTP
         
-        let expectation1 = expectation(description: "event 1 sent")
-        let expectation2 = expectation(description: "event 2 sent")
-        let expectation3 = expectation(description: "event 3 sent")
         let event1 = FPTIBatchData.Event(eventName: "event1")
         let event2 = FPTIBatchData.Event(eventName: "event2")
         let event3 = FPTIBatchData.Event(eventName: "event3")
             
-        sut.sendAnalyticEvent(event1, apiClient: stubAPIClient) {
-            expectation1.fulfill()
-        }
-        sut.sendAnalyticEvent(event2, apiClient: stubAPIClient) {
-            expectation2.fulfill()
-        }
-        sut.sendAnalyticEvent(event3, apiClient: stubAPIClient) {
-            expectation3.fulfill()
-        }
-        
-        wait(for: [expectation1, expectation2, expectation3], timeout: 3)
+        await sut.sendAnalyticEvent(event1, apiClient: stubAPIClient)
+        await sut.sendAnalyticEvent(event2, apiClient: stubAPIClient)
+        await sut.sendAnalyticEvent(event3, apiClient: stubAPIClient)
         
         XCTAssertEqual(mockAnalyticsHTTP.POSTRequestCount, 3)
         XCTAssertEqual(mockAnalyticsHTTP.lastRequestEndpoint, "v1/tracking/batch/events")

--- a/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
@@ -1,0 +1,26 @@
+@testable import BraintreeCore
+
+class MockBackgroundTaskManager: BackgroundTaskManaging {
+    
+    var didBeginBackgroundTask = false
+    var didEndBackgroundTask = false
+    var lastTaskName: String?
+    var lastTaskID: UIBackgroundTaskIdentifier = .invalid
+    var expirationHandler: (@MainActor @Sendable () -> Void)?
+    var endedTaskID: UIBackgroundTaskIdentifier?
+    
+    func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (@MainActor @Sendable () -> Void)?) -> UIBackgroundTaskIdentifier {
+        didBeginBackgroundTask = true
+        lastTaskName = taskName
+        
+        // Simulate expiration handler call
+        self.expirationHandler = handler
+        
+        return lastTaskID
+    }
+
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+        didEndBackgroundTask = true
+        endedTaskID = identifier
+    }
+}

--- a/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
@@ -5,9 +5,11 @@ class MockBackgroundTaskManager: BackgroundTaskManaging {
     var didBeginBackgroundTask = false
     var didEndBackgroundTask = false
     var lastTaskName: String?
-    var lastTaskID: UIBackgroundTaskIdentifier = .invalid
     var expirationHandler: (@MainActor @Sendable () -> Void)?
     var endedTaskID: UIBackgroundTaskIdentifier?
+    var endedTaskIDs: Set<UIBackgroundTaskIdentifier> = []
+    var begunTaskIDs: Set<UIBackgroundTaskIdentifier> = []
+    var taskIDsToReturn: Set<UIBackgroundTaskIdentifier> = []
     
     func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (@MainActor @Sendable () -> Void)?) -> UIBackgroundTaskIdentifier {
         didBeginBackgroundTask = true
@@ -15,12 +17,14 @@ class MockBackgroundTaskManager: BackgroundTaskManaging {
         
         // Simulate expiration handler call
         self.expirationHandler = handler
-        
-        return lastTaskID
+        let id = taskIDsToReturn.isEmpty ? .invalid : taskIDsToReturn.removeFirst()
+        begunTaskIDs.insert(id)
+        return id
     }
 
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
         didEndBackgroundTask = true
         endedTaskID = identifier
+        endedTaskIDs.insert(identifier)
     }
 }


### PR DESCRIPTION
### Summary of changes
- Refactors background task management for analytics event sending by introducing the `BackgroundTaskManaging` protocol and updating `BTAnalyticsService` to use it. This abstraction allows for easier testing and decouples background task logic from `UIApplication`.

**Key Changes:**
- Added the BackgroundTaskManaging protocol in BackgroundTaskManaging.swift, defining methods for starting and ending background tasks.
- Extended UIApplication to conform to BackgroundTaskManaging, enabling seamless integration with existing app lifecycle.
- Updated BTAnalyticsService to use a BackgroundTaskManaging instance (defaulting to UIApplication.shared) for background task operations, improving testability and flexibility.
- Refactored background task handling in analytics event sending to use the new protocol.

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
