### PR TITLE
Updated demo app with `.userAction`

### DIFF
--- a/Demo/Application/Base/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Base/Settings/Settings.bundle/Root.plist
@@ -93,7 +93,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>New PayPal Checkout Tokenization Key</string>
+				<string>ModXO (New PayPal Checkout) Tokenization Key</string>
 			</array>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsAuthorizationTypeKey</string>
@@ -103,7 +103,7 @@
 			<array>
 				<string>Client Token</string>
 				<string>Tokenization Key</string>
-				<string>New PayPal Checkout Tokenization Key</string>
+				<string>ModXO (New PayPal Checkout) Tokenization Key</string>
 			</array>
 			<key>Values</key>
 			<array>

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -76,7 +76,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     
     let payLaterToggle = Toggle(title: "Offer Pay Later")
     
-    let newPayPalCheckoutToggle = Toggle(title: "New PayPal Checkout Experience")
+    let newPayPalCheckoutToggle = Toggle(title: "ModXO (New PayPal Checkout Experience)")
     
     let rbaDataToggle = Toggle(title: "Recurring Billing (RBA) Data")
     
@@ -196,10 +196,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         var request = BTPayPalVaultRequest()
         request.userAuthenticationEmail = emailTextField.text
-        request.userPhoneNumber = BTPayPalPhoneNumber(
-            countryCode: countryCodeTextField.text ?? "",
-            nationalNumber: nationalNumberTextField.text ?? ""
-        )
+        request.userAction = .setupNow
         
         if rbaDataToggle.isOn {
             let billingPricing = BTPayPalBillingPricing(


### PR DESCRIPTION
Updated demo app with `BTPayPalVaultRequest.userAction = .setupNow`

### Summary of changes

- Passed in `BTPayPalVaultRequest.userAction = .setupNow`. **Must use "ModXO (New PayPal Checkout) Tokenization Key" to see the PayPal button changes**
- Removed `.userPhoneNumber` which was causing 422 error
- Updated new PayPal Checkout toggle and tokenization names for clarification


![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-12 at 16 06 47](https://github.com/user-attachments/assets/8060ee86-8649-4202-b188-c09ee3e6e4c3)

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 
