### PR TITLE
Add GenerateCustomerRecommendations GraphQL Query

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -103,6 +103,9 @@
 		57D94370296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D9436F296CC79B0079EAB1 /* BraintreePayPal_IntegrationTests.swift */; };
 		57D94372296CCA2F0079EAB1 /* String+NonceValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D94371296CCA2F0079EAB1 /* String+NonceValidation.swift */; };
 		620C3C652BA21E5700C40A03 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 620C3C642BA21E5700C40A03 /* PrivacyInfo.xcprivacy */; };
+		621149DA2E01E9A5006D7687 /* BTCustomerRecommendationsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621149D92E01E999006D7687 /* BTCustomerRecommendationsAPI.swift */; };
+		621149DC2E01EC7F006D7687 /* GenerateCustomerRecommendationsGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621149DB2E01EC74006D7687 /* GenerateCustomerRecommendationsGraphQLBody.swift */; };
+		621149DE2E0201C7006D7687 /* Variables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621149DD2E0201C3006D7687 /* Variables.swift */; };
 		62236E1A2B98CFB000CDCC37 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62236E192B98CFB000CDCC37 /* PrivacyInfo.xcprivacy */; };
 		624454DE2DDE399D00A3383B /* CreateCustomerSessionMutationGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624454DD2DDE398200A3383B /* CreateCustomerSessionMutationGraphQLBody.swift */; };
 		624B27F72B6AE0C2000AC08A /* BTShopperInsightsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624B27F62B6AE0C2000AC08A /* BTShopperInsightsError.swift */; };
@@ -868,6 +871,9 @@
 		57D94371296CCA2F0079EAB1 /* String+NonceValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NonceValidation.swift"; sourceTree = "<group>"; };
 		59A4135427B90CD7AE94D5CC /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		620C3C642BA21E5700C40A03 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		621149D92E01E999006D7687 /* BTCustomerRecommendationsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCustomerRecommendationsAPI.swift; sourceTree = "<group>"; };
+		621149DB2E01EC74006D7687 /* GenerateCustomerRecommendationsGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCustomerRecommendationsGraphQLBody.swift; sourceTree = "<group>"; };
+		621149DD2E0201C3006D7687 /* Variables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variables.swift; sourceTree = "<group>"; };
 		62236E192B98CFB000CDCC37 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		624454DD2DDE398200A3383B /* CreateCustomerSessionMutationGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCustomerSessionMutationGraphQLBody.swift; sourceTree = "<group>"; };
 		624B27F62B6AE0C2000AC08A /* BTShopperInsightsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsError.swift; sourceTree = "<group>"; };
@@ -1511,6 +1517,8 @@
 		624454DA2DDE37CA00A3383B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				621149DD2E0201C3006D7687 /* Variables.swift */,
+				621149DB2E01EC74006D7687 /* GenerateCustomerRecommendationsGraphQLBody.swift */,
 				624454DD2DDE398200A3383B /* CreateCustomerSessionMutationGraphQLBody.swift */,
 				455AA27A2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift */,
 			);
@@ -1553,6 +1561,7 @@
 		804698292B27C4D70090878E /* BraintreeShopperInsights */ = {
 			isa = PBXGroup;
 			children = (
+				621149D92E01E999006D7687 /* BTCustomerRecommendationsAPI.swift */,
 				04AA311F2D07990A0043ACAB /* BTButtonOrder.swift */,
 				04AA31172D0797460043ACAB /* BTButtonType.swift */,
 				62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */,
@@ -3457,12 +3466,15 @@
 				624B27F72B6AE0C2000AC08A /* BTShopperInsightsError.swift in Sources */,
 				804698372B27C5390090878E /* BTShopperInsightsClient.swift in Sources */,
 				455AA27B2DEE38ED008D99AB /* BTUpdateCustomerSessionAPI.swift in Sources */,
+				621149DA2E01E9A5006D7687 /* BTCustomerRecommendationsAPI.swift in Sources */,
 				455AA27C2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift in Sources */,
+				621149DC2E01EC7F006D7687 /* GenerateCustomerRecommendationsGraphQLBody.swift in Sources */,
 				456B950E2DB963FA009A374D /* BTShopperInsightsClientV2.swift in Sources */,
 				800ED7832B4F5B66007D8A30 /* BTEligiblePaymentsRequest.swift in Sources */,
 				8037BFB02B2CCC130017072C /* BTShopperInsightsAnalytics.swift in Sources */,
 				04AA311A2D0797570043ACAB /* BTPresentmentDetails.swift in Sources */,
 				04AA31202D07990E0043ACAB /* BTButtonOrder.swift in Sources */,
+				621149DE2E0201C7006D7687 /* Variables.swift in Sources */,
 				62EA90492B63071800DD79BC /* BTEligiblePaymentMethods.swift in Sources */,
 				804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */,
 				624454DE2DDE399D00A3383B /* CreateCustomerSessionMutationGraphQLBody.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -65,7 +65,6 @@
 		455AA2782DEE0681008D99AB /* BTPaymentOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA2772DEE067A008D99AB /* BTPaymentOptions.swift */; };
 		455AA27B2DEE38ED008D99AB /* BTUpdateCustomerSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA2792DEE38ED008D99AB /* BTUpdateCustomerSessionAPI.swift */; };
 		455AA27C2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA27A2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift */; };
-		455AA27F2DEF8E4C008D99AB /* BTPurchaseUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */; };
 		455AA2822DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA2812DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift */; };
 		456B950E2DB963FA009A374D /* BTShopperInsightsClientV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456B950D2DB963F7009A374D /* BTShopperInsightsClientV2.swift */; };
 		456B95102DBAA951009A374D /* BTShopperInsightsClientV2_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456B950F2DBAA936009A374D /* BTShopperInsightsClientV2_Tests.swift */; };
@@ -115,6 +114,7 @@
 		62B811882CC002470024A688 /* BTPayPalPhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */; };
 		62BEEB8A2E0B11EA002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEEB892E0B11DE002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift */; };
 		62BEEB8C2E0B27B6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEEB8B2E0B27A6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift */; };
+		62BEEB902E0B4059002C848D /* BTPurchaseUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEEB8F2E0B4059002C848D /* BTPurchaseUnit.swift */; };
 		62BF860E2DD2BF0300A05064 /* BTCreateCustomerSessionAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BF860D2DD2BEF100A05064 /* BTCreateCustomerSessionAPI_Tests.swift */; };
 		62C458D32DD291AE00B4F9B3 /* BTCreateCustomerSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */; };
 		62C458D52DD292D900B4F9B3 /* BTCustomerSessionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C458D42DD292CF00B4F9B3 /* BTCustomerSessionRequest.swift */; };
@@ -828,7 +828,6 @@
 		455AA2772DEE067A008D99AB /* BTPaymentOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPaymentOptions.swift; sourceTree = "<group>"; };
 		455AA2792DEE38ED008D99AB /* BTUpdateCustomerSessionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUpdateCustomerSessionAPI.swift; sourceTree = "<group>"; };
 		455AA27A2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCustomerSessionMutationGraphQLBody.swift; sourceTree = "<group>"; };
-		455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPurchaseUnit.swift; sourceTree = "<group>"; };
 		455AA2812DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUpdateCustomerSessionAPI_Tests.swift; sourceTree = "<group>"; };
 		456B950D2DB963F7009A374D /* BTShopperInsightsClientV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsClientV2.swift; sourceTree = "<group>"; };
 		456B950F2DBAA936009A374D /* BTShopperInsightsClientV2_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsClientV2_Tests.swift; sourceTree = "<group>"; };
@@ -884,6 +883,7 @@
 		62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalPhoneNumber.swift; sourceTree = "<group>"; };
 		62BEEB892E0B11DE002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGenerateCustomerRecommendationAPI_Tests.swift; sourceTree = "<group>"; };
 		62BEEB8B2E0B27A6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCustomerRecommendationsGraphQLBody_Tests.swift; sourceTree = "<group>"; };
+		62BEEB8F2E0B4059002C848D /* BTPurchaseUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPurchaseUnit.swift; sourceTree = "<group>"; };
 		62BF860D2DD2BEF100A05064 /* BTCreateCustomerSessionAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCreateCustomerSessionAPI_Tests.swift; sourceTree = "<group>"; };
 		62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCreateCustomerSessionAPI.swift; sourceTree = "<group>"; };
 		62C458D42DD292CF00B4F9B3 /* BTCustomerSessionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCustomerSessionRequest.swift; sourceTree = "<group>"; };
@@ -1563,6 +1563,7 @@
 		804698292B27C4D70090878E /* BraintreeShopperInsights */ = {
 			isa = PBXGroup;
 			children = (
+				62BEEB8F2E0B4059002C848D /* BTPurchaseUnit.swift */,
 				621149D92E01E999006D7687 /* BTCustomerRecommendationsAPI.swift */,
 				04AA311F2D07990A0043ACAB /* BTButtonOrder.swift */,
 				04AA31172D0797460043ACAB /* BTButtonType.swift */,
@@ -1575,7 +1576,6 @@
 				04AA311D2D0798F70043ACAB /* BTPageType.swift */,
 				455AA2772DEE067A008D99AB /* BTPaymentOptions.swift */,
 				04AA31192D0797510043ACAB /* BTPresentmentDetails.swift */,
-				455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */,
 				8037BFAF2B2CCC130017072C /* BTShopperInsightsAnalytics.swift */,
 				8064F38E2B1E492F0059C4CB /* BTShopperInsightsClient.swift */,
 				456B950D2DB963F7009A374D /* BTShopperInsightsClientV2.swift */,
@@ -3459,12 +3459,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62BEEB902E0B4059002C848D /* BTPurchaseUnit.swift in Sources */,
 				62C458D32DD291AE00B4F9B3 /* BTCreateCustomerSessionAPI.swift in Sources */,
 				04AA311E2D0798FC0043ACAB /* BTPageType.swift in Sources */,
 				62C458D52DD292D900B4F9B3 /* BTCustomerSessionRequest.swift in Sources */,
 				804698382B27C53B0090878E /* BTShopperInsightsRequest.swift in Sources */,
 				04B001102D0CF46E00C0060D /* BTExperimentType.swift in Sources */,
-				455AA27F2DEF8E4C008D99AB /* BTPurchaseUnit.swift in Sources */,
 				04AA31182D07974D0043ACAB /* BTButtonType.swift in Sources */,
 				455AA2782DEE0681008D99AB /* BTPaymentOptions.swift in Sources */,
 				624B27F72B6AE0C2000AC08A /* BTShopperInsightsError.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		455AA27C2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA27A2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift */; };
 		455AA27F2DEF8E4C008D99AB /* BTPurchaseUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */; };
 		455AA2822DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA2812DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift */; };
-		455AA27F2DEF8E4C008D99AB /* BTPurchaseUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */; };
 		456B950E2DB963FA009A374D /* BTShopperInsightsClientV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456B950D2DB963F7009A374D /* BTShopperInsightsClientV2.swift */; };
 		456B95102DBAA951009A374D /* BTShopperInsightsClientV2_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456B950F2DBAA936009A374D /* BTShopperInsightsClientV2_Tests.swift */; };
 		457D7FC82C29CEC300EF6523 /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */; };
@@ -114,6 +113,8 @@
 		62A659A42B98CB23008DFD67 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */; };
 		62A746412B9255AC003D32FF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62A746402B9255AC003D32FF /* PrivacyInfo.xcprivacy */; };
 		62B811882CC002470024A688 /* BTPayPalPhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */; };
+		62BEEB8A2E0B11EA002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEEB892E0B11DE002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift */; };
+		62BEEB8C2E0B27B6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEEB8B2E0B27A6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift */; };
 		62BF860E2DD2BF0300A05064 /* BTCreateCustomerSessionAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BF860D2DD2BEF100A05064 /* BTCreateCustomerSessionAPI_Tests.swift */; };
 		62C458D32DD291AE00B4F9B3 /* BTCreateCustomerSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */; };
 		62C458D52DD292D900B4F9B3 /* BTCustomerSessionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C458D42DD292CF00B4F9B3 /* BTCustomerSessionRequest.swift */; };
@@ -829,7 +830,6 @@
 		455AA27A2DEE38ED008D99AB /* UpdateCustomerSessionMutationGraphQLBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCustomerSessionMutationGraphQLBody.swift; sourceTree = "<group>"; };
 		455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPurchaseUnit.swift; sourceTree = "<group>"; };
 		455AA2812DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUpdateCustomerSessionAPI_Tests.swift; sourceTree = "<group>"; };
-		455AA27E2DEF8E4C008D99AB /* BTPurchaseUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPurchaseUnit.swift; sourceTree = "<group>"; };
 		456B950D2DB963F7009A374D /* BTShopperInsightsClientV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsClientV2.swift; sourceTree = "<group>"; };
 		456B950F2DBAA936009A374D /* BTShopperInsightsClientV2_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTShopperInsightsClientV2_Tests.swift; sourceTree = "<group>"; };
 		457D7FC72C29CEC300EF6523 /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
@@ -882,6 +882,8 @@
 		62A659A32B98CB23008DFD67 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		62A746402B9255AC003D32FF /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		62B811872CC002470024A688 /* BTPayPalPhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalPhoneNumber.swift; sourceTree = "<group>"; };
+		62BEEB892E0B11DE002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGenerateCustomerRecommendationAPI_Tests.swift; sourceTree = "<group>"; };
+		62BEEB8B2E0B27A6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCustomerRecommendationsGraphQLBody_Tests.swift; sourceTree = "<group>"; };
 		62BF860D2DD2BEF100A05064 /* BTCreateCustomerSessionAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCreateCustomerSessionAPI_Tests.swift; sourceTree = "<group>"; };
 		62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCreateCustomerSessionAPI.swift; sourceTree = "<group>"; };
 		62C458D42DD292CF00B4F9B3 /* BTCustomerSessionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCustomerSessionRequest.swift; sourceTree = "<group>"; };
@@ -1590,6 +1592,8 @@
 		8046982A2B27C4E80090878E /* BraintreeShopperInsightsTests */ = {
 			isa = PBXGroup;
 			children = (
+				62BEEB8B2E0B27A6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift */,
+				62BEEB892E0B11DE002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift */,
 				62BF860D2DD2BEF100A05064 /* BTCreateCustomerSessionAPI_Tests.swift */,
 				62970D0E2B5AE1E400BAB584 /* BTShopperInsightsAnalytics_Tests.swift */,
 				8064F3942B1E4FEB0059C4CB /* BTShopperInsightsClient_Tests.swift */,
@@ -3489,9 +3493,11 @@
 				456B95102DBAA951009A374D /* BTShopperInsightsClientV2_Tests.swift in Sources */,
 				62BF860E2DD2BF0300A05064 /* BTCreateCustomerSessionAPI_Tests.swift in Sources */,
 				45F58CAE2DF22DB7004973F5 /* UpdateCustomerSessionMutationGraphQLBody_Tests.swift in Sources */,
+				62BEEB8C2E0B27B6002C848D /* GenerateCustomerRecommendationsGraphQLBody_Tests.swift in Sources */,
 				80B59A132B27C7FC004C2FA3 /* BTShopperInsightsClient_Tests.swift in Sources */,
 				62970D102B5AF2C000BAB584 /* BTShopperInsightsAnalytics_Tests.swift in Sources */,
 				455AA2822DF0E5DC008D99AB /* BTUpdateCustomerSessionAPI_Tests.swift in Sources */,
+				62BEEB8A2E0B11EA002C848D /* BTGenerateCustomerRecommendationAPI_Tests.swift in Sources */,
 				45F58CB02DF231FA004973F5 /* CreateCustomerSessionMutationGraphQLBody_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -28,7 +28,7 @@ final class BTCustomerRecommendationsAPI {
     func execute(
         _ request: BTCustomerSessionRequest,
         sessionID: String
-    ) async throws -> BTCustomerRecommendationsResult? {
+    ) async throws -> BTCustomerRecommendationsResult {
         do {
             let graphQLParameters = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
             let (body, _) = try await apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI)

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -51,10 +51,6 @@ final class BTCustomerRecommendationsAPI {
                 }
             }
             
-            guard let sessionID = sessionID, let isInPayPalNetwork = isInPayPalNetwork, let paymentOptions = paymentOptions else {
-                throw BTHTTPError.httpResponseInvalid
-            }
-            
             return BTCustomerRecommendationsResult(
                 sessionID: sessionID,
                 isInPayPalNetwork: isInPayPalNetwork,

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -39,17 +39,21 @@ final class BTCustomerRecommendationsAPI {
             
             let sessionID = body["data"]["generateCustomerRecommendations"]["sessionId"].asString()
             let isInPayPalNetwork = body["data"]["generateCustomerRecommendations"]["isInPayPalNetwork"].asBool()
-            var paymentOptions: [BTPaymentOptions] = []
+            var paymentOptions: [BTPaymentOptions]? = []
             if let paymentRecommendations = body["data"]["generateCustomerRecommendations"]["paymentRecommendations"].asArray() {
                 for recommendation in paymentRecommendations {
-                    print("paymentRecommendation: \(recommendation)")
-                    paymentOptions.append(
+                    paymentOptions?.append(
                         BTPaymentOptions(
                             paymentOption: recommendation["paymentOption"].asString() ?? "",
                             recommendedPriority: recommendation["recommendedPriority"].asIntegerOrZero()
                         )
                     )
                 }
+            }
+            
+            guard let sessionID = sessionID, let isInPayPalNetwork = isInPayPalNetwork,
+                  let paymentOptions = paymentOptions else {
+                throw BTHTTPError.httpResponseInvalid
             }
             
             return BTCustomerRecommendationsResult(

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+#if canImport(BraintreeCore)
+import BraintreeCore
+#endif
+
+final class BTCustomerRecommendationsAPI {
+    
+    // MARK: - Properties
+    
+    private let apiClient: BTAPIClient
+    
+    // MARK: - Initializer
+    
+    /// Creates a `BTCustomerRecommendationsAPI`
+    /// - Parameters:
+    ///    - apiClient: A `BTAPIClient` instance
+    init(apiClient: BTAPIClient) {
+        self.apiClient = apiClient
+    }
+    
+    /// This method will call the `GenerateCustomerRecommendations` GQL query, which returns a `BTCustomerRecommendationsResult` if successful.
+    /// - Parameters:
+    ///    - request: A `BTCustomerSessionRequest`
+    ///    - sessionID: The session ID to update.
+    ///    - Returns: A `BTCustomerRecommendationsResult` which determines what payment options to render.
+    ///    - Throws: An error if the request fails or if the response is invalid.
+    func execute(
+        _ request: BTCustomerSessionRequest,
+        sessionID: String
+    ) async throws -> BTCustomerRecommendationsResult? {
+        do {
+            let graphQLParameters = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+            let (body, _) = try await apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI)
+            
+            guard let body else {
+                throw BTShopperInsightsError.emptyBodyReturned
+            }
+            
+            let sessionID = body["data"]["generateCustomerRecommendations"]["sessionId"].asString()
+            let isInPayPalNetwork = body["data"]["generateCustomerRecommendations"]["isInPayPalNetwork"].asBool()
+            var paymentOptions: [BTPaymentOptions] = []
+            if let paymentRecommendations = body["data"]["generateCustomerRecommendations"]["paymentRecommendations"].asArray() {
+                for recommendation in paymentRecommendations {
+                    print("paymentRecommendation: \(recommendation)")
+                    paymentOptions.append(
+                        BTPaymentOptions(
+                            paymentOption: recommendation["paymentOption"].asString() ?? "",
+                            recommendedPriority: recommendation["recommendedPriority"].asIntegerOrZero()
+                        )
+                    )
+                }
+            }
+            
+            return BTCustomerRecommendationsResult(
+                sessionID: sessionID,
+                isInPayPalNetwork: isInPayPalNetwork,
+                paymentRecommendations: paymentOptions
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -51,8 +51,7 @@ final class BTCustomerRecommendationsAPI {
                 }
             }
             
-            guard let sessionID = sessionID, let isInPayPalNetwork = isInPayPalNetwork,
-                  let paymentOptions = paymentOptions else {
+            guard let sessionID = sessionID, let isInPayPalNetwork = isInPayPalNetwork, let paymentOptions = paymentOptions else {
                 throw BTHTTPError.httpResponseInvalid
             }
             

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsResult.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsResult.swift
@@ -11,5 +11,5 @@ public struct BTCustomerRecommendationsResult {
     public let isInPayPalNetwork: Bool?
     
     /// The payment recommendations for the shopper.
-    public let paymentRecommendations: [BTPaymentOptions]
+    public let paymentRecommendations: [BTPaymentOptions]?
 }

--- a/Sources/BraintreeShopperInsights/Models/CreateCustomerSessionMutationGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/CreateCustomerSessionMutationGraphQLBody.swift
@@ -14,6 +14,6 @@ struct CreateCustomerSessionMutationGraphQLBody: Encodable {
                 }
             }
             """
-        variables = Variables(request: request, sessionID: nil)
+        variables = Variables(request: request)
     }
 }

--- a/Sources/BraintreeShopperInsights/Models/CreateCustomerSessionMutationGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/CreateCustomerSessionMutationGraphQLBody.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// swiftlint:disable nesting
 /// The POST body for the GraphQL mutation `CreateCustomerSession`
 struct CreateCustomerSessionMutationGraphQLBody: Encodable {
     
@@ -15,68 +14,6 @@ struct CreateCustomerSessionMutationGraphQLBody: Encodable {
                 }
             }
             """
-        variables = Variables(request: request)
-    }
-    
-    struct Variables: Encodable {
-        
-        let input: InputParameters
-        
-        init(request: BTCustomerSessionRequest) {
-            input = InputParameters(request: request)
-        }
-        
-        struct InputParameters: Encodable {
-            
-            let customer: Customer?
-            let purchaseUnits: [PurchaseUnit]?
-            
-            init(request: BTCustomerSessionRequest) {
-                customer = Customer(request: request)
-                purchaseUnits = request.purchaseUnits?.compactMap {
-                    PurchaseUnit(request: $0)
-                }
-            }
-            
-            struct Customer: Encodable {
-                
-                let hashedEmail: String?
-                let hashedPhoneNumber: String?
-                let payPalAppInstalled: Bool?
-                let venmoAppInstalled: Bool?
-                
-                init(request: BTCustomerSessionRequest) {
-                    hashedEmail = request.hashedEmail
-                    hashedPhoneNumber = request.hashedPhoneNumber
-                    payPalAppInstalled = request.payPalAppInstalled
-                    venmoAppInstalled = request.venmoAppInstalled
-                }
-                
-                enum CodingKeys: String, CodingKey {
-                    case hashedEmail
-                    case hashedPhoneNumber
-                    case payPalAppInstalled = "paypalAppInstalled"
-                    case venmoAppInstalled
-                }
-            }
-            
-            struct PurchaseUnit: Encodable {
-                
-                let amount: Amount?
-                
-                init(request: BTPurchaseUnit) {
-                    amount = Amount(
-                        value: request.amount,
-                        currencyCode: request.currencyCode
-                    )
-                }
-                
-                struct Amount: Encodable {
-                    
-                    let value: String?
-                    let currencyCode: String?
-                }
-            }
-        }
+        variables = Variables(request: request, sessionID: nil)
     }
 }

--- a/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
@@ -8,8 +8,8 @@ struct GenerateCustomerRecommendationsGraphQLBody: Encodable {
     
     init(request: BTCustomerSessionRequest, sessionID: String) {
         query = """
-            mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
-                generateCustomerRecommendations(input: ${'$'}input) {
+            mutation GenerateCustomerRecommendations($input: GenerateCustomerRecommendationsInput!) {
+                generateCustomerRecommendations(input: $input) {
                     sessionId
                     isInPayPalNetwork
                     paymentRecommendations {

--- a/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The POST body for the GraphQL mutation `GenerateCustomerRecommendations`
+struct GenerateCustomerRecommendationsGraphQLBody: Encodable {
+    
+    let query: String
+    let variables: Variables
+    
+    init(request: BTCustomerSessionRequest, sessionID: String) {
+        query = """
+            mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                generateCustomerRecommendations(input: ${'$'}input) {
+                    sessionId
+                    isInPayPalNetwork
+                    paymentRecommendations {
+                        paymentOption
+                        recommendedPriority
+                    }
+                }
+            }
+            """
+        variables = Variables(request: request, sessionID: sessionID)
+    }
+}

--- a/Sources/BraintreeShopperInsights/Models/UpdateCustomerSessionMutationGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/UpdateCustomerSessionMutationGraphQLBody.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// swiftlint:disable nesting
 /// The POST body for the GraphQL mutation `UpdateCustomerSession`
 struct UpdateCustomerSessionMutationGraphQLBody: Encodable {
     
@@ -16,75 +15,5 @@ struct UpdateCustomerSessionMutationGraphQLBody: Encodable {
             }
             """
         variables = Variables(request: request, sessionID: sessionID)
-    }
-    
-    struct Variables: Encodable {
-        
-        let input: InputParameters
-        
-        init(request: BTCustomerSessionRequest, sessionID: String) {
-            input = InputParameters(request: request, sessionID: sessionID)
-        }
-        
-        struct InputParameters: Encodable {
-            
-            let sessionID: String
-            let customer: Customer?
-            let purchaseUnits: [PurchaseUnit]?
-            
-            init(request: BTCustomerSessionRequest, sessionID: String) {
-                self.sessionID = sessionID
-                customer = Customer(request: request)
-                purchaseUnits = request.purchaseUnits?.compactMap {
-                    PurchaseUnit(purchaseUnit: $0)
-                }
-            }
-            
-            enum CodingKeys: String, CodingKey {
-                case sessionID = "sessionId"
-                case customer
-                case purchaseUnits
-            }
-            
-            struct Customer: Encodable {
-                
-                let hashedEmail: String?
-                let hashedPhoneNumber: String?
-                let payPalAppInstalled: Bool?
-                let venmoAppInstalled: Bool?
-                
-                init(request: BTCustomerSessionRequest) {
-                    hashedEmail = request.hashedEmail
-                    hashedPhoneNumber = request.hashedPhoneNumber
-                    payPalAppInstalled = request.payPalAppInstalled
-                    venmoAppInstalled = request.venmoAppInstalled
-                }
-                
-                enum CodingKeys: String, CodingKey {
-                    case hashedEmail
-                    case hashedPhoneNumber
-                    case payPalAppInstalled = "paypalAppInstalled"
-                    case venmoAppInstalled
-                }
-            }
-            
-            struct PurchaseUnit: Encodable {
-                
-                let amount: Amount?
-                
-                init(purchaseUnit: BTPurchaseUnit) {
-                    amount = Amount(
-                        value: purchaseUnit.amount,
-                        currencyCode: purchaseUnit.currencyCode
-                    )
-                }
-                
-                struct Amount: Encodable {
-                    
-                    let value: String?
-                    let currencyCode: String?
-                }
-            }
-        }
     }
 }

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+// swiftlint:disable nesting
+struct Variables: Encodable {
+    
+    let input: InputParameters
+    
+    init(request: BTCustomerSessionRequest, sessionID: String?) {
+        input = InputParameters(request: request, sessionID: sessionID)
+    }
+    
+    struct InputParameters: Encodable {
+        
+        let sessionID: String?
+        let customer: Customer?
+        let purchaseUnits: [PurchaseUnit]?
+        
+        init(request: BTCustomerSessionRequest, sessionID: String?) {
+            self.sessionID = sessionID
+            customer = Customer(request: request)
+            purchaseUnits = request.purchaseUnits?.compactMap {
+                PurchaseUnit(purchaseUnit: $0)
+            }
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "sessionId"
+            case customer
+            case purchaseUnits
+        }
+        
+        struct Customer: Encodable {
+            
+            let hashedEmail: String?
+            let hashedPhoneNumber: String?
+            let payPalAppInstalled: Bool?
+            let venmoAppInstalled: Bool?
+            
+            init(request: BTCustomerSessionRequest) {
+                hashedEmail = request.hashedEmail
+                hashedPhoneNumber = request.hashedPhoneNumber
+                payPalAppInstalled = request.payPalAppInstalled
+                venmoAppInstalled = request.venmoAppInstalled
+            }
+            
+            enum CodingKeys: String, CodingKey {
+                case hashedEmail
+                case hashedPhoneNumber
+                case payPalAppInstalled = "paypalAppInstalled"
+                case venmoAppInstalled
+            }
+        }
+        
+        struct PurchaseUnit: Encodable {
+            
+            let amount: Amount?
+            
+            init(purchaseUnit: BTPurchaseUnit) {
+                amount = Amount(
+                    value: purchaseUnit.amount,
+                    currencyCode: purchaseUnit.currencyCode
+                )
+            }
+            
+            struct Amount: Encodable {
+                
+                let value: String?
+                let currencyCode: String?
+            }
+        }
+    }
+}

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -5,7 +5,7 @@ struct Variables: Encodable {
     
     let input: InputParameters
     
-    init(request: BTCustomerSessionRequest, sessionID: String?) {
+    init(request: BTCustomerSessionRequest, sessionID: String? = nil) {
         input = InputParameters(request: request, sessionID: sessionID)
     }
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import BraintreeCore
 @testable import BraintreeShopperInsights
 
-class BTGenerateCustomerRecommendationApi_Tests: XCTestCase {
+class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
     
     var mockAPIClient: MockAPIClient!
     var sut: BTCustomerRecommendationsAPI!
@@ -64,33 +64,8 @@ class BTGenerateCustomerRecommendationApi_Tests: XCTestCase {
         
         XCTAssertEqual(expectedResult?.sessionID, expectedSessionID)
         XCTAssertEqual(expectedResult?.isInPayPalNetwork, true)
-        XCTAssertEqual(expectedResult?.paymentRecommendations.first?.paymentOption, "PAYPAL")
-        XCTAssertEqual(expectedResult?.paymentRecommendations.first?.recommendedPriority, 1)
-    }
-    
-    func testExecute_whenGenerateCustomerRecommendationsRequestIsInvalid_throwsBTHTTPError() async {
-        let mockGenerateCustomerRecommendationsResponse = BTJSON(
-            value: [
-                "data": [
-                    "generateCustomerRecommendations": [
-                        "random-session-id": "invalid-session-id",
-                        "isInPayPalNetwork": nil,
-                        "paymentRecommendations": nil
-                    ]
-                ]
-            ]
-        )
-        mockAPIClient.cannedResponseBody = mockGenerateCustomerRecommendationsResponse
-        
-        do {
-            let _ = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
-            XCTFail("Expected BTHTTPError to be thrown")
-        } catch let error as BTHTTPError {
-            XCTAssertEqual(error.errorCode, BTHTTPError.httpResponseInvalid.errorCode)
-            XCTAssertEqual(error.localizedDescription, "Unable to create HTTPURLResponse from response data.")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+        XCTAssertEqual(expectedResult?.paymentRecommendations?.first?.paymentOption, "PAYPAL")
+        XCTAssertEqual(expectedResult?.paymentRecommendations?.first?.recommendedPriority, 1)
     }
     
     func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -62,10 +62,10 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         
         let expectedResult = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
         
-        XCTAssertEqual(expectedResult?.sessionID, expectedSessionID)
-        XCTAssertEqual(expectedResult?.isInPayPalNetwork, true)
-        XCTAssertEqual(expectedResult?.paymentRecommendations?.first?.paymentOption, "PAYPAL")
-        XCTAssertEqual(expectedResult?.paymentRecommendations?.first?.recommendedPriority, 1)
+        XCTAssertEqual(expectedResult.sessionID, expectedSessionID)
+        XCTAssertEqual(expectedResult.isInPayPalNetwork, true)
+        XCTAssertEqual(expectedResult.paymentRecommendations?.first?.paymentOption, "PAYPAL")
+        XCTAssertEqual(expectedResult.paymentRecommendations?.first?.recommendedPriority, 1)
     }
     
     func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import BraintreeTestShared
+@testable import BraintreeCore
+@testable import BraintreeShopperInsights
+
+class BTGenerateCustomerRecommendationApi_Tests: XCTestCase {
+    
+    var mockAPIClient: MockAPIClient!
+    var sut: BTCustomerRecommendationsAPI!
+    
+    let clientToken = TestClientTokenFactory.token(withVersion: 2)
+    let sessionID = "shopper-session-id"
+    
+    let generateCustomerRecommendationsRequest = BTCustomerSessionRequest(
+        hashedEmail: "test-hashed-email.com",
+        hashedPhoneNumber: "test-hashed-phone-number",
+        payPalAppInstalled: true,
+        venmoAppInstalled: false,
+        purchaseUnits: [
+            BTPurchaseUnit(
+                amount: "4.50",
+                currencyCode: "USD"
+            ),
+            BTPurchaseUnit(
+                amount: "12.00",
+                currencyCode: "USD"
+            )
+        ]
+    )
+    
+    override func setUp() {
+        super.setUp()
+        mockAPIClient = MockAPIClient(authorization: clientToken)
+        sut = BTCustomerRecommendationsAPI(apiClient: mockAPIClient)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+        mockAPIClient = nil
+    }
+    
+    func testExecute_whenGenerateCustomerRecommendationsRequestIsValid_returnsSuccessfulBTCustomerRecommendationsResult() async throws {
+        let expectedSessionID = "session-id"
+        let mockGenerateCustomerRecommendationsResponse = BTJSON(
+            value: [
+                "data": [
+                    "generateCustomerRecommendations": [
+                        "sessionId": expectedSessionID,
+                        "isInPayPalNetwork": true,
+                        "paymentRecommendations": [
+                            [
+                                "paymentOption": "PAYPAL",
+                                "recommendedPriority": 1
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        )
+        mockAPIClient.cannedResponseBody = mockGenerateCustomerRecommendationsResponse
+        
+        let expectedResult = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+        
+        XCTAssertEqual(expectedResult?.sessionID, expectedSessionID)
+        XCTAssertEqual(expectedResult?.isInPayPalNetwork, true)
+        XCTAssertEqual(expectedResult?.paymentRecommendations.first?.paymentOption, "PAYPAL")
+        XCTAssertEqual(expectedResult?.paymentRecommendations.first?.recommendedPriority, 1)
+    }
+    
+    func testExecute_whenGenerateCustomerRecommendationsRequestIsInvalid_throwsBTHTTPError() async {
+        let mockGenerateCustomerRecommendationsResponse = BTJSON(
+            value: [
+                "data": [
+                    "generateCustomerRecommendations": [
+                        "random-session-id": "invalid-session-id",
+                        "isInPayPalNetwork": nil,
+                        "paymentRecommendations": nil
+                    ]
+                ]
+            ]
+        )
+        mockAPIClient.cannedResponseBody = mockGenerateCustomerRecommendationsResponse
+        
+        do {
+            let _ = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+            XCTFail("Expected BTHTTPError to be thrown")
+        } catch let error as BTHTTPError {
+            XCTAssertEqual(error.errorCode, BTHTTPError.httpResponseInvalid.errorCode)
+            XCTAssertEqual(error.localizedDescription, "Unable to create HTTPURLResponse from response data.")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {
+        mockAPIClient.cannedResponseBody = nil
+        
+        do {
+            _ = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+            XCTFail("Expected an error")
+        } catch let error as BTShopperInsightsError {
+            XCTAssertEqual((error as NSError).domain, BTShopperInsightsError.errorDomain)
+            XCTAssertEqual(error.errorCode, BTShopperInsightsError.emptyBodyReturned.errorCode)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testExceute_whenGenerateCustomerRecommendationsAPIFails_throwsNSError() async {
+        let mockError = NSError(domain: "generate-customer-recommendations-error", code: 1, userInfo: nil)
+        mockAPIClient.cannedResponseError = mockError
+        
+        do {
+            _ = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+            XCTFail("Expected an error")
+        } catch let error as NSError {
+            XCTAssertEqual(error, mockError)
+        }
+    }
+}
+

--- a/UnitTests/BraintreeShopperInsightsTests/BTUpdateCustomerSessionAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTUpdateCustomerSessionAPI_Tests.swift
@@ -95,7 +95,7 @@ class BTUpdateCustomerSessionApi_Test: XCTestCase {
     }
     
     func testExceute_whenCreateCustomerSessionAPIFails_throwsNSError() async {
-        let mockError = NSError(domain: "create-customer-sessionerror", code: 1, userInfo: nil)
+        let mockError = NSError(domain: "update-customer-session-error", code: 1, userInfo: nil)
         mockAPIClient.cannedResponseError = mockError
         
         do {

--- a/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import BraintreeTestShared
+@testable import BraintreeShopperInsights
+
+class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
+    
+    let sessionID = "shopper-session-id"
+    let request = BTCustomerSessionRequest(
+        hashedEmail: "test-hashed-email.com",
+        hashedPhoneNumber: "test-hashed-phone-number",
+        payPalAppInstalled: true,
+        venmoAppInstalled: false,
+        purchaseUnits: [
+            BTPurchaseUnit(
+                amount: "5.00",
+                currencyCode: "USD"
+            ),
+            BTPurchaseUnit(
+                amount: "12.00",
+                currencyCode: "USD"
+            )
+        ]
+    )
+    let expectedQuery = """
+            mutation GenerateCustomerRecommendations($input: GenerateCustomerRecommendationsInput!) {
+                generateCustomerRecommendations(input: $input) {
+                    sessionId
+                    isInPayPalNetwork
+                    paymentRecommendations {
+                        paymentOption
+                        recommendedPriority
+                    }
+                }
+            }
+            """
+    
+    func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithFullData() {
+        let body =  GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+        
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let customer = input?["customer"] as? [String: Any]
+        let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
+        XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
+        XCTAssertEqual(amount?["value"] as? String, "5.00")
+    }
+    
+    func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithNilData() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: nil,
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: nil,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil
+        )
+        
+        let body = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let customer = input?["customer"] as? [String: Any]
+        let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        
+        XCTAssertNotNil(customer)
+        XCTAssertNil(purchaseUnits)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
+    
+    func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithEmptyData() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: nil,
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: nil,
+            venmoAppInstalled: nil,
+            purchaseUnits: []
+        )
+        
+        let body = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let customer = input?["customer"] as? [String: Any]
+        let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        
+        XCTAssertNotNil(customer)
+        XCTAssertEqual(purchaseUnits?.count, 0)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Add a new feature to generate customer recommendations using the `GenerateCustomerRecommendations` GraphQL mutation.
- Implement the `BTCustomerRecommendationsApi` class, its corresponding GraphQL POST body, and unit tests for both the class and model

### Checklist

- [ ]~Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
