### PR TITLE
Add `updateCustomerSession` to the `ShopperInsightsClientV2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreeShopperInsights (BETA)
   * Add `createCustomerSession(request:)` to `BTShopperInsightsClientV2`
+  * Add `updateCustomerSession(request:sessionID:)` to `BTShopperInsightsClientV2`
 
 ## 6.33.0 (2025-05-22)
 * BraintreeCore

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClientV2.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClientV2.swift
@@ -38,6 +38,7 @@ public class BTShopperInsightsClientV2 {
     ///    - request: A `BTCustomerSessionRequest`
     /// - Returns: A `String` representing a session ID if successful
     /// - Throws: An error if the request fails for some reason or if the response is invalid.
+    /// - Warning: This method is currently in beta and may change or be removed in future releases.
     public func createCustomerSession(request: BTCustomerSessionRequest) async throws -> String {
         let createCustomerSessionAPI = BTCreateCustomerSessionAPI(apiClient: apiClient)
         return try await createCustomerSessionAPI.execute(request)
@@ -49,6 +50,7 @@ public class BTShopperInsightsClientV2 {
     ///    - sessionID: the ID of the session to update
     /// - Returns: A `String` representing a session ID if successful
     /// - Throws: An error if the request fails for some reason or if the response is invalid.
+    /// - Warning: This method is currently in beta and may change or be removed in future releases.
     public func updateCustomerSession(request: BTCustomerSessionRequest, sessionID: String) async throws -> String {
         let updateCustomerSessionAPI = BTUpdateCustomerSessionAPI(apiClient: apiClient)
         return try await updateCustomerSessionAPI.execute(request, sessionID: sessionID)

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsClientV2.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsClientV2.swift
@@ -43,6 +43,17 @@ public class BTShopperInsightsClientV2 {
         return try await createCustomerSessionAPI.execute(request)
     }
     
+    /// This method updates an existing customer session.
+    /// - Parameters:
+    ///    - request: A `BTCustomerSessionRequest`
+    ///    - sessionID: the ID of the session to update
+    /// - Returns: A `String` representing a session ID if successful
+    /// - Throws: An error if the request fails for some reason or if the response is invalid.
+    public func updateCustomerSession(request: BTCustomerSessionRequest, sessionID: String) async throws -> String {
+        let updateCustomerSessionAPI = BTUpdateCustomerSessionAPI(apiClient: apiClient)
+        return try await updateCustomerSessionAPI.execute(request, sessionID: sessionID)
+    }
+    
     /// Call this method when the PayPal or Venmo button has been successfully displayed to the buyer.
     /// This method sends analytics to help improve the Shopper Insights feature experience.
     /// - Parameters:

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -200,4 +200,33 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTAssertEqual(error, mockError)
         }
     }
+    
+    func testUpdateCustomerSession_whenSuccessful_returnsSessionID() async throws {
+        let expectedSessionID = "expected-session-id"
+        let mockUpdateCustomerSessionResponse = BTJSON(
+            value: [
+                "data": [
+                    "updateCustomerSession": [
+                        "sessionId": "expected-session-id"
+                    ]
+                ]
+            ]
+        )
+        mockAPIClient.cannedResponseBody = mockUpdateCustomerSessionResponse
+        
+        let sessionID = try await sut.updateCustomerSession(request: customerSessionRequest, sessionID: sessionID)
+        XCTAssertEqual(expectedSessionID, sessionID)
+    }
+    
+    func testUpdateCustomerSession_whenFails_throwsAnError() async throws {
+        let mockError = NSError(domain: "update-customer-session-test-error", code: 2, userInfo: nil)
+        mockAPIClient.cannedResponseError = mockError
+        
+        do {
+            _ = try await sut.updateCustomerSession(request: customerSessionRequest, sessionID: sessionID)
+            XCTFail("Expected error to be thrown.")
+        } catch let error as NSError {
+            XCTAssertEqual(error, mockError)
+        }
+    }
 }


### PR DESCRIPTION
### Summary of changes

- Add the `updateCustomerSession` func to the `BTShopperInsightsClientV2` class

### Checklist

- [x] Added a changelog entry
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
