### PR TITLE
Fix Multiple ASWeb Sessions

### DIFF
--- a/Sources/BraintreeCore/BTWebAuthenticationSession.swift
+++ b/Sources/BraintreeCore/BTWebAuthenticationSession.swift
@@ -9,18 +9,22 @@ public class BTWebAuthenticationSession: NSObject {
     public var prefersEphemeralWebBrowserSession: Bool?
 
     private var currentSession: ASWebAuthenticationSession?
+    
+    public typealias BAToken = String
 
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
-        sessionDidComplete: @escaping (URL?, Error?) -> Void,
+        sessionDidComplete: @escaping (URL?, Error?, BAToken?) -> Void,
         sessionDidAppear: @escaping (Bool) -> Void,
         sessionDidCancel: @escaping () -> Void,
-        sessionDidDuplicate: @escaping () -> Void = { }
+        sessionDidDuplicate: @escaping (BAToken?) -> Void = { _ in }
     ) {
+        let baToken = getBAToken(from: url)
+        
         guard currentSession == nil else {
-            sessionDidDuplicate()
+            sessionDidDuplicate(baToken)
             return
         }
         
@@ -32,7 +36,7 @@ public class BTWebAuthenticationSession: NSObject {
             if let error = error as? NSError, error.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
                 sessionDidCancel()
             } else {
-                sessionDidComplete(url, error)
+                sessionDidComplete(url, error, baToken)
             }
         }
 
@@ -42,5 +46,17 @@ public class BTWebAuthenticationSession: NSObject {
         DispatchQueue.main.async {
             sessionDidAppear(self.currentSession?.start() ?? false)
         }
+    }
+    
+    private func getBAToken(from url: URL) -> String? {
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?
+            .compactMap { $0 }
+        
+        guard let baToken = queryItems?.first(where: { $0.name == "ba_token" })?.value, !baToken.isEmpty else {
+            return nil
+        }
+        
+        return baToken
     }
 }

--- a/Sources/BraintreeCore/BTWebAuthenticationSession.swift
+++ b/Sources/BraintreeCore/BTWebAuthenticationSession.swift
@@ -16,10 +16,15 @@ public class BTWebAuthenticationSession: NSObject {
         context: ASWebAuthenticationPresentationContextProviding,
         sessionDidComplete: @escaping (URL?, Error?) -> Void,
         sessionDidAppear: @escaping (Bool) -> Void,
-        sessionDidCancel: @escaping () -> Void
+        sessionDidCancel: @escaping () -> Void,
+        sessionDidDuplicate: @escaping () -> Void = { }
     ) {
-        guard currentSession == nil else { return }
-        let authenticationSession = ASWebAuthenticationSession(
+        guard currentSession == nil else {
+            sessionDidDuplicate()
+            return
+        }
+        
+        currentSession = ASWebAuthenticationSession(
             url: url,
             callbackURLScheme: BTCoreConstants.callbackURLScheme
         ) { url, error in
@@ -33,9 +38,9 @@ public class BTWebAuthenticationSession: NSObject {
 
         currentSession?.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession ?? false
         currentSession?.presentationContextProvider = context
-        currentSession = authenticationSession
+        
         DispatchQueue.main.async {
-            sessionDidAppear(authenticationSession.start())
+            sessionDidAppear(self.currentSession?.start() ?? false)
         }
     }
 }

--- a/Sources/BraintreeCore/BTWebAuthenticationSession.swift
+++ b/Sources/BraintreeCore/BTWebAuthenticationSession.swift
@@ -16,7 +16,7 @@ public class BTWebAuthenticationSession: NSObject {
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
-        sessionDidComplete: @escaping (URL?, Error?, BAToken?) -> Void,
+        sessionDidComplete: @escaping (URL?, Error?) -> Void,
         sessionDidAppear: @escaping (Bool) -> Void,
         sessionDidCancel: @escaping () -> Void,
         sessionDidDuplicate: @escaping (BAToken?) -> Void = { _ in }
@@ -36,7 +36,7 @@ public class BTWebAuthenticationSession: NSObject {
             if let error = error as? NSError, error.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
                 sessionDidCancel()
             } else {
-                sessionDidComplete(url, error, baToken)
+                sessionDidComplete(url, error)
             }
         }
 

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -285,7 +285,7 @@ import BraintreeDataCollector
         }
 
         webSessionReturned = false
-        webAuthenticationSession.start(url: url, context: self) { [weak self] url, error, _ in
+        webAuthenticationSession.start(url: url, context: self) { [weak self] url, error in
             guard let self else {
                 NSLog("%@ BTLocalPaymentClient has been deallocated.", BTLogLevelDescription.string(for: .critical))
                 return

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -304,13 +304,13 @@ import BraintreeDataCollector
                 apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.paymentFailed)
                 onPayment(with: nil, error: BTLocalPaymentError.missingReturnURL)
             }
-        } sessionDidAppear: { [self] didAppear in
+        } sessionDidAppear: { [self] didAppear, _  in
             if didAppear {
                 apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.browserPresentationSucceeded)
             } else {
                 apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.browserPresentationFailed)
             }
-        } sessionDidCancel: { [self] in
+        } sessionDidCancel: { [self] _ in
             if !webSessionReturned {
                 // User tapped system cancel button on permission alert
                 apiClient.sendAnalyticsEvent(BTLocalPaymentAnalytics.browserLoginAlertCanceled)

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -285,7 +285,7 @@ import BraintreeDataCollector
         }
 
         webSessionReturned = false
-        webAuthenticationSession.start(url: url, context: self) { [weak self] url, error in
+        webAuthenticationSession.start(url: url, context: self) { [weak self] url, error, _ in
             guard let self else {
                 NSLog("%@ BTLocalPaymentClient has been deallocated.", BTLogLevelDescription.string(for: .critical))
                 return

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -9,6 +9,7 @@ enum BTPayPalAnalytics {
     static let tokenizeStarted = "paypal:tokenize:started"
     static let tokenizeFailed = "paypal:tokenize:failed"
     static let tokenizeSucceeded = "paypal:tokenize:succeeded"
+    static let tokenizeDuplicateRequest = "paypal:tokenize:duplicate-request"
    
     // MARK: - Browser Presentation Events
   

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -502,7 +502,9 @@ import BraintreeDataCollector
             case .unknownPath:
                 notifyFailure(with: BTPayPalError.asWebAuthenticationSessionURLInvalid(url.absoluteString), completion: completion)
             }
-        } sessionDidAppear: { [self] didAppear in
+        } sessionDidAppear: { [self] didAppear, baToken in
+            payPalContextID = baToken
+            
             if didAppear {
                 apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationSucceeded,
@@ -523,7 +525,8 @@ import BraintreeDataCollector
                     shopperSessionID: payPalRequest?.shopperSessionID
                 )
             }
-        } sessionDidCancel: { [self] in
+        } sessionDidCancel: { [self] baToken in
+            payPalContextID = baToken
             if !webSessionReturned {
                 // User tapped system cancel button on permission alert
                 apiClient.sendAnalyticsEvent(
@@ -540,6 +543,7 @@ import BraintreeDataCollector
             notifyCancel(completion: completion)
             return
         } sessionDidDuplicate: { [self] baToken in
+            payPalContextID = baToken
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.tokenizeDuplicateRequest,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -535,6 +535,15 @@ import BraintreeDataCollector
             // (e.g. System "Cancel" button on permission alert or browser during ASWebAuthenticationSession)
             notifyCancel(completion: completion)
             return
+        } sessionDidDuplicate: { [self] in
+            apiClient.sendAnalyticsEvent(
+                BTPayPalAnalytics.tokenizeDuplicateRequest,
+                didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
+                didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                isVaultRequest: isVaultRequest,
+                payPalContextID: payPalContextID,
+                shopperSessionID: payPalRequest?.shopperSessionID
+            )
         }
     }
 

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -549,7 +549,7 @@ import BraintreeDataCollector
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                 isVaultRequest: isVaultRequest,
-                payPalContextID: baToken,
+                payPalContextID: payPalContextID,
                 shopperSessionID: payPalRequest?.shopperSessionID
             )
         }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -471,8 +471,10 @@ import BraintreeDataCollector
         
         webAuthenticationSession.prefersEphemeralWebBrowserSession = experiment == "InAppBrowserNoPopup"
 
-        webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error, baToken in
-            self?.payPalContextID = baToken
+        webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error in
+            if let url {
+                self?.payPalContextID = BTURLUtils.queryParameters(for: url)["ba_token"]
+            }
             
             guard let self else {
                 completion(nil, BTPayPalError.deallocated)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -471,7 +471,9 @@ import BraintreeDataCollector
         
         webAuthenticationSession.prefersEphemeralWebBrowserSession = experiment == "InAppBrowserNoPopup"
 
-        webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error in
+        webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error, baToken in
+            self?.payPalContextID = baToken
+            
             guard let self else {
                 completion(nil, BTPayPalError.deallocated)
                 return
@@ -535,13 +537,13 @@ import BraintreeDataCollector
             // (e.g. System "Cancel" button on permission alert or browser during ASWebAuthenticationSession)
             notifyCancel(completion: completion)
             return
-        } sessionDidDuplicate: { [self] in
+        } sessionDidDuplicate: { [self] baToken in
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.tokenizeDuplicateRequest,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                 isVaultRequest: isVaultRequest,
-                payPalContextID: payPalContextID,
+                payPalContextID: baToken,
                 shopperSessionID: payPalRequest?.shopperSessionID
             )
         }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -26,7 +26,7 @@ import BraintreeDataCollector
 
     /// Exposed for testing the clientMetadataID associated with this request.
     /// Used in POST body for FPTI analytics & `/paypal_account` fetch.
-    var clientMetadataID: String?
+    var clientMetadataIDs: [String: String] = [:]
     
     /// Exposed for testing the intent associated with this request
     var payPalRequest: BTPayPalRequest?
@@ -202,7 +202,7 @@ import BraintreeDataCollector
     ) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.handleReturnStarted,
-            correlationID: clientMetadataID,
+            correlationID: payPalContextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             isVaultRequest: isVaultRequest,
@@ -246,7 +246,7 @@ import BraintreeDataCollector
             }
         }
         
-        if let clientMetadataID {
+        if let clientMetadataID = payPalContextID.flatMap({ clientMetadataIDs[$0] }) {
             account["correlation_id"] = clientMetadataID
         }
 
@@ -409,8 +409,12 @@ import BraintreeDataCollector
                 self.experiment = approvalURL.experiment
 
                 let dataCollector = BTDataCollector(apiClient: self.apiClient)
-                self.clientMetadataID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.payPalContextID)
-
+                let correlationID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.payPalContextID)
+                
+                if let contextID = self.payPalContextID {
+                    self.clientMetadataIDs[contextID] = correlationID
+                }
+                
                 switch approvalURL.redirectType {
                 case .payPalApp(let url):
                     self.didPayPalServerAttemptAppSwitch = true
@@ -473,7 +477,7 @@ import BraintreeDataCollector
 
         webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error in
             if let url {
-                self?.payPalContextID = BTURLUtils.queryParameters(for: url)["ba_token"]
+                self?.payPalContextID = self?.extractToken(from: url)
             }
             
             guard let self else {
@@ -554,6 +558,13 @@ import BraintreeDataCollector
             )
         }
     }
+    
+    /// extract BA or EC token from the URL to set `payPalContextID` correctly
+    private func extractToken(from url: URL) -> String? {
+        let baToken = BTURLUtils.queryParameters(for: url)["ba_token"]
+        let ecToken = BTURLUtils.queryParameters(for: url)["token"]
+        return baToken ?? ecToken
+    }
 
     // MARK: - Analytics Helper Methods
 
@@ -563,7 +574,7 @@ import BraintreeDataCollector
     ) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.tokenizeSucceeded,
-            correlationID: clientMetadataID,
+            correlationID: payPalContextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             isVaultRequest: isVaultRequest,
@@ -576,7 +587,7 @@ import BraintreeDataCollector
     private func notifyFailure(with error: Error, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.tokenizeFailed,
-            correlationID: clientMetadataID,
+            correlationID: payPalContextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             errorDescription: error.localizedDescription,
@@ -590,7 +601,7 @@ import BraintreeDataCollector
     private func notifyCancel(completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
         self.apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.browserLoginCanceled,
-            correlationID: clientMetadataID,
+            correlationID: payPalContextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             isVaultRequest: isVaultRequest,

--- a/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
+++ b/Sources/BraintreeSEPADirectDebit/BTSEPADirectDebitClient.swift
@@ -149,13 +149,13 @@ import BraintreeCore
             }
 
             self.handleWebAuthenticationSessionResult(url: url, error: error, completion: completion)
-        } sessionDidAppear: { [self] didAppear in
+        } sessionDidAppear: { [self] didAppear, _ in
             if didAppear {
                 apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengePresentationSucceeded)
             } else {
                 apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengePresentationFailed)
             }
-        } sessionDidCancel: { [self] in
+        } sessionDidCancel: { [self] _ in
             // User canceled by breaking out of the PayPal browser switch flow
             // (e.g. Cancel button on the WebAuthenticationSession)
             apiClient.sendAnalyticsEvent(BTSEPADirectAnalytics.challengeCanceled)

--- a/UnitTests/BraintreeTestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/BraintreeTestShared/MockWebAuthenticationSession.swift
@@ -6,18 +6,26 @@ class MockWebAuthenticationSession: BTWebAuthenticationSession {
     var cannedResponseURL: URL?
     var cannedErrorResponse: Error?
     var cannedSessionDidDisplay: Bool = true
+    var cannedSessionDidDuplicate: Bool = false
+    var cannedBAToken: BAToken? = nil
 
     override func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
         sessionDidComplete: @escaping (URL?, Error?) -> Void,
-        sessionDidAppear: @escaping (Bool) -> Void,
-        sessionDidCancel: @escaping () -> Void
+        sessionDidAppear: @escaping (Bool, BAToken?) -> Void,
+        sessionDidCancel: @escaping (BAToken?) -> Void,
+        sessionDidDuplicate: @escaping (BAToken?) -> Void = { _ in }
     ) {
-        sessionDidAppear(cannedSessionDidDisplay)
+        guard !cannedSessionDidDuplicate else {
+            sessionDidDuplicate(cannedBAToken)
+            return
+        }
+        
+        sessionDidAppear(cannedSessionDidDisplay, cannedBAToken)
 
         if let error = cannedErrorResponse as? NSError, error.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
-            sessionDidCancel()
+            sessionDidCancel(cannedBAToken)
         } else {
             sessionDidComplete(cannedResponseURL, cannedErrorResponse)
         }


### PR DESCRIPTION
### Summary of changes

Prevents duplicate session starts, and refining analytics reporting. Additionally, test cases have been updated to reflect these changes.

### Enhancements to Token Handling and Session Management:

* `BTWebAuthenticationSession.swift`:
  - Introduced a `BAToken` type alias and a `currentSession` property to manage active sessions.
  - Added logic to extract `ba_token` from URLs using a helper method `getBAToken(from:)`.
  - Updated the `start` method to prevent duplicate sessions via a new `sessionDidDuplicate` callback and reset the session upon completion.

* `BTPayPalClient.swift`:
  - Replaced `clientMetadataID` with `clientMetadataIDs` to manage multiple correlation IDs tied to tokens.
  - Added a method `extractToken(from:)` to extract `ba_token` or `ec_token` from URLs.
  - Updated session callbacks (`sessionDidAppear`, `sessionDidCancel`, `sessionDidDuplicate`) to handle tokens and send appropriate analytics events, including a new event for duplicate requests. [[1]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R203-R207) [[2]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360L501-R511) [[3]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R549-R567)

### Updates to Analytics Tracking:

* `BTPayPalAnalytics.swift`:
  - Added a new analytics event `tokenizeDuplicateRequest` to track duplicate PayPal tokenization attempts.

* `BTPayPalClient.swift`:
  - Updated analytics calls to use `payPalContextID` and its associated correlation ID for more accurate tracking. [[1]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360L412-R418) [[2]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360L549-R578)

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

-  @richherrera 
