### PR TITLE
[v7] Revert Open Override

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulato'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-15-xlarge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 15,OS=17.5,platform=iOS Simulator'  test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'Braintree.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,OS=18.2,platform=iOS Simulato'  test | ./Pods/xcbeautify/xcbeautify
   integration_test_job:
     name: Integration
     runs-on: macOS-15-xlarge

--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -7,9 +7,14 @@ import UIKit
 public protocol URLOpener {
 
     func canOpenURL(_ url: URL) -> Bool
-    func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?)
     func isPayPalAppInstalled() -> Bool
     func isVenmoAppInstalled() -> Bool
+    
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    )
 }
 
 extension UIApplication: URLOpener {
@@ -32,13 +37,5 @@ extension UIApplication: URLOpener {
             return false
         }
         return canOpenURL(payPalURL)
-    }
-
-    // TODO: once Xcode 16 is the minimum supported version remove this method and update the protocol to the default open signature from UIApplication
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    /// Indicates whether the PayPal App is installed.
-    @_documentation(visibility: private)
-    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
-        UIApplication.shared.open(url, options: [:], completionHandler: completion)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -428,7 +428,7 @@ import BraintreeDataCollector
             return
         }
 
-        application.open(redirectURL) { success in
+        application.open(redirectURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, url: redirectURL, completion: completion)
         }
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -188,7 +188,7 @@ import BraintreeCore
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
-        application.open(appStoreURL, completionHandler: nil)
+        application.open(appStoreURL, options: [:], completionHandler: nil)
     }
 
     // MARK: - App Switch Methods
@@ -279,7 +279,7 @@ import BraintreeCore
             linkType: linkType,
             payPalContextID: payPalContextID
         )
-        application.open(appSwitchURL) { success in
+        application.open(appSwitchURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, appSwitchURL: appSwitchURL, completion: completion)
         }
     }

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -8,11 +8,22 @@ public class FakeApplication: URLOpener {
     var cannedOpenURLSuccess: Bool = true
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
+    var openURLOverride: (
+        (
+            _ url: URL,
+            _ options: [UIApplication.OpenExternalURLOptionsKey: Any],
+            _ completion: (@MainActor @Sendable (Bool) -> Void)?
+        ) -> Void
+    )?
 
-    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
+    public func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+) {
         lastOpenURL = url
         openURLWasCalled = true
-        completion?(cannedOpenURLSuccess)
+        openURLOverride?(url, options, completion)
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -20,7 +20,7 @@ public class FakeApplication: URLOpener {
         _ url: URL,
         options: [UIApplication.OpenExternalURLOptionsKey: Any],
         completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
-) {
+    ) {
         lastOpenURL = url
         openURLWasCalled = true
         openURLOverride?(url, options, completion)

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -36,6 +36,7 @@ class BTVenmoClient_Tests: XCTestCase {
         )
         
         venmoClient.apiClient = mockAPIClient
+        BTVenmoClient.venmoClient = venmoClient
     }
 
     func testTokenize_whenRemoteConfigurationFetchFails_callsBackWithConfigurationError() {


### PR DESCRIPTION
### Summary of changes

- Revert this override change needed when supporting older Xcode versions: https://github.com/braintree/braintree_ios/pull/1360#discussion_r1672339486

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
