### PR TITLE
Add Payment Ready v2 Events

### DIFF
--- a/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
@@ -29,6 +29,8 @@ final class BTCreateCustomerSessionAPI {
     ///    - Throws: An error if the request fails or if the response is invalid.
     func execute(_ request: BTCustomerSessionRequest) async throws -> String {
         do {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.createCustomerSessionStarted)
+            
             let graphQLParams = CreateCustomerSessionMutationGraphQLBody(request: request)
             
             let (body, _) = try await apiClient.post("", parameters: graphQLParams, httpType: .graphQLAPI)
@@ -40,9 +42,11 @@ final class BTCreateCustomerSessionAPI {
             guard let sessionID = body["data"]["createCustomerSession"]["sessionId"].asString() else {
                 throw BTHTTPError.httpResponseInvalid
             }
-            
+           
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.createCustomerSessionSucceeded)
             return sessionID
         } catch {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.createCustomerSessionFailed)
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
@@ -48,7 +48,7 @@ final class BTCreateCustomerSessionAPI {
                 shopperSessionID: sessionID
             )
             return sessionID
-        } catch let error as NSError {
+        } catch let error {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.createCustomerSessionFailed,
                 errorDescription: error.localizedDescription

--- a/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
@@ -43,10 +43,16 @@ final class BTCreateCustomerSessionAPI {
                 throw BTHTTPError.httpResponseInvalid
             }
            
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.createCustomerSessionSucceeded)
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.createCustomerSessionSucceeded,
+                shopperSessionID: sessionID
+            )
             return sessionID
-        } catch {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.createCustomerSessionFailed)
+        } catch let error as NSError {
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.createCustomerSessionFailed,
+                errorDescription: error.localizedDescription
+            )
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCreateCustomerSessionAPI.swift
@@ -48,7 +48,7 @@ final class BTCreateCustomerSessionAPI {
                 shopperSessionID: sessionID
             )
             return sessionID
-        } catch let error {
+        } catch {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.createCustomerSessionFailed,
                 errorDescription: error.localizedDescription

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -30,7 +30,7 @@ final class BTCustomerRecommendationsAPI {
         sessionID: String
     ) async throws -> BTCustomerRecommendationsResult {
         do {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsStarted)
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsStarted)
             let graphQLParameters = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
             let (body, _) = try await apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI)
             
@@ -52,14 +52,14 @@ final class BTCustomerRecommendationsAPI {
                 }
             }
             
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsSucceeded)
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsSucceeded)
             return BTCustomerRecommendationsResult(
                 sessionID: sessionID,
                 isInPayPalNetwork: isInPayPalNetwork,
                 paymentRecommendations: paymentOptions
             )
         } catch {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsFailed)
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed)
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -61,7 +61,7 @@ final class BTCustomerRecommendationsAPI {
                 isInPayPalNetwork: isInPayPalNetwork,
                 paymentRecommendations: paymentOptions
             )
-        } catch let error as NSError {
+        } catch let error {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed,
                 errorDescription: error.localizedDescription

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -30,7 +30,10 @@ final class BTCustomerRecommendationsAPI {
         sessionID: String?
     ) async throws -> BTCustomerRecommendationsResult {
         do {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsStarted)
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.generateCustomerRecommendationsStarted,
+                shopperSessionID: sessionID
+            )
             let graphQLParameters = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
             let (body, _) = try await apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI)
             

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -30,6 +30,7 @@ final class BTCustomerRecommendationsAPI {
         sessionID: String
     ) async throws -> BTCustomerRecommendationsResult {
         do {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsStarted)
             let graphQLParameters = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
             let (body, _) = try await apiClient.post("", parameters: graphQLParameters, httpType: .graphQLAPI)
             
@@ -51,12 +52,14 @@ final class BTCustomerRecommendationsAPI {
                 }
             }
             
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsSucceeded)
             return BTCustomerRecommendationsResult(
                 sessionID: sessionID,
                 isInPayPalNetwork: isInPayPalNetwork,
                 paymentRecommendations: paymentOptions
             )
         } catch {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.getCustomerRecommendationsFailed)
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -64,10 +64,11 @@ final class BTCustomerRecommendationsAPI {
                 isInPayPalNetwork: isInPayPalNetwork,
                 paymentRecommendations: paymentOptions
             )
-        } catch let error {
+        } catch {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed,
-                errorDescription: error.localizedDescription
+                errorDescription: error.localizedDescription,
+                shopperSessionID: sessionID
             )
             throw error
         }

--- a/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTCustomerRecommendationsAPI.swift
@@ -52,14 +52,20 @@ final class BTCustomerRecommendationsAPI {
                 }
             }
             
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsSucceeded)
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.generateCustomerRecommendationsSucceeded,
+                shopperSessionID: sessionID
+            )
             return BTCustomerRecommendationsResult(
                 sessionID: sessionID,
                 isInPayPalNetwork: isInPayPalNetwork,
                 paymentRecommendations: paymentOptions
             )
-        } catch {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed)
+        } catch let error as NSError {
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed,
+                errorDescription: error.localizedDescription
+            )
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
@@ -6,7 +6,7 @@ enum BTShopperInsightsAnalytics {
     
     static let buttonPresented = "shopper-insights:button-presented"
     static let buttonSelected = "shopper-insights:button-selected"
-    
+
     // MARK: - SDK Triggered Events
     
     static let recommendedPaymentsStarted = "shopper-insights:get-recommended-payments:started"

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
@@ -3,13 +3,31 @@ import Foundation
 enum BTShopperInsightsAnalytics {
     
     // MARK: - Merchant Triggered Events
-      
+    
     static let buttonPresented = "shopper-insights:button-presented"
     static let buttonSelected = "shopper-insights:button-selected"
-
+    
     // MARK: - SDK Triggered Events
     
     static let recommendedPaymentsStarted = "shopper-insights:get-recommended-payments:started"
     static let recommendedPaymentsSucceeded = "shopper-insights:get-recommended-payments:succeeded"
     static let recommendedPaymentsFailed = "shopper-insights:get-recommended-payments:failed"
+    
+    // MARK: - Payment Ready V2 Events
+    
+    static let createCustomerSessionStarted = "shopper-insights:create-customer-session:started"
+    static let createCustomerSessionSucceeded = "shopper-insights:create-customer-session:succeeded"
+    static let createCustomerSessionFailed = "shopper-insights:create-customer-session:failed"
+    
+    static let updateCustomerSessionStarted = "shopper-insights:update-customer-session:started"
+    static let updateCustomerSessionSucceeded = "shopper-insights:update-customer-session:succeeded"
+    static let updateCustomerSessionFailed = "shopper-insights:update-customer-session:failed"
+    
+    static let getCustomerRecommendationsStarted = "shopper-insights:get-customer-recommendations:started"
+    static let getCustomerRecommendationsSucceeded = "shopper-insights:get-customer-recommendations:succeeded"
+    static let getCustomerRecommendationsFailed = "shopper-insights:get-customer-recommendations:failed"
+    
+    static let manageCustomerSessionWithRecommendationsStarted = "shopper-insights:manage-customer-session-with-recommendations:started"
+    static let manageCustomerSessionWithRecommendationsSucceeded = "shopper-insights:manage-customer-session-with-recommendations:succeeded"
+    static let manageCustomerSessionWithRecommendationsFailed = "shopper-insights:manage-customer-session-with-recommendations:failed"
 }

--- a/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
+++ b/Sources/BraintreeShopperInsights/BTShopperInsightsAnalytics.swift
@@ -23,11 +23,7 @@ enum BTShopperInsightsAnalytics {
     static let updateCustomerSessionSucceeded = "shopper-insights:update-customer-session:succeeded"
     static let updateCustomerSessionFailed = "shopper-insights:update-customer-session:failed"
     
-    static let getCustomerRecommendationsStarted = "shopper-insights:get-customer-recommendations:started"
-    static let getCustomerRecommendationsSucceeded = "shopper-insights:get-customer-recommendations:succeeded"
-    static let getCustomerRecommendationsFailed = "shopper-insights:get-customer-recommendations:failed"
-    
-    static let manageCustomerSessionWithRecommendationsStarted = "shopper-insights:manage-customer-session-with-recommendations:started"
-    static let manageCustomerSessionWithRecommendationsSucceeded = "shopper-insights:manage-customer-session-with-recommendations:succeeded"
-    static let manageCustomerSessionWithRecommendationsFailed = "shopper-insights:manage-customer-session-with-recommendations:failed"
+    static let generateCustomerRecommendationsStarted = "shopper-insights:generate-customer-recommendations:started"
+    static let generateCustomerRecommendationsSucceeded = "shopper-insights:generate-customer-recommendations:succeeded"
+    static let generateCustomerRecommendationsFailed = "shopper-insights:generate-customer-recommendations:failed"
 }

--- a/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
@@ -53,10 +53,11 @@ final class BTUpdateCustomerSessionAPI {
                 shopperSessionID: sessionID
             )
             return sessionID
-        } catch let error {
+        } catch {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.updateCustomerSessionFailed,
-                errorDescription: error.localizedDescription
+                errorDescription: error.localizedDescription,
+                shopperSessionID: sessionID
             )
             throw error
         }

--- a/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
@@ -31,7 +31,10 @@ final class BTUpdateCustomerSessionAPI {
         sessionID: String
     ) async throws -> String {
         do {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionStarted)
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.updateCustomerSessionStarted,
+                shopperSessionID: sessionID
+            )
             
             let graphQLParams = UpdateCustomerSessionMutationGraphQLBody(request: request, sessionID: sessionID)
             

--- a/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
@@ -31,6 +31,8 @@ final class BTUpdateCustomerSessionAPI {
         sessionID: String
     ) async throws -> String {
         do {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionStarted)
+            
             let graphQLParams = UpdateCustomerSessionMutationGraphQLBody(request: request, sessionID: sessionID)
             
             let (body, _) = try await apiClient.post("", parameters: graphQLParams, httpType: .graphQLAPI)
@@ -43,8 +45,10 @@ final class BTUpdateCustomerSessionAPI {
                 throw BTHTTPError.httpResponseInvalid
             }
             
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionSucceeded)
             return sessionID
         } catch {
+            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionFailed)
             throw error
         }
     }

--- a/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
@@ -50,7 +50,7 @@ final class BTUpdateCustomerSessionAPI {
                 shopperSessionID: sessionID
             )
             return sessionID
-        } catch let error as NSError {
+        } catch let error {
             apiClient.sendAnalyticsEvent(
                 BTShopperInsightsAnalytics.updateCustomerSessionFailed,
                 errorDescription: error.localizedDescription

--- a/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
+++ b/Sources/BraintreeShopperInsights/BTUpdateCustomerSessionAPI.swift
@@ -45,10 +45,16 @@ final class BTUpdateCustomerSessionAPI {
                 throw BTHTTPError.httpResponseInvalid
             }
             
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionSucceeded)
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.updateCustomerSessionSucceeded,
+                shopperSessionID: sessionID
+            )
             return sessionID
-        } catch {
-            apiClient.sendAnalyticsEvent(BTShopperInsightsAnalytics.updateCustomerSessionFailed)
+        } catch let error as NSError {
+            apiClient.sendAnalyticsEvent(
+                BTShopperInsightsAnalytics.updateCustomerSessionFailed,
+                errorDescription: error.localizedDescription
+            )
             throw error
         }
     }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsAnalytics_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsAnalytics_Tests.swift
@@ -10,4 +10,16 @@ final class BTShopperInsightsAnalytics_Tests: XCTestCase {
         XCTAssertEqual(BTShopperInsightsAnalytics.recommendedPaymentsSucceeded, "shopper-insights:get-recommended-payments:succeeded")
         XCTAssertEqual(BTShopperInsightsAnalytics.recommendedPaymentsFailed, "shopper-insights:get-recommended-payments:failed")
     }
+    
+    func test_createCustomerSessionAnalyticEvents_sendsExpectedEventNames() {
+        XCTAssertEqual(BTShopperInsightsAnalytics.createCustomerSessionStarted, "shopper-insights:create-customer-session:started")
+        XCTAssertEqual(BTShopperInsightsAnalytics.createCustomerSessionSucceeded, "shopper-insights:create-customer-session:succeeded")
+        XCTAssertEqual(BTShopperInsightsAnalytics.createCustomerSessionFailed, "shopper-insights:create-customer-session:failed")
+    }
+    
+    func test_updateCustomerSessionAnalyticEvents_sendsExpectedEventNames() {
+        XCTAssertEqual(BTShopperInsightsAnalytics.updateCustomerSessionStarted, "shopper-insights:update-customer-session:started")
+        XCTAssertEqual(BTShopperInsightsAnalytics.updateCustomerSessionSucceeded, "shopper-insights:update-customer-session:succeeded")
+        XCTAssertEqual(BTShopperInsightsAnalytics.updateCustomerSessionFailed, "shopper-insights:update-customer-session:failed")
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsAnalytics_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsAnalytics_Tests.swift
@@ -22,4 +22,10 @@ final class BTShopperInsightsAnalytics_Tests: XCTestCase {
         XCTAssertEqual(BTShopperInsightsAnalytics.updateCustomerSessionSucceeded, "shopper-insights:update-customer-session:succeeded")
         XCTAssertEqual(BTShopperInsightsAnalytics.updateCustomerSessionFailed, "shopper-insights:update-customer-session:failed")
     }
+    
+    func test_generateCustomerRecommendations_sendsExpectedEventNames() {
+        XCTAssertEqual(BTShopperInsightsAnalytics.generateCustomerRecommendationsStarted, "shopper-insights:generate-customer-recommendations:started")
+        XCTAssertEqual(BTShopperInsightsAnalytics.generateCustomerRecommendationsSucceeded, "shopper-insights:generate-customer-recommendations:succeeded")
+        XCTAssertEqual(BTShopperInsightsAnalytics.generateCustomerRecommendationsFailed, "shopper-insights:generate-customer-recommendations:failed")
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -187,6 +187,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         let sessionID = try await sut.createCustomerSession(request: customerSessionRequest)
         
         XCTAssertEqual(expectedSessionID, sessionID)
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:succeeded")
     }
     
     func testCreateCustomerSession_whenFails_throwsAnError() async throws {
@@ -198,6 +199,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTFail("Expected error to be thrown.")
         } catch let error as NSError {
             XCTAssertEqual(error, mockError)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:failed")
         }
     }
     
@@ -216,6 +218,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         
         let sessionID = try await sut.updateCustomerSession(request: customerSessionRequest, sessionID: sessionID)
         XCTAssertEqual(expectedSessionID, sessionID)
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:update-customer-session:succeeded")
     }
     
     func testUpdateCustomerSession_whenFails_throwsAnError() async throws {
@@ -227,6 +230,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTFail("Expected error to be thrown.")
         } catch let error as NSError {
             XCTAssertEqual(error, mockError)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:update-customer-session:failed")
         }
     }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -284,7 +284,9 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
 
             XCTAssertEqual(recommendations[1].paymentOption, "Venmo")
             XCTAssertEqual(recommendations[1].recommendedPriority, 2)
-
+            
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:succeeded")
         } catch {
             XCTFail("Expected no error, but got: \(error)")
         }
@@ -303,6 +305,8 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         } catch let error as NSError {
             XCTAssertEqual(error.domain, expectedError.domain)
             XCTAssertEqual(error.code, expectedError.code)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:failed")
         } catch {
             XCTFail("Expected NSError but got a different error: \(error)")
         }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -187,6 +187,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         let sessionID = try await sut.createCustomerSession(request: customerSessionRequest)
         
         XCTAssertEqual(expectedSessionID, sessionID)
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:create-customer-session:started")
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:succeeded")
     }
     
@@ -199,6 +200,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTFail("Expected error to be thrown.")
         } catch let error as NSError {
             XCTAssertEqual(error, mockError)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:create-customer-session:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:failed")
         }
     }
@@ -218,6 +220,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         
         let sessionID = try await sut.updateCustomerSession(request: customerSessionRequest, sessionID: sessionID)
         XCTAssertEqual(expectedSessionID, sessionID)
+        XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:update-customer-session:started")
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:update-customer-session:succeeded")
     }
     
@@ -230,6 +233,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTFail("Expected error to be thrown.")
         } catch let error as NSError {
             XCTAssertEqual(error, mockError)
+            XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:update-customer-session:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:update-customer-session:failed")
         }
     }

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -189,6 +189,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
         XCTAssertEqual(expectedSessionID, sessionID)
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:create-customer-session:started")
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:succeeded")
+        XCTAssertEqual(mockAPIClient.postedShopperSessionID, expectedSessionID)
     }
     
     func testCreateCustomerSession_whenFails_throwsAnError() async throws {
@@ -202,6 +203,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTAssertEqual(error, mockError)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:create-customer-session:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:create-customer-session:failed")
+            XCTAssertNotNil(mockAPIClient.postedErrorDescription)
         }
     }
     
@@ -235,6 +237,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTAssertEqual(error, mockError)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:update-customer-session:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:update-customer-session:failed")
+            XCTAssertNotNil(mockAPIClient.postedErrorDescription)
         }
     }
     
@@ -307,6 +310,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
             XCTAssertEqual(error.code, expectedError.code)
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:failed")
+            XCTAssertNotNil(mockAPIClient.postedErrorDescription)
         } catch {
             XCTFail("Expected NSError but got a different error: \(error)")
         }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -24,6 +24,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedIsPayPalAppInstalled: Bool? = nil
     public var postedDidEnablePayPalAppSwitch: Bool? = nil
     public var postedDidPayPalServerAttemptAppSwitch: Bool? = nil
+    public var postedErrorDescription: String? = nil
     
     @objc public var cannedConfigurationResponseBody : BTJSON? = nil
     @objc public var cannedConfigurationResponseError : NSError? = nil
@@ -125,6 +126,7 @@ public class MockAPIClient: BTAPIClient {
         postedShopperSessionID = shopperSessionID
         postedDidEnablePayPalAppSwitch = didEnablePayPalAppSwitch
         postedDidPayPalServerAttemptAppSwitch = didPayPalServerAttemptAppSwitch
+        postedErrorDescription = errorDescription
 
         postedAnalyticsEvents.append(eventName)
     }


### PR DESCRIPTION
### Summary of changes

- Add all the new events and sanity unit tests for events we want to send as part of Payment Ready v2

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
