### PR TITLE
Fix bug where `browserLoginAlertCanceled` is fired in the None-WAS popup flow

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -510,8 +510,8 @@ import BraintreeDataCollector
         approvalURL = appSwitchURL
         webSessionReturned = false
         
-        webAuthenticationSession.prefersEphemeralWebBrowserSession = experiment == "InAppBrowserNoPopup"
-
+        configureSessionIfNeeded(for: experiment)
+        
         webAuthenticationSession.start(url: appSwitchURL, context: self) { [weak self] url, error in
             self?.payPalContextID = self?.extractToken(from: url)
             
@@ -603,6 +603,13 @@ import BraintreeDataCollector
         let baToken = BTURLUtils.queryParameters(for: url)["ba_token"]
         let ecToken = BTURLUtils.queryParameters(for: url)["token"]
         return baToken ?? ecToken
+    }
+    
+    private func configureSessionIfNeeded(for experiment: String? = nil) {
+        if experiment == "InAppBrowserNoPopup" {
+            webSessionReturned = true
+            webAuthenticationSession.prefersEphemeralWebBrowserSession = true
+        }
     }
 
     // MARK: - Analytics Helper Methods


### PR DESCRIPTION
### Summary of changes

- Context: The `browserLoginAlertCanceled` was being fired even though the experiment=InAppBrowserNoPopup was being passed in the approval url, which would essentially bypass the WAS popup.
- This fix ensures that we add a check for the experiment and accordingly set the `webSessionReturned` and `prefersEphemeralWebBrowserSession` flag. Abstracted this logic into a separate helper function to check if the experiment is enabled and set these properties accordingly (and to allow us to edit in the future in case we enable more experiments)

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
