### PR TITLE
[Analytics] Add `browser-presentation:started` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Bug fix: Pass `unitTaxAmount` as expected in `BTPayPalLineItem`
   * Make `BTPayPalLineItem` parameters settable
   * Bug fix: only attempt to call `UIApplication.shared.open` on one URL at a time blocking other `open` calls until the current one is finished
+  * Add `paypal:tokenize:browser-presentation:started` event for when the `ASWebAuthenticationSession.start` is launched
 
 ## 6.34.0 (2025-06-18)
 * BraintreePayPal

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -13,6 +13,7 @@ enum BTPayPalAnalytics {
    
     // MARK: - Browser Presentation Events
   
+    static let browserPresentationStarted = "paypal:tokenize:browser-presentation:started"
     static let browserPresentationSucceeded = "paypal:tokenize:browser-presentation:succeeded"
     static let browserPresentationFailed = "paypal:tokenize:browser-presentation:failed"
     

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -507,6 +507,15 @@ import BraintreeDataCollector
         paymentType: BTPayPalPaymentType,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
+        apiClient.sendAnalyticsEvent(
+            BTPayPalAnalytics.browserPresentationStarted,
+            didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
+            didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            isVaultRequest: isVaultRequest,
+            payPalContextID: payPalContextID,
+            shopperSessionID: payPalRequest?.shopperSessionID
+        )
+        
         approvalURL = appSwitchURL
         webSessionReturned = false
         

--- a/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
@@ -7,6 +7,7 @@ final class BTPayPalAnalytics_Tests: XCTestCase {
         XCTAssertEqual(BTPayPalAnalytics.tokenizeFailed, "paypal:tokenize:failed")
         XCTAssertEqual(BTPayPalAnalytics.tokenizeSucceeded, "paypal:tokenize:succeeded")
         XCTAssertEqual(BTPayPalAnalytics.browserLoginCanceled, "paypal:tokenize:browser-login:canceled")
+        XCTAssertEqual(BTPayPalAnalytics.browserPresentationStarted, "paypal:tokenize:browser-presentation:started")
         XCTAssertEqual(BTPayPalAnalytics.browserPresentationSucceeded, "paypal:tokenize:browser-presentation:succeeded")
         XCTAssertEqual(BTPayPalAnalytics.browserPresentationFailed, "paypal:tokenize:browser-presentation:failed")
         XCTAssertEqual(BTPayPalAnalytics.browserLoginAlertCanceled, "paypal:tokenize:browser-login:alert-canceled")

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -330,6 +330,23 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(mockAPIClient.postedDidPayPalServerAttemptAppSwitch, false)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:handle-return:started"))
     }
+    
+    func testTokenize_whenApprovalURLIsWebBrowserRedirectType_sendsBrowserPresentationStartedEvent() {
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "approvalUrl": "https://www.paypal.com/agreements/approve?ba_token=A_FAKE_BA_TOKEN"
+            ]
+        ])
+        
+        let request = BTPayPalCheckoutRequest(amount: "10.00")
+        mockWebAuthenticationSession.cannedResponseURL = URL(string: "sdk.ios.braintree://onetouch/v1/success?ba_token=A_FAKE_BA_TOKEN")
+        payPalClient.tokenize(request) { _, _ in }
+        
+        XCTAssertEqual(mockAPIClient.postedPayPalContextID, "A_FAKE_BA_TOKEN")
+        XCTAssertEqual(mockAPIClient.postedDidEnablePayPalAppSwitch, false)
+        XCTAssertEqual(mockAPIClient.postedDidPayPalServerAttemptAppSwitch, false)
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains("paypal:tokenize:browser-presentation:started"))
+    }
 
     // MARK: - Browser switch
 


### PR DESCRIPTION
### Summary of changes

Introduces a new analytics event, `paypal:tokenize:browser-presentation:started`, to track when the `ASWebAuthenticationSession.start` is launched in the PayPal tokenization flow. 

### New analytics event implementation:

* **Event added to changelog**: Documented the addition of the `paypal:tokenize:browser-presentation:started` event in `CHANGELOG.md`.
* **Constant definition**: Added `browserPresentationStarted` to the `BTPayPalAnalytics` enum in `Sources/BraintreePayPal/BTPayPalAnalytics.swift`.
* **Event handling in client**: Updated `BTPayPalClient.swift` to send the `browserPresentationStarted` analytics event when the browser presentation begins.

### Unit tests for the new event:

* **Analytics constant test**: Verified the `browserPresentationStarted` constant in `BTPayPalAnalytics_Tests.swift`.
* **Client behavior test**: Added a test in `BTPayPalClient_Tests.swift` to ensure the `browserPresentationStarted` event is sent when the approval URL corresponds to a web browser redirect.

<img width="638" height="259" alt="Screenshot 2025-07-14 at 2 39 36 p m" src="https://github.com/user-attachments/assets/8dbf9f52-e255-4733-ad36-a355c2837644" />


### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
