### PR TITLE
[v7] Revert Open Override

### DIFF
--- a/Sources/BraintreeCore/UIApplication+URLOpener.swift
+++ b/Sources/BraintreeCore/UIApplication+URLOpener.swift
@@ -7,9 +7,13 @@ import UIKit
 public protocol URLOpener {
 
     func canOpenURL(_ url: URL) -> Bool
-    func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?)
     func isPayPalAppInstalled() -> Bool
     func isVenmoAppInstalled() -> Bool
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    )
 }
 
 extension UIApplication: URLOpener {
@@ -32,13 +36,5 @@ extension UIApplication: URLOpener {
             return false
         }
         return canOpenURL(payPalURL)
-    }
-
-    // TODO: once Xcode 16 is the minimum supported version remove this method and update the protocol to the default open signature from UIApplication
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    /// Indicates whether the PayPal App is installed.
-    @_documentation(visibility: private)
-    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
-        UIApplication.shared.open(url, options: [:], completionHandler: completion)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -434,7 +434,7 @@ import BraintreeDataCollector
             return
         }
 
-        application.open(redirectURL) { success in
+        application.open(redirectURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, url: redirectURL, completion: completion)
         }
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -279,7 +279,7 @@ import BraintreeCore
             linkType: linkType,
             payPalContextID: payPalContextID
         )
-        application.open(appSwitchURL, options: [:], ) { success in
+        application.open(appSwitchURL, options: [:]) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, appSwitchURL: appSwitchURL, completion: completion)
         }
     }

--- a/Sources/BraintreeVenmo/BTVenmoClient.swift
+++ b/Sources/BraintreeVenmo/BTVenmoClient.swift
@@ -188,7 +188,7 @@ import BraintreeCore
 
     /// Switches to the App Store to download the Venmo application.
     @objc public func openVenmoAppPageInAppStore() {
-        application.open(appStoreURL, completionHandler: nil)
+        application.open(appStoreURL, options: [:], completionHandler: nil)
     }
 
     // MARK: - App Switch Methods
@@ -279,7 +279,7 @@ import BraintreeCore
             linkType: linkType,
             payPalContextID: payPalContextID
         )
-        application.open(appSwitchURL) { success in
+        application.open(appSwitchURL, options: [:], ) { success in
             self.invokedOpenURLSuccessfully(success, shouldVault: vault, appSwitchURL: appSwitchURL, completion: completion)
         }
     }

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -9,10 +9,17 @@ public class FakeApplication: URLOpener {
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
 
-    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
+    public func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    ) {
         lastOpenURL = url
         openURLWasCalled = true
-        completion?(cannedOpenURLSuccess)
+        
+        Task { @MainActor in
+            completion?(cannedOpenURLSuccess)
+        }
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {

--- a/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoClient_Tests.swift
@@ -339,7 +339,9 @@ class BTVenmoClient_Tests: XCTestCase {
             ]
         ])
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
+        }
 
         waitForExpectations(timeout: 1)
     }
@@ -359,7 +361,9 @@ class BTVenmoClient_Tests: XCTestCase {
         mockAPIClient.cannedResponseBody = nil
         mockAPIClient.cannedResponseError = NSError(domain: "some-domain", code: 1, userInfo: nil)
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?resource_id=12345")!)
+        }
 
         waitForExpectations(timeout: 1)
     }
@@ -380,7 +384,10 @@ class BTVenmoClient_Tests: XCTestCase {
             XCTAssertEqual(venmoAccount.username, "fake-username")
             expectation.fulfill()
         }
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
 
         waitForExpectations(timeout: 2)
     }
@@ -403,7 +410,10 @@ class BTVenmoClient_Tests: XCTestCase {
             XCTAssertEqual(venmoAccount.username, "fake-username")
             expectation.fulfill()
         }
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
         
         waitForExpectations(timeout: 2)
     }
@@ -419,7 +429,10 @@ class BTVenmoClient_Tests: XCTestCase {
             XCTAssertEqual(error.domain, "com.braintreepayments.BTVenmoAppSwitchReturnURLErrorDomain")
             expectation.fulfill()
         }
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/error")!)
+        
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/error")!)
+        }
 
         waitForExpectations(timeout: 2)
     }
@@ -437,7 +450,10 @@ class BTVenmoClient_Tests: XCTestCase {
             expectation.fulfill()
         }
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
+        
         waitForExpectations(timeout: 2)
     }
 
@@ -452,7 +468,10 @@ class BTVenmoClient_Tests: XCTestCase {
             expectation.fulfill()
         }
         
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
+        
         waitForExpectations(timeout: 2)
     }
     
@@ -490,7 +509,10 @@ class BTVenmoClient_Tests: XCTestCase {
             ] as [String: Any]]
         ])
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
+        
         waitForExpectations(timeout: 2)
     }
     
@@ -528,7 +550,10 @@ class BTVenmoClient_Tests: XCTestCase {
             ] as [String: Any]]
         ])
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
+        
         waitForExpectations(timeout: 2)
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)
@@ -551,7 +576,10 @@ class BTVenmoClient_Tests: XCTestCase {
 
         mockAPIClient.cannedResponseError = NSError(domain: "Fake Error", code: 400, userInfo: nil)
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=fake-nonce&username=fake-username")!)
+        }
+        
         waitForExpectations(timeout: 2)
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeFailed)
@@ -573,7 +601,10 @@ class BTVenmoClient_Tests: XCTestCase {
             
             expectation.fulfill()
         }
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/cancel")!)
+        
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/cancel")!)
+        }
 
         waitForExpectations(timeout: 2)
     }
@@ -748,7 +779,10 @@ class BTVenmoClient_Tests: XCTestCase {
             expectation.fulfill()
         }
 
-        BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=lmnop-venmo-nonce&username=venmotim")!)
+        DispatchQueue.main.async {
+            BTVenmoClient.handleReturnURL(URL(string: "scheme://x-callback-url/vzero/auth/venmo/success?paymentMethodNonce=lmnop-venmo-nonce&username=venmotim")!)
+        }
+        
         waitForExpectations(timeout: 2)
 
         XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last!, BTVenmoAnalytics.tokenizeSucceeded)


### PR DESCRIPTION
### Summary of changes

- Revert this override change needed when supporting older Xcode versions: https://github.com/braintree/braintree_ios/pull/1360#discussion_r1672339486

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 