### PR TITLE
[Analytics] URL FPTI Tag Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Make `BTPayPalLineItem` parameters settable
   * Bug fix: only attempt to call `UIApplication.shared.open` on one URL at a time blocking other `open` calls until the current one is finished
   * Bug fix: Ensure that the `browserLoginAlertCanceled` event is not fired off when the `ASWebAutheniticationSession` popup is disabled.
+  * Update `url` FPTI tag to represent the approval URL prior to checkout and the success URL after checkout.
 
 ## 6.34.0 (2025-06-18)
 * BraintreePayPal

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -208,6 +208,7 @@ import BraintreeDataCollector
 
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.handleReturnStarted,
+            appSwitchURL: url,
             correlationID: payPalContextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
@@ -461,6 +462,7 @@ import BraintreeDataCollector
         guard !hasOpenedURL else {
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.tokenizeDuplicateRequest,
+                appSwitchURL: payPalAppRedirectURL,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                 isVaultRequest: isVaultRequest,
@@ -476,6 +478,7 @@ import BraintreeDataCollector
 
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.appSwitchStarted,
+            appSwitchURL: payPalAppRedirectURL,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             isVaultRequest: isVaultRequest,
@@ -547,6 +550,7 @@ import BraintreeDataCollector
             if didAppear {
                 apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationSucceeded,
+                    appSwitchURL: appSwitchURL,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                     isConfigFromCache: isConfigFromCache,
@@ -557,6 +561,7 @@ import BraintreeDataCollector
             } else {
                 apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserPresentationFailed,
+                    appSwitchURL: appSwitchURL,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                     isVaultRequest: isVaultRequest,
@@ -571,6 +576,7 @@ import BraintreeDataCollector
                 // User tapped system cancel button on permission alert
                 apiClient.sendAnalyticsEvent(
                     BTPayPalAnalytics.browserLoginAlertCanceled,
+                    appSwitchURL: appSwitchURL,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                     isVaultRequest: isVaultRequest,
@@ -587,6 +593,7 @@ import BraintreeDataCollector
             
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.tokenizeDuplicateRequest,
+                appSwitchURL: appSwitchURL,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                 isVaultRequest: isVaultRequest,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -512,6 +512,7 @@ import BraintreeDataCollector
     ) {
         apiClient.sendAnalyticsEvent(
             BTPayPalAnalytics.browserPresentationStarted,
+            appSwitchURL: appSwitchURL,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             isVaultRequest: isVaultRequest,


### PR DESCRIPTION
### Summary of changes

Updates the `BTPayPalClient` to include the `appSwitchURL` parameter in various analytics events.

### Enhancements to Analytics Event Tracking:

* Added the `appSwitchURL` parameter to the `sendAnalyticsEvent` method for the following analytics events:
  - `handleReturnStarted` to track the URL used during app switch return handling.
  - `tokenizeDuplicateRequest` to track duplicate tokenization requests. [[1]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R465) [[2]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R596)
  - `appSwitchStarted` to track the initiation of PayPal app switching.
  - `browserPresentationSucceeded` and `browserPresentationFailed` to track the success or failure of browser presentation during PayPal interactions. [[1]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R553) [[2]](diffhunk://#diff-7593900bd413ee81d48fae61aeeab899a00cbfdc0d2a688e21d3acf3f7ef3360R564)
  - `browserLoginAlertCanceled` to track user cancellation of the login alert.

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
