### PR TITLE
[Analytics] Add Space Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreeCore
   * Analytics updates for PayPal's analytics service (FPTI)
-    * Add `space_key` to `event_params`
+    * Add `space_key` to `batch_params`
 
 ## 6.35.0 (2025-07-23)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Analytics updates for PayPal's analytics service (FPTI)
+    * Add `space_key`
+
 ## 6.35.0 (2025-07-23)
 * BraintreePayPal
   * Bug fix: `BTPayPalRequest.userPhoneNumber` could be passed as an empty string resulting in an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreeCore
   * Analytics updates for PayPal's analytics service (FPTI)
-    * Add `space_key`
+    * Add `space_key` to `event_params`
 
 ## 6.35.0 (2025-07-23)
 * BraintreePayPal

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -207,6 +207,8 @@ struct FPTIBatchData: Codable {
         /// Either a randomly generated session ID or the shopper session ID passed in by a merchant
         let sessionID: String
 
+        let spaceKey: String = "SKDUYK"
+
         let tokenizationKey: String?
 
         let venmoInstalled: Bool = application.isVenmoAppInstalled()
@@ -230,6 +232,7 @@ struct FPTIBatchData: Codable {
             case merchantID = "merchant_id"
             case platform = "platform"
             case sessionID = "session_id"
+            case spaceKey = "space_key"
             case tokenizationKey = "tokenization_key"
             case venmoInstalled = "venmo_installed"
         }

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -88,6 +88,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(batchParams["merchant_id"] as! String, "fake-merchant-id")
         XCTAssertEqual(batchParams["platform"] as? String, "iOS")
         XCTAssertEqual(batchParams["session_id"] as? String, "fake-session")
+        XCTAssertEqual(batchParams["space_key"] as? String, "SKDUYK")
         XCTAssertEqual(batchParams["tokenization_key"] as! String, "fake-auth")
         XCTAssertEqual(batchParams["paypal_installed"] as! Bool, false)
         XCTAssertEqual(batchParams["venmo_installed"] as! Bool, false)


### PR DESCRIPTION
**Note:** this work is going into a feature branch, once all changes are completed this will be verified and merged in with the appropriate teams. This is part of an alignment on the tags we pass to FPTI as well as some new tags and the same work being done on iOS will also be done on Android.

### Summary of changes

- Add `space_key` - this is a hardcoded value that represents the BT SDKs
- Verified this tag is now sent in FPTI
- Add unit test

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
