### PR TITLE
[Analytics] Add Product Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Analytics updates for PayPal's analytics service (FPTI)
+    * Add `product_name` to `event_params`
+
 ## 6.35.0 (2025-07-23)
 * BraintreePayPal
   * Bug fix: `BTPayPalRequest.userPhoneNumber` could be passed as an empty string resulting in an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreeCore
   * Analytics updates for PayPal's analytics service (FPTI)
-    * Add `product_name` to `event_params`
+    * Add `product_name` to `batch_params`
 
 ## 6.35.0 (2025-07-23)
 * BraintreePayPal

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -203,6 +203,8 @@ struct FPTIBatchData: Codable {
         let payPalInstalled: Bool = application.isPayPalAppInstalled()
 
         let platform = "iOS"
+        
+        let productName: String = "BT_DCC"
 
         /// Either a randomly generated session ID or the shopper session ID passed in by a merchant
         let sessionID: String
@@ -224,6 +226,7 @@ struct FPTIBatchData: Codable {
             case environment = "merchant_sdk_env"
             case packageManager = "ios_package_manager"
             case payPalInstalled = "paypal_installed"
+            case productName = "product_name"
             case integrationType = "api_integration_type"
             case isSimulator = "is_simulator"
             case merchantAppVersion = "mapv"

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -81,6 +81,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(batchParams["merchant_sdk_env"] as? String, "fake-env")
         XCTAssertEqual(batchParams["event_source"] as? String, "mobile-native")
         XCTAssertTrue((batchParams["ios_package_manager"] as! String).matches("Carthage or Other|CocoaPods|Swift Package Manager"))
+        XCTAssertEqual(batchParams["product_name"] as? String, "BT_DCC")
         XCTAssertEqual(batchParams["api_integration_type"] as? String, "fake-integration-type")
         XCTAssertEqual(batchParams["is_simulator"] as? Bool, true)
         XCTAssertNotNil(batchParams["mapv"] as? String) // Unable to specify bundle version number within test targets


### PR DESCRIPTION
**Note:** this work is going into a feature branch, once all changes are completed this will be verified and merged in with the appropriate teams. This is part of an alignment on the tags we pass to FPTI as well as some new tags and the same work being done on iOS will also be done on Android.

### Summary of changes

- Add `product_name` - this is a hardcoded value that represents the BT SDKs and is the value we were told to use for this change
- Verified this tag is now sent in FPTI
- Add unit test

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 