### PR TITLE
[Analytics] Correct Context Type Values

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -74,7 +74,7 @@ import BraintreeDataCollector
     /// Used for analytics purposes, to determine if browser-presentation event is associated with a locally cached, or remotely fetched `BTConfiguration`
     private var isConfigFromCache: Bool?
     
-    /// Used for analytics purpose to determine if the context type is `BA_TOKEN` or `EC_TOKEN`
+    /// Used for analytics purpose to determine if the context type is `BA-TOKEN` or `EC-TOKEN`
     private var contextType: String?
 
     // MARK: - Initializer
@@ -130,7 +130,7 @@ import BraintreeDataCollector
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         isVaultRequest = true
-        contextType = "BA_TOKEN"
+        contextType = "BA-TOKEN"
         tokenize(request: request, completion: completion)
     }
 
@@ -174,7 +174,7 @@ import BraintreeDataCollector
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         isVaultRequest = false
-        contextType = "EC_TOKEN"
+        contextType = "EC-TOKEN"
         tokenize(request: request, completion: completion)
     }
 

--- a/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/FPTIBatchData_Tests.swift
@@ -19,7 +19,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         FPTIBatchData.Event(
             connectionStartTime: 123,
             contextID: "fake-order-id",
-            contextType: "BA_TOKEN",
+            contextType: "BA-TOKEN",
             correlationID: "fake-correlation-id-1",
             endpoint: "/v1/paypal_hermes/setup_billing_agreement",
             endTime: 111222333444555,
@@ -108,7 +108,7 @@ final class FPTIBatchData_Tests: XCTestCase {
         XCTAssertEqual(eventParams[1]["context_id"] as! String, "fake-order-id-2")
         XCTAssertEqual(eventParams[0]["error_desc"] as? String, "fake-error-description-1")
         XCTAssertNil(eventParams[1]["error_desc"])
-        XCTAssertEqual(eventParams[0]["context_type"] as? String, "BA_TOKEN")
+        XCTAssertEqual(eventParams[0]["context_type"] as? String, "BA-TOKEN")
         XCTAssertNil(eventParams[1]["context_type"])
         XCTAssertEqual(eventParams[0]["correlation_id"] as? String, "fake-correlation-id-1")
         XCTAssertNil(eventParams[1]["correlation_id"])

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1226,7 +1226,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let _ = try? await payPalClient.tokenize(vaultRequest)
 
         XCTAssertTrue(mockAPIClient.postedIsVaultRequest)
-        XCTAssertEqual(mockAPIClient.postedContextType, "BA_TOKEN")
+        XCTAssertEqual(mockAPIClient.postedContextType, "BA-TOKEN")
     }
 
     func testTokenize_whenCheckoutRequest_setsVaultAnalyticsTags() async {
@@ -1235,7 +1235,7 @@ class BTPayPalClient_Tests: XCTestCase {
         let _ = try? await payPalClient.tokenize(checkoutRequest)
 
         XCTAssertFalse(mockAPIClient.postedIsVaultRequest)
-        XCTAssertEqual(mockAPIClient.postedContextType, "EC_TOKEN")
+        XCTAssertEqual(mockAPIClient.postedContextType, "EC-TOKEN")
     }
     
     func testTokenize_whenShopperSessionIDSetOnRequest_includesInAnalytics() async {


### PR DESCRIPTION
**Note:** this work is going into a feature branch, once all changes are completed this will be verified and merged in with the appropriate teams. This is part of an alignment on the tags we pass to FPTI as well as some new tags and the same work being done on iOS will also be done on Android.

### Summary of changes

- The values for context type should use dashes and not underscores

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
