### PR TITLE
[v7] LocalPayment Encodable

### DIFF
--- a/Demo/Application/Features/IdealViewController.swift
+++ b/Demo/Application/Features/IdealViewController.swift
@@ -47,7 +47,7 @@ class IdealViewController: PaymentButtonBaseViewController {
     }
 
     private func startPaymentWithBank() {
-        localPaymentClient = BTLocalPaymentClient(authorization: authorization)
+        localPaymentClient = BTLocalPaymentClient(authorization: "sandbox_f252zhq7_hh4cpc39zq4rgjcg")
 
         let postalAddress = BTPostalAddress()
         postalAddress.countryCodeAlpha2 = "NL"

--- a/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
+++ b/Sources/BraintreeLocalPayment/Models/LocalPaymentAccountsPOSTBody.swift
@@ -4,7 +4,7 @@ import Foundation
 import BraintreeCore
 #endif
 
-/// The POST body for v1/payment_methods/paypal_accounts
+/// The POST body for `v1/payment_methods/paypal_accounts`
 struct LocalPaymentPayPalAccountsPOSTBody: Encodable {
     
     // MARK: - Private Properties
@@ -41,7 +41,7 @@ extension LocalPaymentPayPalAccountsPOSTBody {
         let intent = "sale"
         let response: Response
         let responseType = "web"
-        let options = [Option()]
+        let options = Option()
         
         var correlationID: String?
         
@@ -70,6 +70,7 @@ extension LocalPaymentPayPalAccountsPOSTBody {
             case correlationID = "correlation_id"
             case intent
             case options
+            case response
             case responseType = "response_type"
         }
     }

--- a/Sources/BraintreeLocalPayment/Models/LocalPaymentPOSTBody.swift
+++ b/Sources/BraintreeLocalPayment/Models/LocalPaymentPOSTBody.swift
@@ -4,7 +4,7 @@ import Foundation
 import BraintreeCore
 #endif
 
-/// The POST body for v1/local_payments/create
+/// The POST body for `v1/local_payments/create`
 struct LocalPaymentPOSTBody: Encodable {
     
     // MARK: - Private Properties

--- a/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
+++ b/UnitTests/BraintreeLocalPaymentTests/BTLocalPaymentClient_UnitTests.swift
@@ -406,6 +406,55 @@ class BTLocalPaymentClient_UnitTests: XCTestCase {
         mockAPIClient.cannedResponseBody = nil
     }
     
+    func testHandleOpenURL_postAllLocalPaymentPayPalAccountsParameters() {
+        let client = BTLocalPaymentClient(authorization: tempClientToken)
+        client.apiClient = mockAPIClient
+        
+        mockAPIClient.cannedResponseBody = BTJSON(
+            value: [
+                "paymentResource": [
+                    "redirectUrl": "https://www.somebankurl.com",
+                    "paymentToken": "123aaa-123-543-777",
+                ]
+            ]
+        )
+        
+        let paymentRequest = BTLocalPaymentRequest(
+            paymentType: "ideal",
+            amount: "1.01",
+            currencyCode: "EUR"
+        )
+        paymentRequest.localPaymentFlowDelegate = mockLocalPaymentRequestDelegate
+
+        client.startPaymentFlow(paymentRequest) { _, _ in }
+
+        client.handleOpen(
+            URL(string: "com.braintreepayments.demo.payments://x-callback-url/braintree/local-payment/success")!
+        )
+
+        guard
+            let payPalAccount = mockAPIClient.lastPOSTParameters!["paypal_account"] as? [String: Any],
+            let meta = mockAPIClient.lastPOSTParameters!["_meta"] as? [String: Any] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalAccount["response_type"] as? String, "web")
+        XCTAssertEqual(payPalAccount["intent"] as? String, "sale")
+        XCTAssertEqual(meta["source"] as? String, "unknown")
+        XCTAssertEqual(meta["integration"] as? String, "custom")
+        
+        guard
+            let options = payPalAccount["options"] as? [String: Any],
+            let response = payPalAccount["response"] as? [String: Any] else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertFalse(options["validate"] as! Bool)
+        XCTAssertEqual(response["webURL"] as? String, "com.braintreepayments.demo.payments://x-callback-url/braintree/local-payment/success")
+    }
+    
     func testHandleOpenURL_whenMissingAccountsResponse_returnsError() {
         let client = BTLocalPaymentClient(authorization: tempClientToken)
         let expectation = self.expectation(description: "Calls onPaymentComplete with result")
@@ -425,4 +474,3 @@ class BTLocalPaymentClient_UnitTests: XCTestCase {
         waitForExpectations(timeout: 1.0, handler: nil)
     }
 }
-


### PR DESCRIPTION
### Summary of changes

Several minor improvements and fixes related to local payment handling and documentation.

**Local payment POST body changes:**

* Changed the encoding of the `options` property in `LocalPaymentPayPalAccountsPOSTBody` from an array to a single `Option` object for better alignment with expected API format.
* Added the `response` property to the list of encoded keys in the `CodingKeys` enum for `LocalPaymentPayPalAccountsPOSTBody`.

**Demo application change:**

* Updated the authorization value in `IdealViewController.swift` to use a hardcoded sandbox token instead of a variable, likely for testing purposes.

| Main branch | 🐛 | 🧼 |
| ------- | ------- | ------- |
| <img width="1441" height="448" alt="Screenshot 2025-08-07 at 3 58 17 p m" src="https://github.com/user-attachments/assets/54d44af3-c5ff-4851-aae5-ff3a4e97dcce" /> | <img width="742" height="417" alt="Screenshot 2025-08-07 at 3 59 51 p m" src="https://github.com/user-attachments/assets/c181e62b-5daf-45ef-a34c-953fc6e50142" /> | <img width="1437" height="442" alt="Screenshot 2025-08-07 at 3 59 01 p m" src="https://github.com/user-attachments/assets/dcf90711-b96a-4ad6-a3e6-d9d54348a9d9" /> |

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
