### PR TITLE
Add required query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreePayPal
   * Fix an issue where `BTPayPalRequest` was sending `phone_number` instead of `payer_phone`
+  * Add `merchant` and `flow_type` as query parameters to the app switch URL.
 
 ## 6.36.0 (2025-08-13)
 * BraintreeCore

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -145,7 +145,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
 
-        let request = BTPayPalCheckoutRequest(amount: "5.00")
+        let request = BTPayPalCheckoutRequest(amount: "5.00", offerPayLater: payLaterToggle.isOn)
         request.userAuthenticationEmail = emailTextField.text
         request.userPhoneNumber = BTPayPalPhoneNumber(
             countryCode: countryCodeTextField.text ?? "",
@@ -247,7 +247,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             userAuthenticationEmail: emailTextField.text,
             enablePayPalAppSwitch: true,
             amount: "10.00",
-            userAction: .payNow
+            userAction: .payNow,
+            offerPayLater: payLaterToggle.isOn
         )
 
         payPalClient.tokenize(request) { nonce, error in

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -145,7 +145,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
 
-        let request = BTPayPalCheckoutRequest(amount: "5.00", offerPayLater: payLaterToggle.isOn)
+        let request = BTPayPalCheckoutRequest(amount: "50.00", offerPayLater: payLaterToggle.isOn)
         request.userAuthenticationEmail = emailTextField.text
         request.userPhoneNumber = BTPayPalPhoneNumber(
             countryCode: countryCodeTextField.text ?? "",
@@ -246,7 +246,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let request = BTPayPalCheckoutRequest(
             userAuthenticationEmail: emailTextField.text,
             enablePayPalAppSwitch: true,
-            amount: "10.00",
+            amount: "50.00",
             userAction: .payNow,
             offerPayLater: payLaterToggle.isOn
         )

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -246,7 +246,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let request = BTPayPalCheckoutRequest(
             userAuthenticationEmail: emailTextField.text,
             enablePayPalAppSwitch: true,
-            amount: "10.00"
+            amount: "10.00",
+            userAction: .payNow
         )
 
         payPalClient.tokenize(request) { nonce, error in

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -145,7 +145,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
 
-        let request = BTPayPalCheckoutRequest(amount: "50.00", offerPayLater: payLaterToggle.isOn)
+        // pay later is only available on amounts greater than or equal to 35
+        let amount = payLaterToggle.isOn ? "35.00" : "5.00"
+        let request = BTPayPalCheckoutRequest(amount: amount, offerPayLater: payLaterToggle.isOn)
         request.userAuthenticationEmail = emailTextField.text
         request.userPhoneNumber = BTPayPalPhoneNumber(
             countryCode: countryCodeTextField.text ?? "",
@@ -243,10 +245,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
         
+        // pay later is only available on amounts greater than or equal to 35
+        let amount = payLaterToggle.isOn ? "35.00" : "10.00"
         let request = BTPayPalCheckoutRequest(
             userAuthenticationEmail: emailTextField.text,
             enablePayPalAppSwitch: true,
-            amount: "50.00",
+            amount: amount,
             userAction: .payNow,
             offerPayLater: payLaterToggle.isOn
         )

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -455,7 +455,7 @@ import BraintreeDataCollector
                         return
                     }
                     let merchantAccountID = json["merchantId"].asString()
-                    self.launchPayPalApp(with: url, merchantAccountId: merchantAccountId, completion: completion)
+                    self.launchPayPalApp(with: url, merchantAccountID: merchantAccountID, completion: completion)
                 case .webBrowser(let url):
                     self.didPayPalServerAttemptAppSwitch = false
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)
@@ -504,7 +504,7 @@ import BraintreeDataCollector
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000)))),
             URLQueryItem(name: "flow_type", value: isVaultRequest ? "va" : "ecs"),
-            URLQueryItem(name: "merchant", value: merchantAccountId ?? "unknown")
+            URLQueryItem(name: "merchant", value: merchantAccountID ?? "unknown")
         ]
         
         urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -500,7 +500,9 @@ import BraintreeDataCollector
         var urlComponents = URLComponents(url: payPalAppRedirectURL, resolvingAgainstBaseURL: true)
         let additionalQueryItems: [URLQueryItem] = [
             URLQueryItem(name: "source", value: "braintree_sdk"),
-            URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000))))
+            URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000)))),
+            URLQueryItem(name: "flow_type", value: isVaultRequest ? "va" : "ecs"),
+            URLQueryItem(name: "merchant", value: payPalRequest?.merchantAccountID ?? "unknown")
         ]
         
         urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -466,7 +466,7 @@ import BraintreeDataCollector
 
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
-        merchantAccountId: String? = nil,
+        merchantAccountID: String? = nil,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         /// Prevent multiple calls to open the app

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -454,7 +454,7 @@ import BraintreeDataCollector
                         )
                         return
                     }
-                    let merchantAccountId = json["merchantId"].asString()
+                    let merchantAccountID = json["merchantId"].asString()
                     self.launchPayPalApp(with: url, merchantAccountId: merchantAccountId, completion: completion)
                 case .webBrowser(let url):
                     self.didPayPalServerAttemptAppSwitch = false

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -466,7 +466,7 @@ import BraintreeDataCollector
 
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
-        merchantAccountId: String?,
+        merchantAccountId: String? = nil,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         /// Prevent multiple calls to open the app

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -454,7 +454,8 @@ import BraintreeDataCollector
                         )
                         return
                     }
-                    self.launchPayPalApp(with: url, completion: completion)
+                    let merchantAccountId = json["merchantId"].asString()
+                    self.launchPayPalApp(with: url, merchantAccountId: merchantAccountId, completion: completion)
                 case .webBrowser(let url):
                     self.didPayPalServerAttemptAppSwitch = false
                     self.handlePayPalRequest(with: url, paymentType: request.paymentType, completion: completion)
@@ -465,6 +466,7 @@ import BraintreeDataCollector
 
     private func launchPayPalApp(
         with payPalAppRedirectURL: URL,
+        merchantAccountId: String?,
         completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
     ) {
         /// Prevent multiple calls to open the app
@@ -502,7 +504,7 @@ import BraintreeDataCollector
             URLQueryItem(name: "source", value: "braintree_sdk"),
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000)))),
             URLQueryItem(name: "flow_type", value: isVaultRequest ? "va" : "ecs"),
-            URLQueryItem(name: "merchant", value: payPalRequest?.merchantAccountID ?? "unknown")
+            URLQueryItem(name: "merchant", value: merchantAccountId ?? "unknown")
         ]
         
         urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -874,6 +874,10 @@ class BTPayPalClient_Tests: XCTestCase {
         } else {
             XCTFail("Expected integer value for query param `switch_initiated_time`")
         }
+        XCTAssertEqual(urlComponents?.queryItems?[3].name, "flow_type")
+        XCTAssertEqual(urlComponents?.queryItems?[3].value, "va")
+        XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
+        XCTAssertEqual(urlComponents?.queryItems?[4].value, "unknown")
     }
 
     func testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError() {
@@ -989,6 +993,10 @@ class BTPayPalClient_Tests: XCTestCase {
         } else {
             XCTFail("Expected integer value for query param `switch_initiated_time`")
         }
+        XCTAssertEqual(urlComponents?.queryItems?[3].name, "flow_type")
+        XCTAssertEqual(urlComponents?.queryItems?[3].value, "ecs")
+        XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
+        XCTAssertEqual(urlComponents?.queryItems?[4].value, "unknown")
     }
     
     func testTokenizeCheckoutAccount_whenPayPalAppApprovalURLMissingECToken_returnsError() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -14,7 +14,8 @@ class BTPayPalClient_Tests: XCTestCase {
         mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")!
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: [
             "paypalEnabled": true,
-            "paypal": ["environment": "offline"]
+            "paypal": ["environment": "offline"],
+            "merchantId": "testMerchantId"
         ] as [String: Any])
         mockAPIClient.cannedResponseBody = BTJSON(value: [
             "paymentResource": ["redirectUrl": "http://fakeURL.com"]
@@ -877,7 +878,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].name, "flow_type")
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "va")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
-        XCTAssertEqual(urlComponents?.queryItems?[4].value, "unknown")
+        XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
     }
 
     func testTokenizeVaultAccount_whenPayPalAppApprovalURLMissingBAToken_returnsError() {
@@ -996,7 +997,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].name, "flow_type")
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "ecs")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
-        XCTAssertEqual(urlComponents?.queryItems?[4].value, "unknown")
+        XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
     }
     
     func testTokenizeCheckoutAccount_whenPayPalAppApprovalURLMissingECToken_returnsError() {


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- Added new query parameters that will be required from the PayPal app switch universal link.
- Updated the Demo App so that we'd be able to test the Pay Later functionality.

### Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> @nastassiarodzik

### Video
Pay later functionality on One time checkout flow:
https://github.com/user-attachments/assets/9ab4fe2f-9908-40e5-beaf-7ce725bc95b1


