### PR TITLE
Feature: Add Payment ID to PayPal Nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreePayPal
   * Fix an issue where `BTPayPalRequest` was sending `phone_number` instead of `payer_phone`
-  * Add `payPalOrderID` to `BTPayPalAccountNonce`
+  * Add `paymentID` to `BTPayPalAccountNonce`
 
 ## 6.36.0 (2025-08-13)
 * BraintreeCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreePayPal
   * Fix an issue where `BTPayPalRequest` was sending `phone_number` instead of `payer_phone`
+  * Add `payPalOrderID` to `BTPayPalAccountNonce`
 
 ## 6.36.0 (2025-08-13)
 * BraintreeCore

--- a/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
+++ b/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
@@ -36,6 +36,9 @@ import BraintreeCore
     /// Will be provided for Vault and Checkout.
     public let creditFinancing: BTPayPalCreditFinancing?
     
+    /// The PayPal order ID associated with this transaction.
+    public let payPalOrderID: String?
+    
     init?(json: BTJSON) {
         guard let nonce = json["nonce"].asString() else { return nil }
         
@@ -51,6 +54,7 @@ import BraintreeCore
         self.clientMetadataID = details["correlationId"].asString()
         self.payerID = payerInfo["payerId"].asString()
         self.creditFinancing = details["creditFinancingOffered"].asPayPalCreditFinancing()
+        self.payPalOrderID = details["paymentToken"].asString()
         super.init(nonce: nonce, type: "PayPal", isDefault: json["default"].isTrue)
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
+++ b/Sources/BraintreePayPal/BTPayPalAccountNonce.swift
@@ -36,8 +36,8 @@ import BraintreeCore
     /// Will be provided for Vault and Checkout.
     public let creditFinancing: BTPayPalCreditFinancing?
     
-    /// The PayPal order ID associated with this transaction.
-    public let payPalOrderID: String?
+    /// The payment ID associated with this transaction.
+    public let paymentID: String?
     
     init?(json: BTJSON) {
         guard let nonce = json["nonce"].asString() else { return nil }
@@ -54,7 +54,7 @@ import BraintreeCore
         self.clientMetadataID = details["correlationId"].asString()
         self.payerID = payerInfo["payerId"].asString()
         self.creditFinancing = details["creditFinancingOffered"].asPayPalCreditFinancing()
-        self.payPalOrderID = details["paymentToken"].asString()
+        self.paymentID = details["paymentToken"].asString()
         super.init(nonce: nonce, type: "PayPal", isDefault: json["default"].isTrue)
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
@@ -78,6 +78,7 @@ final class BTPayPalAccountNonce_Tests: XCTestCase {
                     "description": "jane.doe@example.com",
                     "details": [
                         "email": "jane.doe@example.com",
+                        "paymentToken": "fake-order-id",
                         "creditFinancingOffered": [
                             "cardAmountImmutable": true,
                             "monthlyPayment": [
@@ -109,6 +110,7 @@ final class BTPayPalAccountNonce_Tests: XCTestCase {
         XCTAssertEqual(payPalAccountNonce?.type, "PayPal")
         XCTAssertEqual(payPalAccountNonce?.email, "jane.doe@example.com")
         XCTAssertTrue(payPalAccountNonce!.isDefault)
+        XCTAssertEqual(payPalAccountNonce?.payPalOrderID, "fake-order-id")
 
         guard let creditFinancing = payPalAccountNonce?.creditFinancing else {
             XCTFail("Expected credit financing terms")

--- a/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAccountNonce_Tests.swift
@@ -110,7 +110,7 @@ final class BTPayPalAccountNonce_Tests: XCTestCase {
         XCTAssertEqual(payPalAccountNonce?.type, "PayPal")
         XCTAssertEqual(payPalAccountNonce?.email, "jane.doe@example.com")
         XCTAssertTrue(payPalAccountNonce!.isDefault)
-        XCTAssertEqual(payPalAccountNonce?.payPalOrderID, "fake-order-id")
+        XCTAssertEqual(payPalAccountNonce?.paymentID, "fake-order-id")
 
         guard let creditFinancing = payPalAccountNonce?.creditFinancing else {
             XCTFail("Expected credit financing terms")


### PR DESCRIPTION
### Summary of changes

- Add `paymentID` to `BTPayPalAccountNonce` - tested and verified we are getting this value as expected in sandbox
- Android PR: https://github.com/braintree/braintree_android/pull/1405

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
