### PR TITLE
[OPEN DEV] Update `release.yml` for Cocoapods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,5 +168,6 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-        git checkout ${{ github.event.inputs.version }}
-        pod trunk push Braintree.podspec
+          git stash
+          git checkout ${{ github.event.inputs.version }}
+          pod trunk push Braintree.podspec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,4 +167,6 @@ jobs:
       - name: Publish to CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push Braintree.podspec
+        run: |
+        git checkout ${{ github.event.inputs.version }}
+        pod trunk push Braintree.podspec


### PR DESCRIPTION
### Summary of changes

Recently we received the error `[!] The specified path Braintree.podspec does not point to an existing podspec file.` when doing releases. I think this is due to change in the runners where we are attempting to push the `Braintree.podspec` from the `gh-pages` branch previous to this step. This PR updated to stash and diff, checkout the release tag, then do `pod trunk push`. Hoping my theory is correct but no way to test until the next release. 😅 

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
