### PR TITLE
Include RP fields in App Switch flow for BT iOS SDK

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -218,6 +218,14 @@ import BraintreeCore
         parameters["return_url"] = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)success"
         parameters["cancel_url"] = BTCoreConstants.callbackURLScheme + "://\(BTPayPalRequest.callbackURLHostAndPath)cancel"
         parameters["experience_profile"] = experienceProfile
+        
+        if let recurringBillingPlanType {
+            parameters["plan_type"] = recurringBillingPlanType.rawValue
+        }
+
+        if let recurringBillingDetails {
+            parameters["plan_metadata"] = recurringBillingDetails.parameters()
+        }
  
         if let universalLink, enablePayPalAppSwitch, isPayPalAppInstalled {
             let appSwitchParameters: [String: Any] = [
@@ -228,14 +236,6 @@ import BraintreeCore
             ]
             
             return parameters.merging(appSwitchParameters) { $1 }
-        }
-
-        if let recurringBillingPlanType {
-            parameters["plan_type"] = recurringBillingPlanType.rawValue
-        }
-
-        if let recurringBillingDetails {
-            parameters["plan_metadata"] = recurringBillingDetails.parameters()
         }
         
         return parameters


### PR DESCRIPTION

### Summary of changes

- Identified an issue where Recurring Payment (RP) fields (plan_type and plan_metadata) were not being appended during the App Switch flow due to an early return in BTPayPalRequest.parameters. The flow breaks starting from this [commit](https://github.com/braintree/braintree_ios/commit/abb4adc3570f471ba82b5c141275de938bb147fc#diff-12a919f5b0b117b30354b85383385d0c8885df582c4974647e7407f0804518cf) .
- Moved the logic for setting RP fields above the enableAppSwitch condition, ensuring they are included for both App Switch and non-App Switch flows.
- Verified that the RP fields are now correctly passed in the final parameters during App Switch.


### Checklist

- [ ] Verified that RP fields are included in both App Switch and non-App Switch flows
- [ ] Tested with **checkout-rba-metadata-feature** branch for RP without purchase

### Authors
@karthikeyan-2907
