### PR TITLE
 Instrument and capture merchant userAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * BraintreePayPal
   * Add `recurringBillingDetails`, `recurringBillingPlanType`, and `amountBreakdown` properties to `BTPayPalCheckoutRequest`. Enables RBA metadata to be passed for the PayPal Checkout Vault with Purchase flow
   * Add `userAction` property to `BTPayPalVaultRequest`
+  * Add `userAction` property to `BTPayPalRequest` and refactor `BTPayPalRequestUserAction` enum:
+    * Deprecate `.none`, add `.continue` and `.unknown` cases.
+    * Update initializers to support explicit merchant intent.
+  * Instrument analytics to include new `merchantPassedUserAction` field in all PayPal checkout events.
 
 ## 6.38.0 (2025-09-09)
 * BraintreeShopperInsights (BETA)

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -64,6 +64,8 @@ struct FPTIBatchData: Codable {
         let didPayPalServerAttemptAppSwitch: Bool?
         /// The experiment details associated with a shopper insights flow
         let merchantExperiment: String?
+        /// Captures userAction value provided by the merchant and distinguish explicit vs. default SDK behavior
+        let merchantPassedUserAction: String?
         /// The type of page where the payment button is displayed or where an event occured.
         let pageType: String?
         /// UTC millisecond timestamp when a networking task started requesting a resource. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
@@ -94,6 +96,7 @@ struct FPTIBatchData: Codable {
             isVaultRequest: Bool? = nil,
             linkType: String? = nil,
             merchantExperiment: String? = nil,
+            merchantPassedUserAction: String? = nil,
             pageType: String? = nil,
             requestStartTime: Int? = nil,
             shopperSessionID: String? = nil,
@@ -117,6 +120,7 @@ struct FPTIBatchData: Codable {
             self.isVaultRequest = isVaultRequest
             self.linkType = linkType
             self.merchantExperiment = merchantExperiment
+            self.merchantPassedUserAction = merchantPassedUserAction
             self.pageType = pageType
             self.requestStartTime = requestStartTime
             self.shopperSessionID = shopperSessionID
@@ -140,6 +144,7 @@ struct FPTIBatchData: Codable {
             case isVaultRequest = "is_vault"
             case linkType = "link_type"
             case merchantExperiment = "experiment"
+            case merchantPassedUserAction = "merchant_passed_user_action"
             case pageType = "page_type"
             case requestStartTime = "request_start_time"
             case timestamp = "t"

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -314,6 +314,7 @@ import UIKit
         didPayPalServerAttemptAppSwitch: Bool? = nil,
         errorDescription: String? = nil,
         merchantExperiment: String? = nil,
+        merchantPassedUserAction: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
@@ -337,6 +338,7 @@ import UIKit
                 isVaultRequest: isVaultRequest,
                 linkType: linkType?.rawValue,
                 merchantExperiment: merchantExperiment,
+                merchantPassedUserAction: merchantPassedUserAction,
                 pageType: pageType,
                 shopperSessionID: shopperSessionID
             )

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -75,7 +75,7 @@ import BraintreeCore
     ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
     ///   - amount: Required: Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
     ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
-    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.none`.
+    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.unknown`.
     ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
     ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
     ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
@@ -88,7 +88,7 @@ import BraintreeCore
         enablePayPalAppSwitch: Bool,
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
-        userAction: BTPayPalRequestUserAction = .none,
+        userAction: BTPayPalRequestUserAction = .unknown,
         offerPayLater: Bool = false,
         currencyCode: String? = nil,
         requestBillingAgreement: Bool = false,
@@ -111,7 +111,7 @@ import BraintreeCore
     ///   - amount: Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.'
     ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
     ///   and is limited to 7 digits before the decimal point.
-    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.none`.
+    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.unknown`.
     ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
     ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
     ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
@@ -126,7 +126,7 @@ import BraintreeCore
     public init(
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
-        userAction: BTPayPalRequestUserAction = .none,
+        userAction: BTPayPalRequestUserAction = .unknown,
         offerPayLater: Bool = false,
         currencyCode: String? = nil,
         requestBillingAgreement: Bool = false,

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -220,6 +220,7 @@ import BraintreeDataCollector
             correlationID: contextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -329,6 +330,7 @@ import BraintreeDataCollector
                 contextType: contextType,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                 isVaultRequest: isVaultRequest
             )
             BTPayPalClient.payPalClient = self
@@ -342,6 +344,7 @@ import BraintreeDataCollector
                 contextType: contextType,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                 isVaultRequest: isVaultRequest
             )
             
@@ -432,6 +435,7 @@ import BraintreeDataCollector
             applicationState: UIApplication.shared.applicationStateString,
             contextType: contextType,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -525,6 +529,7 @@ import BraintreeDataCollector
                 contextType: contextType,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                 isVaultRequest: isVaultRequest,
                 shopperSessionID: payPalRequest?.shopperSessionID
             )
@@ -543,6 +548,7 @@ import BraintreeDataCollector
             contextType: contextType,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -581,6 +587,7 @@ import BraintreeDataCollector
             contextType: contextType,
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -631,6 +638,7 @@ import BraintreeDataCollector
                     contextType: contextType,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                    merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                     isConfigFromCache: isConfigFromCache,
                     isVaultRequest: isVaultRequest,
                     shopperSessionID: payPalRequest?.shopperSessionID
@@ -644,6 +652,7 @@ import BraintreeDataCollector
                     contextType: contextType,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                    merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                     isVaultRequest: isVaultRequest,
                     shopperSessionID: payPalRequest?.shopperSessionID
                 )
@@ -661,6 +670,7 @@ import BraintreeDataCollector
                     contextType: contextType,
                     didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                     didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                    merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                     isVaultRequest: isVaultRequest
                 )
             }
@@ -680,6 +690,7 @@ import BraintreeDataCollector
                 contextType: contextType,
                 didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+                merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
                 isVaultRequest: isVaultRequest,
                 shopperSessionID: payPalRequest?.shopperSessionID
             )
@@ -716,6 +727,7 @@ import BraintreeDataCollector
             correlationID: contextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -732,6 +744,7 @@ import BraintreeDataCollector
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
             errorDescription: error.localizedDescription,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )
@@ -746,6 +759,7 @@ import BraintreeDataCollector
             correlationID: contextID.flatMap { clientMetadataIDs[$0] },
             didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
             didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction: payPalRequest?.userAction.analyticsValue,
             isVaultRequest: isVaultRequest,
             shopperSessionID: payPalRequest?.shopperSessionID
         )

--- a/Sources/BraintreePayPal/BTPayPalRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequest.swift
@@ -111,7 +111,7 @@ import BraintreeCore
     /// Optional: Recurring billing product details.
     public var recurringBillingDetails: BTPayPalRecurringBillingDetails?
     
-    /// Optional: Changes the call-to-action in the PayPal flow. Defaults to `.none`.
+    /// Optional: Changes the call-to-action in the PayPal flow. Defaults to `.unknown`.
     public var userAction: BTPayPalRequestUserAction
 
     // MARK: - Internal Properties
@@ -145,7 +145,7 @@ import BraintreeCore
         shopperSessionID: String? = nil,
         recurringBillingDetails: BTPayPalRecurringBillingDetails? = nil,
         recurringBillingPlanType: BTPayPalRecurringBillingPlanType? = nil,
-        userAction: BTPayPalRequestUserAction = .none
+        userAction: BTPayPalRequestUserAction = .unknown
     ) {
         self.hermesPath = hermesPath
         self.paymentType = paymentType
@@ -192,8 +192,10 @@ import BraintreeCore
         }
 
         experienceProfile["address_override"] = shippingAddressOverride != nil ? !isShippingAddressEditable : false
-        
-        if userAction != .none {
+
+        // Only set experienceProfile user_action for explicit actions like .payNow, .setupNow or future cases.
+        // For .continue, .none, and .unknown, do not set user_action. As they all use the default "continue" flow.
+        if ![.continue, .none, .unknown].contains(userAction) {
             experienceProfile["user_action"] = userAction.stringValue
         }
 

--- a/Sources/BraintreePayPal/BTPayPalRequestUserAction.swift
+++ b/Sources/BraintreePayPal/BTPayPalRequestUserAction.swift
@@ -9,7 +9,7 @@
 ///  Setting the `BTPayPalVaultRequest.userAction` to `.setupNow` changes the button text to "Setup Now", conveying to
 ///  the user that the funding instrument will be set up for future payments.
 @objc public enum BTPayPalRequestUserAction: Int {
-    /// Default
+    @available(*, deprecated, message: "Use a specific user action like `.payNow`, `.continue`, or `.setupNow`. `.none` will be removed.")
     case none
 
     /// Pay Now - this value can only be passed for the `BTPayPalCheckoutRequest`
@@ -17,6 +17,12 @@
     
     /// Setup Now - this value can only be passed for the `BTPayPalVaultRequest`
     case setupNow
+
+    /// Continue
+    case `continue`
+
+    /// Reserved for unknown or unsupported values.
+    case unknown
 
     var stringValue: String {
         switch self {
@@ -26,6 +32,19 @@
             return "setup_now"
         default:
             return ""
+        }
+    }
+
+    var analyticsValue: String {
+        switch self {
+        case .payNow:
+            return "pay"
+        case .setupNow:
+            return "setup_now"
+        case .continue, .none:
+            return "continue"
+        case .unknown:
+            return "none"
         }
     }
 }

--- a/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultBaseRequest.swift
@@ -21,14 +21,14 @@ import BraintreeCore
     ///   - enablePayPalAppSwitch: Optional: Used to determine if the customer will use the PayPal app switch flow. Defaults to `false`.
     ///   - recurringBillingDetails: Optional: Recurring billing product details.
     ///   - recurringBillingPlanType: Optional: Recurring billing plan type, or charge pattern.
-    ///   - userAction: Optional: Changes the call-to-action in the PayPal Vault flow. Defaults to `.none`.
+    ///   - userAction: Optional: Changes the call-to-action in the PayPal Vault flow. Defaults to `.unknown`.
     public init(
         offerCredit: Bool = false,
         userAuthenticationEmail: String? = nil,
         enablePayPalAppSwitch: Bool = false,
         recurringBillingDetails: BTPayPalRecurringBillingDetails? = nil,
         recurringBillingPlanType: BTPayPalRecurringBillingPlanType? = nil,
-        userAction: BTPayPalRequestUserAction = .none
+        userAction: BTPayPalRequestUserAction = .unknown
     ) {
         self.offerCredit = offerCredit
         

--- a/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalVaultRequest.swift
@@ -34,13 +34,13 @@ import BraintreeCore
     ///   - recurringBillingDetails: Optional: Recurring billing product details.
     ///   - recurringBillingPlanType: Optional: Recurring billing plan type, or charge pattern.
     ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    ///   - userAction: Optional: Changes the call-to-action in the PayPal Vault flow. Defaults to `.none`.
+    ///   - userAction: Optional: Changes the call-to-action in the PayPal Vault flow. Defaults to `.unknown`.
     public init(
         offerCredit: Bool = false,
         recurringBillingDetails: BTPayPalRecurringBillingDetails? = nil,
         recurringBillingPlanType: BTPayPalRecurringBillingPlanType? = nil,
         userAuthenticationEmail: String? = nil,
-        userAction: BTPayPalRequestUserAction = .none
+        userAction: BTPayPalRequestUserAction = .unknown
     ) {
         super.init(
             offerCredit: offerCredit,

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -66,7 +66,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
 
     func testUserActionAsString_whenUserActionIsDefault_returnsEmptyString() {
         let request = BTPayPalCheckoutRequest(amount: "1")
-        request.userAction = .none
+        request.userAction = .unknown
         XCTAssertEqual(request.userAction.stringValue, "")
     }
 
@@ -74,6 +74,32 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         let request = BTPayPalCheckoutRequest(amount: "1")
         request.userAction = .payNow
         XCTAssertEqual(request.userAction.stringValue, "commit")
+    }
+
+    // MARK: - userAction AnalyticsValue
+
+    func testUserActionAnalyticsValue_whenUserActionIsPayNow_returnsPay() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .payNow
+        XCTAssertEqual(request.userAction.analyticsValue, "pay")
+    }
+
+    func testUserActionAnalyticsValue_whenUserActionIsContinue_returnsContinue() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .continue
+        XCTAssertEqual(request.userAction.analyticsValue, "continue")
+    }
+
+    func testUserActionAnalyticsValue_whenUserActionIsNone_returnsContinue() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .none
+        XCTAssertEqual(request.userAction.analyticsValue, "continue")
+    }
+
+    func testUserActionAnalyticsValue_whenUserActionIsUnknown_returnsNone() {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .unknown
+        XCTAssertEqual(request.userAction.analyticsValue, "none")
     }
 
     // MARK: - parametersWithConfiguration

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1380,4 +1380,40 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertEqual(mockAPIClient.postedApplicationState, "active")
     }
+
+    func testTokenize_whenCheckoutRequest_setsMerchantPassedUserActionWithPayNow() async {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .payNow
+
+        let _ = try? await payPalClient.tokenize(request)
+
+        XCTAssertEqual(mockAPIClient.postedMerchantPassedUserAction, "pay")
+    }
+
+    func testTokenize_whenCheckoutRequest_setsMerchantPassedUserActionWithContinue() async {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .continue
+
+        let _ = try? await payPalClient.tokenize(request)
+
+        XCTAssertEqual(mockAPIClient.postedMerchantPassedUserAction, "continue")
+    }
+
+    func testTokenize_whenCheckoutRequest_setsMerchantPassedUserActionWithUnknown() async {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        request.userAction = .unknown
+
+        let _ = try? await payPalClient.tokenize(request)
+
+        XCTAssertEqual(mockAPIClient.postedMerchantPassedUserAction, "none")
+    }
+
+    func testTokenize_whenCheckoutRequest_setsMerchantPassedUserActionWithDefault() async {
+        let request = BTPayPalCheckoutRequest(amount: "1")
+        // Do not set userAction, uses default (.unknown)
+
+        let _ = try? await payPalClient.tokenize(request)
+
+        XCTAssertEqual(mockAPIClient.postedMerchantPassedUserAction, "none")
+    }
 }

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -19,6 +19,7 @@ public class MockAPIClient: BTAPIClient {
     public var postedIsVaultRequest = false
     public var postedLinkType: LinkType? = nil
     public var postedMerchantExperiment: String? = nil
+    public var postedMerchantPassedUserAction: String? = nil
     public var postedPageType: String? = nil
     public var postedContextID: String? = nil
     public var postedShopperSessionID: String? = nil
@@ -113,6 +114,7 @@ public class MockAPIClient: BTAPIClient {
         didPayPalServerAttemptAppSwitch: Bool? = nil,
         errorDescription: String? = nil,
         merchantExperiment experiment: String? = nil,
+        merchantPassedUserAction: String? = nil,
         isConfigFromCache: Bool? = nil,
         isVaultRequest: Bool? = nil,
         linkType: LinkType? = nil,
@@ -127,6 +129,7 @@ public class MockAPIClient: BTAPIClient {
         postedLinkType = linkType
         postedIsVaultRequest = isVaultRequest ?? false
         postedMerchantExperiment = experiment
+        postedMerchantPassedUserAction = merchantPassedUserAction
         postedAppSwitchURL[eventName] = appSwitchURL?.absoluteString
         postedShopperSessionID = shopperSessionID
         postedDidEnablePayPalAppSwitch = didEnablePayPalAppSwitch


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
1. Add userAction property to `BTPayPalRequest` and refactor `BTPayPalRequestUserAction` enum: 
          - Deprecate .none, add .continue and .unknown cases. 
          - Update initializers to support explicit merchant intent.
2. Instrument analytics to include new merchantPassedUserAction field in all PayPal Checkout events.
3. Update unit tests to cover new userAction logic and analytics instrumentation.


Below are screenshots showing the FPTI analytics payload for each possible BTPayPalRequestUserAction value, as currently mapped in the code:

**1. userAction = .none**
<img width="1111" height="297" alt="None-Continue" src="https://github.com/user-attachments/assets/020081fd-0bca-4263-a087-61046472cd15" />
Image: FPTI analytics payload when userAction is set to .none (deprecated, but still possible in legacy integrations).

**2. userAction = .payNow**
<img width="1099" height="305" alt="PayNow-Pay" src="https://github.com/user-attachments/assets/37a87aac-147d-4879-b22d-a4adb5b7eeb8" />
Image: FPTI analytics payload when userAction is set to .payNow (explicit merchant intent to show “Pay Now”).

**3. userAction = .continue**
<img width="1098" height="296" alt="Continue-Continue" src="https://github.com/user-attachments/assets/97a3978b-37d9-4aae-910b-067e34f1e187" />
Image: FPTI analytics payload when userAction is set to .continue (explicit merchant intent to show “Continue”).

**4. userAction = .unknown**
<img width="1100" height="301" alt="Unknow-none" src="https://github.com/user-attachments/assets/b6331340-b580-47c4-b123-dd6b5ab7d55e" />
Image: FPTI analytics payload when userAction is set to .unknown (reserved for unknown or unset values).

**Tested and Confirmed Payment Video Post Change:**
https://github.com/user-attachments/assets/28b63531-02f5-4c52-9c47-a90df37724c9


### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @balaji-umasankar
