### PR TITLE
[v7] Checkout RBA Metadata

### DIFF
--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -28,7 +28,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
     private var recipientPhoneNumber: BTPayPalPhoneNumber?
     private var recipientEmail: String?
     private var recurringBillingDetails: BTPayPalRecurringBillingDetails?
-    private var recurringBillingPlanType: BTPayPalRecurringBillingPlanType??
+    private var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
     private var requestBillingAgreement: Bool?
     private var riskCorrelationID: String?
     private var shippingCallbackURL: String?

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -16,7 +16,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
     private let cancelURL: String
     private let experienceProfile: PayPalExperienceProfile
     
-    private var userPhoneNumber: BTPayPalPhoneNumber?
+    private var amountBreakdown: BTAmountBreakdown?
     private var billingAgreementDescription: BillingAgreementDescription?
     private var enablePayPalAppSwitch: Bool?
     private var contactPreference: String?
@@ -27,12 +27,15 @@ struct PayPalCheckoutPOSTBody: Encodable {
     private var osVersion: String?
     private var recipientPhoneNumber: BTPayPalPhoneNumber?
     private var recipientEmail: String?
+    private var recurringBillingDetails: BTPayPalRecurringBillingDetails?
+    private var recurringBillingPlanType: BTPayPalRecurringBillingPlanType??
     private var requestBillingAgreement: Bool?
     private var riskCorrelationID: String?
     private var shippingCallbackURL: String?
     private var shopperSessionID: String?
     private var universalLink: String?
     private var userAuthenticationEmail: String?
+    private var userPhoneNumber: BTPayPalPhoneNumber?
     
     // Address properties
     private var streetAddress: String?
@@ -55,6 +58,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.amount = payPalRequest.amount
         self.intent = payPalRequest.intent.stringValue
         self.offerPayLater = payPalRequest.offerPayLater
+        self.amountBreakdown = payPalRequest.amountBreakdown
         
         let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode
         
@@ -122,7 +126,15 @@ struct PayPalCheckoutPOSTBody: Encodable {
             !userPhoneNumber.nationalNumber.isEmpty {
             self.userPhoneNumber = userPhoneNumber
         }
+        
+        if let recurringBillingPlanType = payPalRequest.recurringBillingPlanType {
+            self.recurringBillingPlanType = recurringBillingPlanType
+        }
 
+        if let recurringBillingDetails = payPalRequest.recurringBillingDetails {
+            self.recurringBillingDetails = recurringBillingDetails
+        }
+        
         self.returnURL = BTCoreConstants.callbackURLScheme + "://\(PayPalRequestConstants.callbackURLHostAndPath)success"
         self.cancelURL = BTCoreConstants.callbackURLScheme + "://\(PayPalRequestConstants.callbackURLHostAndPath)cancel"
         self.experienceProfile = PayPalExperienceProfile(payPalRequest: payPalRequest, configuration: configuration)
@@ -137,6 +149,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
     
     enum CodingKeys: String, CodingKey {
         case amount
+        case amountBreakdown = "amount_breakdown"
         case billingAgreementDescription = "billing_agreement_details"
         case cancelURL = "cancel_url"
         case contactPreference = "contact_preference"
@@ -151,6 +164,8 @@ struct PayPalCheckoutPOSTBody: Encodable {
         case osVersion = "os_version"
         case recipientPhoneNumber = "international_phone"
         case recipientEmail = "recipient_email"
+        case recurringBillingDetails = "plan_metadata"
+        case recurringBillingPlanType = "plan_type"
         case requestBillingAgreement = "request_billing_agreement"
         case returnURL = "return_url"
         case riskCorrelationID = "correlation_id"

--- a/Sources/BraintreePayPal/RecurringBillingMetadata/BTAmountBreakdown.swift
+++ b/Sources/BraintreePayPal/RecurringBillingMetadata/BTAmountBreakdown.swift
@@ -4,7 +4,7 @@ import Foundation
 /// customize how the transaction amount is broken down. If `BTAmountBreakdown` is provided, `itemTotal`
 /// is required. Some fields are conditionally required or not accepted depending on the checkout flow (e.g., one-time
 /// vs subscription).
-public struct BTAmountBreakdown {
+public struct BTAmountBreakdown: Encodable {
 
     // MARK: - Private Properties
 
@@ -16,6 +16,16 @@ public struct BTAmountBreakdown {
     private let shippingDiscount: String?
     private let discountTotal: String?
 
+    private enum CodingKeys: String, CodingKey {
+        case itemTotal = "item_total"
+        case taxTotal = "tax_total"
+        case shippingTotal = "shipping"
+        case handlingTotal = "handling"
+        case insuranceTotal = "insurance"
+        case shippingDiscount = "shipping_discount"
+        case discountTotal = "discount"
+    }
+    
     // MARK: - Initializer
 
     /// Initialize a `BTAmountBreakdown` object.
@@ -43,39 +53,5 @@ public struct BTAmountBreakdown {
         self.insuranceTotal = insuranceTotal
         self.shippingDiscount = shippingDiscount
         self.discountTotal = discountTotal
-    }
-
-    // MARK: - Internal Methods
-
-    func parameters() -> [String: String] {
-        var parameters: [String: String] = [
-            "item_total": itemTotal
-        ]
-
-        if let taxTotal {
-            parameters["tax_total"] = taxTotal
-        }
-
-        if let shippingTotal {
-            parameters["shipping"] = shippingTotal
-        }
-
-        if let handlingTotal {
-            parameters["handling"] = handlingTotal
-        }
-
-        if let insuranceTotal {
-            parameters["insurance"] = insuranceTotal
-        }
-
-        if let shippingDiscount {
-            parameters["shipping_discount"] = shippingDiscount
-        }
-
-        if let discountTotal {
-            parameters["discount"] = discountTotal
-        }
-
-        return parameters
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -419,16 +419,23 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         )
 
         let request = BTPayPalCheckoutRequest(amount: "1.00", amountBreakdown: amountBreakdown)
-        let parameters = request.parameters(with: configuration)
-        let amountParameters = request.amountBreakdown?.parameters()
+        
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary() else {
+            XCTFail()
+            return
+        }
+        guard let amountParameters = try? request.amountBreakdown?.toDictionary() else {
+            XCTFail()
+            return
+        }
 
         guard parameters["amount_breakdown"] is [String: String] else { XCTFail(); return }
-        XCTAssertEqual(amountParameters?["item_total"] as? String, "10.00")
-        XCTAssertEqual(amountParameters?["tax_total"] as? String, "1.00")
-        XCTAssertEqual(amountParameters?["shipping"] as? String, "2.00")
-        XCTAssertEqual(amountParameters?["handling"] as? String, "3.00")
-        XCTAssertEqual(amountParameters?["insurance"] as? String, "4.00")
-        XCTAssertEqual(amountParameters?["shipping_discount"] as? String, "1.00")
-        XCTAssertEqual(amountParameters?["discount"] as? String, "2.00")
+        XCTAssertEqual(amountParameters["item_total"] as? String, "10.00")
+        XCTAssertEqual(amountParameters["tax_total"] as? String, "1.00")
+        XCTAssertEqual(amountParameters["shipping"] as? String, "2.00")
+        XCTAssertEqual(amountParameters["handling"] as? String, "3.00")
+        XCTAssertEqual(amountParameters["insurance"] as? String, "4.00")
+        XCTAssertEqual(amountParameters["shipping_discount"] as? String, "1.00")
+        XCTAssertEqual(amountParameters["discount"] as? String, "2.00")
     }
 }


### PR DESCRIPTION
### Summary of changes

Updates the PayPal Checkout integration to support additional recurring billing and amount breakdown features. 
Improve how amount breakdown data is encoded and tested.

### Recurring Billing Support

* Added new fields to `PayPalCheckoutPOSTBody` for recurring billing: `recurringBillingDetails` and `recurringBillingPlanType`, enabling the request to carry plan metadata and type for subscriptions. These fields are now set from the request and mapped to their respective JSON keys.

### Amount Breakdown Improvements

* Introduced the `amountBreakdown` property in `PayPalCheckoutPOSTBody`, which is now populated from the request and encoded using the new `BTAmountBreakdown` model.
* Updated `BTAmountBreakdown` to conform to `Encodable`, added a `CodingKeys` enum for explicit JSON key mapping, and removed the manual `parameters()` method for a cleaner encoding approach.

### Testing Updates

* Refactored the unit test for amount breakdown to use the new encoding method, ensuring the breakdown is correctly encoded and its fields are validated in the resulting dictionary. 

### Note

Since the feature branch for [RP-4.1](https://github.com/braintree/braintree_ios/pull/1618) was recently merged into main, I updated this branch accordingly.

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
