### PR TITLE
[v7] AppSwitch Instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * BraintreePayPal
   * Add `recurringBillingDetails`, `recurringBillingPlanType`, and `amountBreakdown` properties to `BTPayPalCheckoutRequest`. Enables RBA metadata to be passed for the PayPal Checkout Vault with Purchase flow
   * Add `userAction` property to `BTPayPalVaultRequest`
+  * Add `paypal:tokenize:default-browser-switch:started` event for when the appSwitch fails for universalLink and `openURLInDefaultBrowser` is triggered.
+  * Add `paypal:tokenize:default-browser-switch:succeeded` and `paypal:tokenize:default-browser-switch:failed` events for when the browser switch succeeds or fails.
 
 ## 6.38.0 (2025-09-09)
 * BraintreeShopperInsights (BETA)

--- a/Sources/BraintreePayPal/BTPayPalAnalytics.swift
+++ b/Sources/BraintreePayPal/BTPayPalAnalytics.swift
@@ -33,4 +33,10 @@ enum BTPayPalAnalytics {
     static let appSwitchStarted = "paypal:tokenize:app-switch:started"
     static let appSwitchSucceeded = "paypal:tokenize:app-switch:succeeded"
     static let appSwitchFailed = "paypal:tokenize:app-switch:failed"
+    
+    // MARK: - Default browser events
+    
+    static let defaultBrowserStarted = "paypal:tokenize:default-browser-switch:started"
+    static let defaultBrowserSucceeded = "paypal:tokenize:default-browser-switch:succeeded"
+    static let defaultBrowserFailed = "paypal:tokenize:default-browser-switch:failed"
 }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -308,10 +308,6 @@ import BraintreeDataCollector
             BTPayPalClient.payPalClient = self
             appSwitchCompletion = completion
         } else {
-            /// reset the `hasOpenedURL` flag to allow for
-            /// future app switch attempts in case of failure to open the initial switch
-            hasOpenedURL = false
-
             apiClient.sendAnalyticsEvent(
                 BTPayPalAnalytics.appSwitchFailed,
                 applicationState: UIApplication.shared.applicationStateString,
@@ -322,6 +318,52 @@ import BraintreeDataCollector
                 didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
                 isVaultRequest: isVaultRequest
             )
+            
+            openURLInDefaultBrowser(url, completion: completion)
+        }
+    }
+    
+    private func openURLInDefaultBrowser(_ url: URL, completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void) {
+        apiClient.sendAnalyticsEvent(
+            BTPayPalAnalytics.defaultBrowserStarted,
+            applicationState: UIApplication.shared.applicationStateString,
+            appSwitchURL: url,
+            contextID: contextID,
+            contextType: contextType,
+            didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
+            didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            isVaultRequest: isVaultRequest,
+            shopperSessionID: payPalRequest?.shopperSessionID
+        )
+        
+        application.open(url, options: [:]) { success in
+            self.invokedOpenURLInDefaultBrowser(success, url: url, completion: completion)
+        }
+    }
+    
+    func invokedOpenURLInDefaultBrowser(
+        _ isSuccess: Bool,
+        url: URL,
+        completion: @escaping (BTPayPalAccountNonce?, Error?) -> Void
+    ) {
+        let eventName = isSuccess ? BTPayPalAnalytics.defaultBrowserSucceeded : BTPayPalAnalytics.defaultBrowserFailed
+
+        apiClient.sendAnalyticsEvent(
+            eventName,
+            applicationState: UIApplication.shared.applicationStateString,
+            appSwitchURL: url,
+            contextID: contextID,
+            contextType: contextType,
+            didEnablePayPalAppSwitch: payPalRequest?.enablePayPalAppSwitch,
+            didPayPalServerAttemptAppSwitch: didPayPalServerAttemptAppSwitch,
+            isVaultRequest: isVaultRequest
+        )
+
+        if isSuccess {
+            BTPayPalClient.payPalClient = self
+            appSwitchCompletion = completion
+        } else {
+            hasOpenedURL = false
             notifyFailure(with: BTPayPalError.appSwitchFailed, completion: completion)
         }
     }
@@ -499,7 +541,7 @@ import BraintreeDataCollector
             return
         }
 
-        application.open(redirectURL, options: [:]) { success in
+        application.open(redirectURL, options: [.universalLinksOnly: NSNumber(value: true)]) { success in
             self.invokedOpenURLSuccessfully(success, url: redirectURL, completion: completion)
         }
     }

--- a/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalAnalytics_Tests.swift
@@ -15,5 +15,8 @@ final class BTPayPalAnalytics_Tests: XCTestCase {
         XCTAssertEqual(BTPayPalAnalytics.appSwitchStarted, "paypal:tokenize:app-switch:started")
         XCTAssertEqual(BTPayPalAnalytics.appSwitchSucceeded, "paypal:tokenize:app-switch:succeeded")
         XCTAssertEqual(BTPayPalAnalytics.appSwitchFailed, "paypal:tokenize:app-switch:failed")
+        XCTAssertEqual(BTPayPalAnalytics.defaultBrowserStarted, "paypal:tokenize:default-browser-switch:started")
+        XCTAssertEqual(BTPayPalAnalytics.defaultBrowserSucceeded, "paypal:tokenize:default-browser-switch:succeeded")
+        XCTAssertEqual(BTPayPalAnalytics.defaultBrowserFailed, "paypal:tokenize:default-browser-switch:failed")
     }
 }

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -1229,6 +1229,122 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertFalse(self.payPalClient.hasOpenedURL)
         XCTAssertEqual(fakeApplication.openCallCount, 1)
     }
+    
+    func testTokenize_whenAppSwitchAttempted_usesUniversalLinksOnlyOption() {
+        let fakeApplication = FakeApplication()
+        payPalClient.application = fakeApplication
+
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?ba_token=value1"
+            ]
+        ])
+
+        let vaultRequest = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        
+        payPalClient.tokenize(vaultRequest) { _, _ in }
+        
+        XCTAssertTrue(fakeApplication.openURLWasCalled)
+        XCTAssertNotNil(fakeApplication.lastOpenOptions)
+        XCTAssertEqual(fakeApplication.lastOpenOptions?[.universalLinksOnly] as? NSNumber, true as NSNumber)
+    }
+    
+    func testTokenize_whenAppSwitchFails_opensInDefaultBrowserWithAnalytics() {
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedOpenURLSuccess = false
+        payPalClient.application = fakeApplication
+
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?ba_token=value1"
+            ]
+        ])
+
+        let vaultRequest = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        
+        payPalClient.tokenize(vaultRequest) { _, _ in }
+        
+        XCTAssertTrue(fakeApplication.openURLWasCalled)
+        XCTAssertEqual(fakeApplication.openCallCount, 2)
+        
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.appSwitchFailed))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserStarted))
+    }
+    
+    func testTokenize_whenDefaultBrowserSwitchSucceeds_sendsDefaultBrowserSucceededAnalytics() {
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedOpenURLSuccessPerCall = [.universalLinksOnly: false, .none: true]
+        payPalClient.application = fakeApplication
+
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?ba_token=value1"
+            ]
+        ])
+
+        let vaultRequest = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        
+        payPalClient.tokenize(vaultRequest) { _, _ in }
+        
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.appSwitchFailed))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserStarted))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserSucceeded))
+    }
+    
+    func testTokenize_whenDefaultBrowserSwitchFails_sendsDefaultBrowserFailedAnalytics() {
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedOpenURLSuccess = false
+        payPalClient.application = fakeApplication
+
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "agreementSetup": [
+                "paypalAppApprovalUrl": "https://www.some-url.com/some-path?ba_token=value1"
+            ]
+        ])
+
+        let vaultRequest = BTPayPalVaultRequest(enablePayPalAppSwitch: true)
+        
+        let expectation = expectation(description: "completion block called")
+        payPalClient.tokenize(vaultRequest) { nonce, error in
+            XCTAssertNil(nonce)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+        
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.appSwitchFailed))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserStarted))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserFailed))
+    }
+    
+    func testTokenizeCheckout_whenAppSwitchFails_opensInDefaultBrowserWithAnalytics() {
+        let fakeApplication = FakeApplication()
+        fakeApplication.cannedOpenURLSuccess = false
+        payPalClient.application = fakeApplication
+
+        mockAPIClient.cannedResponseBody = BTJSON(value: [
+            "paymentResource": [
+                "redirectUrl": "https://www.some-url.com/some-path?token=value1",
+                "launchPayPalApp": true
+            ]
+        ])
+
+        let checkoutRequest = BTPayPalCheckoutRequest(
+            userAuthenticationEmail: "fake-pp@gmail.com",
+            enablePayPalAppSwitch: true,
+            amount: "10.00"
+        )
+        
+        payPalClient.tokenize(checkoutRequest) { _, _ in }
+        
+        XCTAssertTrue(fakeApplication.openURLWasCalled)
+        XCTAssertEqual(fakeApplication.openCallCount, 2)
+        
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.appSwitchFailed))
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalAnalytics.defaultBrowserStarted))
+    }
+    
     // MARK: - Analytics
 
     func testAPIClientMetadata_hasIntegrationSetToCustom() {

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -1,7 +1,7 @@
 import UIKit
 import BraintreeCore
 
-public class FakeApplication: URLOpener {
+public class FakeApplication: @preconcurrency URLOpener {
     
     public var lastOpenURL: URL? = nil
     public var openURLWasCalled: Bool = false
@@ -9,19 +9,25 @@ public class FakeApplication: URLOpener {
     public var cannedCanOpenURL: Bool = true
     public var canOpenURLWhitelist: [URL] = []
     public var openCallCount = 0
+    public var lastOpenOptions: [UIApplication.OpenExternalURLOptionsKey : Any]? = nil
+    public var cannedOpenURLSuccessPerCall: [MockOpenURLOption: Bool] = [:]
 
-    public func open(
+    @MainActor public func open(
         _ url: URL,
         options: [UIApplication.OpenExternalURLOptionsKey: Any],
         completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
     ) {
         lastOpenURL = url
+        lastOpenOptions = options
         openURLWasCalled = true
         openCallCount += 1
 
-        Task { @MainActor in
-            completion?(cannedOpenURLSuccess)
-        }
+//        Task { @MainActor in
+            let success = options.isEmpty
+            ? cannedOpenURLSuccessPerCall[.none]
+            : cannedOpenURLSuccessPerCall[.universalLinksOnly]
+            completion?(success ?? cannedOpenURLSuccess)
+//        }
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {
@@ -39,5 +45,14 @@ public class FakeApplication: URLOpener {
 
     public func isVenmoAppInstalled() -> Bool {
         cannedCanOpenURL
+    }
+    
+    /// Represents options for mocking URL open behavior in `FakeApplication`.
+    public enum MockOpenURLOption {
+        /// Simulates opening a URL as a universal link (using `UIApplication.OpenExternalURLOptionsKey.universalLinksOnly`).
+        case universalLinksOnly
+        
+        /// Simulates opening a URL with no special options.
+        case none
     }
 }

--- a/UnitTests/BraintreeTestShared/FakeApplication.swift
+++ b/UnitTests/BraintreeTestShared/FakeApplication.swift
@@ -22,12 +22,10 @@ public class FakeApplication: @preconcurrency URLOpener {
         openURLWasCalled = true
         openCallCount += 1
 
-//        Task { @MainActor in
-            let success = options.isEmpty
-            ? cannedOpenURLSuccessPerCall[.none]
-            : cannedOpenURLSuccessPerCall[.universalLinksOnly]
-            completion?(success ?? cannedOpenURLSuccess)
-//        }
+        let success = options.isEmpty
+        ? cannedOpenURLSuccessPerCall[.none]
+        : cannedOpenURLSuccessPerCall[.universalLinksOnly]
+        completion?(success ?? cannedOpenURLSuccess)
     }
 
     @objc public func canOpenURL(_ url: URL) -> Bool {


### PR DESCRIPTION

### Summary of changes

This PR updates the `v7` feature branch with the latest changes merged into `main`. The recent [AppSwitch instrumentation changes](https://github.com/braintree/braintree_ios/pull/1648) create a custom “open” API, but the goal in `v7` is to use the native API.


### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
