### PR TITLE
update BTAnalyticsService test to pass offline

### DIFF
--- a/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/BTAnalyticsService_Tests.swift
@@ -275,6 +275,7 @@ final class BTAnalyticsService_Tests: XCTestCase {
         return eventParams?[index]["event_name"] as? String
     }
     
+    /// Sends a dummy event to flush queued analytics and reset state before subsequent unit tests.
     private func resetAnalyticsState(analyticsService: BTAnalyticsService, analyticsHTTP: FakeHTTP) async {
         await analyticsService.performEventRequest(with: FPTIBatchData.Event(eventName: "clear-queue-event"))
         analyticsHTTP.POSTRequestCount = 0


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

### Summary of changes

- When running all unit tests offline all tests pass except `testSendAnalyticsEvent_whenMultipleSessionIDs_sendsMultiplePOSTs`. This seems to be due to the shared Singleton of BTAnalyticsService and a previously running unit test not sending the events it creates after the test runs. I initially tried re-working the test class to do teardown and more extensive setup, but due to the asynchronous calls this caused more issues. 
- 
- Instead, I created a straightforward solution of just sending an event to include any queued events and then capturing the value of the `currentPOSTRequestCount`. However, I created a more readable solution (second commit) that moves the reset logic to a separate helper function.

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- buzzamus
