### PR TITLE
Demo App - Fix iOS 26 Status Label

### DIFF
--- a/Demo/Application/Base/ContainmentViewController.swift
+++ b/Demo/Application/Base/ContainmentViewController.swift
@@ -73,9 +73,11 @@ class ContainmentViewController: UIViewController {
         button.addTarget(self, action: #selector(tappedStatus), for: .touchUpInside)
         button.titleLabel?.textAlignment = .center
         button.titleLabel?.font = .systemFont(ofSize: 14)
-
-        let frame = navigationController?.navigationBar.frame
-        button.frame = CGRect(x: 0, y: 0, width: frame?.size.width ?? 100, height: frame?.size.height ?? 20)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        let widthConstraint = button.widthAnchor.constraint(greaterThanOrEqualToConstant: 200)
+        widthConstraint.priority = .defaultHigh
+        widthConstraint.isActive = true
 
         // Use custom view with button so the text can span multiple lines
         statusItem = UIBarButtonItem(customView: button)


### PR DESCRIPTION
### Summary of changes

- Update button in demo app for iOS 26 changes
- Confirmed this works for older iOS versions as well

| Before | After |
|-----|-----|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-10-14 at 09 37 32" src="https://github.com/user-attachments/assets/0002bd25-d67a-4060-8b2f-17108fa0eb84" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-10-13 at 09 44 22" src="https://github.com/user-attachments/assets/527aa767-b39f-4e45-a1d8-cbfde7bc388f" />|

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @jaxdesmarais 
