### PR TITLE
Update Codescanning for `v7`

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,8 +18,9 @@ on:
 
 jobs:
   code-scanning:
-    uses: braintree/security-workflows/.github/workflows/codeql-ios.yml@main
+    uses: braintree/security-workflows/.github/workflows/codeql-ios.yml@addIOS7Support
     with:
+      mac-runner-version: 15
       project: Demo/Demo.xcodeproj
       workspace: Braintree.xcworkspace
       scheme: Demo


### PR DESCRIPTION
### Summary of changes

- Update codescanning for the iOS v7 branch to use the correct Xcode and Swift version to avoid older versions throwing an incorrect error

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
