### PR TITLE
[V7] Fix UI Tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,13 @@ jobs:
       - name: Boot Simulator
         run: |
           # Boot simulator ahead of time to reduce test startup time
-          xcrun simctl boot "iPhone 16" || true
-          # Wait for simulator to boot
-          xcrun simctl bootstatus "iPhone 16" -b || true
+          # Find iPhone 16 Pro with iOS 18.5
+          DEVICE_UDID=$(xcrun simctl list devices | grep -A 1 "iOS 18.5" | grep "iPhone 16 Pro (" | head -n 1 | grep -oE '\([A-Z0-9-]+\)' | tr -d '()')
+
+          if [ -n "$DEVICE_UDID" ]; then
+            xcrun simctl boot "$DEVICE_UDID" || true
+            xcrun simctl bootstatus "$DEVICE_UDID" -b || true
+          fi
           # Disable hardware keyboard to avoid input issues
           defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
 
@@ -61,11 +65,11 @@ jobs:
         timeout-minutes: 3
         run: |
           # Reset simulator state to ensure clean environment
-          echo "Finding iPhone 16 simulator..."
-          DEVICE_UDID=$(xcrun simctl list devices available | grep "iPhone 16 (" | head -n 1 | grep -oE '\([A-Z0-9-]+\)' | tr -d '()')
+          echo "Finding iPhone 16 Pro (iOS 18.5) simulator..."
+          DEVICE_UDID=$(xcrun simctl list devices | grep -A 1 "iOS 18.5" | grep "iPhone 16 Pro (" | head -n 1 | grep -oE '\([A-Z0-9-]+\)' | tr -d '()')
 
           if [ -z "$DEVICE_UDID" ]; then
-            echo "::error::iPhone 16 simulator not found"
+            echo "::error::iPhone 16 Pro (iOS 18.5) simulator not found"
             exit 1
           fi
 


### PR DESCRIPTION
### Summary of changes

- Add `derivedDataPath` to allow for quicker builds on CI since they will use the derived data when available
- Add missing `PayPalMessaging` UI Tests
- Ensure the correct simulator is being booted (nice catch @agedd)
- Move from `test_attempt_1` to `retry-tests-on-failure` - this simplifies CI logic and allows `xcodebuild` to use it's built in logic to retry failed tests up to 3x vs the entire test file
- Change the UI Tests configuration from `Release` to `Debug` - this was the main issue and fixes it because:
    - Debug builds include all symbols and debugging information
    - Network requests behave more predictably    
    - `ENABLE_TESTABILITY` is typically only enabled for Debug builds
    - Web content in `ASWebAuthenticationSession` loads properly - running the command with the release build pointed me in this direction since the web page was loading blank

### Checklist

- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 
