### PR TITLE
Replace Pay Later toggle with a button in Braintree Demo App

### DIFF
--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -104,7 +104,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             action: #selector(tappedPayPalAppSwitchForVault)
         )
         
-        let payPalAppSwitchForCheckoutWithPayLaterButton = createButton(
+        let payPalAppSwitchForCheckoutPayLaterButton = createButton(
             title: "Pay Later App Switch - Checkout",
             action: #selector(tappedPayLaterForCheckout)
         )
@@ -114,7 +114,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             amountBreakdownToggle,
             payPalCheckoutButton,
             payPalAppSwitchForCheckoutButton,
-            payPalAppSwitchForCheckoutWithPayLaterButton,
+            payPalAppSwitchForCheckoutPayLaterButton,
             payPalAppSwitchForCreditButton
         ])
         oneTimeCheckoutStackView.spacing = 12


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- Remove Pay Later **Toggle** and replace it with a Pay Later **Button** for **Checkout** flow 

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik

### Manual Tests

_Happy Path_

**PayPal App Switch - Checkout** 

https://github.com/user-attachments/assets/faf87a0b-c3fb-48c1-9b56-6dff4cb65e85



**Pay Later App Switch - Checkout** 

https://github.com/user-attachments/assets/d0bb31d3-fdcc-480d-a595-a4f2b591628f



**PayPal Credit** 

https://github.com/user-attachments/assets/0618a93e-b6b2-43dc-8eb8-decaff325c78



**PayPal App Switch - Valut** 

https://github.com/user-attachments/assets/9ad6d9c3-32fd-48a2-b23f-9697f280fc7d

