### PR TITLE
Remove Duplicate 3DS Verify Succeeded Events

### DIFF
--- a/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
+++ b/Sources/BraintreeThreeDSecure/BTThreeDSecureClient.swift
@@ -145,7 +145,7 @@ import BraintreeCore
                 return
             }
 
-            self.notifySuccess(with: jsonString, completion: completion)
+            completion(jsonString, nil)
             return
         }
     }
@@ -407,7 +407,7 @@ import BraintreeCore
                 }
 
                 self.apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.lookupSucceeded)
-                self.notifySuccess(with: BTThreeDSecureResult(json: body), completion: completion)
+                completion(BTThreeDSecureResult(json: body), nil)
                 return
             }
         }
@@ -437,10 +437,5 @@ import BraintreeCore
             errorDescription: error.localizedDescription
         )
         completion(nil, error)
-    }
-
-    private func notifySuccess(with payload: String, completion: @escaping (String?, Error?) -> Void) {
-        apiClient.sendAnalyticsEvent(BTThreeDSecureAnalytics.verifySucceeded)
-        completion(payload, nil)
     }
 }


### PR DESCRIPTION
### Summary of changes

- Duplicate 3ds:verify:succeeded events were being triggered in a 3DS flow due to being sent at 2 incorrect locations:
1. When the `prepareLookup()` function completed, which is called before `start()` is actually called, which led to a succeeded event triggering before an attempt was even made.
2. When `performThreeDSecureLookup()` completed even though the verification flow continued and again later sent another verifySucceeded event. 

This could lead up to 3 succeeded triggers for 1 actual success (or 2 for an actually unsuccessful attempt). This issue is resolved by removing the duplicate calls and leaving a single success call at the end of the actual successful flow.

This fix was verified by comparing analytic counts for success prior to this fix and then summing the counts of several successful attempts after the fix to verify there is a 1 to 1 count on successful calls to each attempt.

### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
