### PR TITLE
Visually Center PayPalButton

### DIFF
--- a/Sources/BraintreeUIComponents/PaymentButtonStyle.swift
+++ b/Sources/BraintreeUIComponents/PaymentButtonStyle.swift
@@ -31,6 +31,8 @@ struct PaymentButtonStyle<Color: PaymentButtonColorProtocol>: ButtonStyle {
                     .frame(height: logoHeight)
             }
         }
+        .padding(.top, 11)
+        .padding(.bottom, 8)
         .frame(width: widthRange)
         .frame(height: 45)
         .background(configuration.isPressed ? color.tappedButtonColor : color.backgroundColor)


### PR DESCRIPTION
### Summary of changes

- Adds 11px padding to top of logo and 8px padding to bottom of logo in PayPalButton

<img width="338" height="538" alt="Screenshot 2025-12-23 at 11 21 58 AM" src="https://github.com/user-attachments/assets/6ea49c4c-ee08-461b-87a4-73d6d5c1b146" />


### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
