### PR TITLE
Fix PayPal Logo Centering

### DIFF
--- a/Sources/BraintreeUIComponents/PayPalButton.swift
+++ b/Sources/BraintreeUIComponents/PayPalButton.swift
@@ -114,7 +114,9 @@ public struct PayPalButton: View {
             accessibilityHint: "Complete payment using PayPal",
             spinnerImageName: color?.spinnerColor,
             isLoading: isLoading,
-            spinnerRotation: spinnerRotation
+            spinnerRotation: spinnerRotation,
+            logoTopPadding: 11,
+            logoBottomPadding: 8
         ) {
             apiClient?.sendAnalyticsEvent(UIComponentsAnalytics.payPalButtonSelected)
             isLoading = true

--- a/Sources/BraintreeUIComponents/PaymentButtonStyle.swift
+++ b/Sources/BraintreeUIComponents/PaymentButtonStyle.swift
@@ -9,6 +9,8 @@ struct PaymentButtonStyle<Color: PaymentButtonColorProtocol>: ButtonStyle {
     let spinnerImageName: String?
     let isLoading: Bool
     let spinnerRotation: Double
+    let logoTopPadding: CGFloat
+    let logoBottomPadding: CGFloat
 
     /// This is the width range for the payment button.
     private var widthRange: CGFloat {
@@ -29,10 +31,10 @@ struct PaymentButtonStyle<Color: PaymentButtonColorProtocol>: ButtonStyle {
                     .resizable()
                     .scaledToFit()
                     .frame(height: logoHeight)
+                    .padding(.top, logoTopPadding)
+                    .padding(.bottom, logoBottomPadding)
             }
         }
-        .padding(.top, 11)
-        .padding(.bottom, 8)
         .frame(width: widthRange)
         .frame(height: 45)
         .background(configuration.isPressed ? color.tappedButtonColor : color.backgroundColor)

--- a/Sources/BraintreeUIComponents/PaymentButtonView.swift
+++ b/Sources/BraintreeUIComponents/PaymentButtonView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Shared payment button view that works with any PaymentButtonColorProtocol
 /// Not to be called directly. Use either BTPayPalButtons or BTVenmoButton instead.
 struct PaymentButtonView<Color: PaymentButtonColorProtocol>: View {
-    
+
     let color: Color
     let width: CGFloat?
     let logoHeight: CGFloat
@@ -12,6 +12,8 @@ struct PaymentButtonView<Color: PaymentButtonColorProtocol>: View {
     let spinnerImageName: String?
     let isLoading: Bool
     let spinnerRotation: Double
+    let logoTopPadding: CGFloat
+    let logoBottomPadding: CGFloat
     let action: () -> Void
 
     var body: some View {
@@ -25,7 +27,9 @@ struct PaymentButtonView<Color: PaymentButtonColorProtocol>: View {
                 logoHeight: logoHeight,
                 spinnerImageName: spinnerImageName,
                 isLoading: isLoading,
-                spinnerRotation: spinnerRotation
+                spinnerRotation: spinnerRotation,
+                logoTopPadding: logoTopPadding,
+                logoBottomPadding: logoBottomPadding
             )
         )
         .disabled(isLoading)

--- a/Sources/BraintreeUIComponents/VenmoButton.swift
+++ b/Sources/BraintreeUIComponents/VenmoButton.swift
@@ -75,6 +75,8 @@ public struct VenmoButton: View {
             spinnerImageName: color?.spinnerColor,
             isLoading: isLoading,
             spinnerRotation: spinnerRotation,
+            logoTopPadding: 0,
+            logoBottomPadding: 0
         ) {
             apiClient?.sendAnalyticsEvent(UIComponentsAnalytics.venmoButtonSelected)
             isLoading = true


### PR DESCRIPTION

### Summary of changes

- Removed previous top and bottom padding to ensure padding is only present on PayPal button by adding it to styling struct, but setting to for Venmo. Also ensured it only is used on PayPal log and not the spinner image during loading, but adding to the else if block on if image is PayPal and not spinner.

<img width="398" height="865" alt="Simulator Screenshot - iPhone 16 Pro - 2025-12-29 at 11 57 14" src="https://github.com/user-attachments/assets/9c3c7905-8301-4c3d-865d-7cda6a829564" />


### Checklist

- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
