### PR TITLE
Fix Flakey Analytics Unit Test

### DIFF
--- a/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
+++ b/UnitTests/BraintreeCoreTests/Analytics/MockBackgroundTaskManager.swift
@@ -1,7 +1,8 @@
+import Foundation
 @testable import BraintreeCore
 
 class MockBackgroundTaskManager: BackgroundTaskManaging {
-    
+
     var didBeginBackgroundTask = false
     var didEndBackgroundTask = false
     var lastTaskName: String?
@@ -10,11 +11,16 @@ class MockBackgroundTaskManager: BackgroundTaskManaging {
     var endedTaskIDs: Set<UIBackgroundTaskIdentifier> = []
     var begunTaskIDs: Set<UIBackgroundTaskIdentifier> = []
     var taskIDsToReturn: Set<UIBackgroundTaskIdentifier> = []
-    
+
+    private let lock = NSLock()
+
     func beginBackgroundTask(named: String?, expirationHandler handler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+        lock.lock()
+        defer { lock.unlock() }
+
         didBeginBackgroundTask = true
         lastTaskName = named
-        
+
         // Simulate expiration handler call
         self.expirationHandler = handler
         let id = taskIDsToReturn.isEmpty ? .invalid : taskIDsToReturn.removeFirst()
@@ -23,6 +29,9 @@ class MockBackgroundTaskManager: BackgroundTaskManaging {
     }
 
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+        lock.lock()
+        defer { lock.unlock() }
+
         didEndBackgroundTask = true
         endedTaskID = identifier
         endedTaskIDs.insert(identifier)


### PR DESCRIPTION
### Summary of changes

- Added `NSLock` to shared access in `MockBackgroundTaskManager`. This was done due to flakey tests around the analytic events. I believe the flakey tests were due to a race condition in the `beginBackgroundTask()` and `endBackgroundTask()` calls. I tested this fix by running tests 200 times to verify no more flakey failures.

One interesting thing to note is the test that was the most flakey (`testSendAnalyticsEventsImmediately_withConcurrentCalls_beginAndEnd_returnSameTaskIDs `) fails almost every time when run by itself. I believe this fix also resolves that issue due to timing differences when running all at once.

This change is only for the mocked version of the background task manager since the production version uses `UIApplication.beginBackgroundTask()`, which is thread safe.


Just a few examples of jobs where these test failed:

 https://github.com/braintree/braintree_ios/actions/runs/20315441931/job/58363751233

https://github.com/braintree/braintree_ios/actions/runs/20767971398/job/59638038574

There were many more, but most of them that I encountered I ended up rerunning the failed jobs, which overwrote the logs.

### Checklist

- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
