### PR TITLE
Rename funding_source PayPal parameter

### DIFF
--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -558,7 +558,7 @@ import BraintreeDataCollector
             URLQueryItem(name: "switch_initiated_time", value: String(Int(round(Date().timeIntervalSince1970 * 1000)))),
             URLQueryItem(name: "flow_type", value: isVaultRequest ? "va" : "ecs"),
             URLQueryItem(name: "merchant", value: merchantID ?? "unknown"),
-            URLQueryItem(name: "funding_source", value: fundingSource?.rawValue ?? BTPayPalFundingSource.payPal.rawValue)
+            URLQueryItem(name: "fundingSource", value: fundingSource?.rawValue ?? BTPayPalFundingSource.payPal.rawValue)
         ]
         
         urlComponents?.queryItems?.append(contentsOf: additionalQueryItems)

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -908,7 +908,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "va")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
         XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
-        XCTAssertEqual(urlComponents?.queryItems?[5].name, "funding_source")
+        XCTAssertEqual(urlComponents?.queryItems?[5].name, "fundingSource")
         XCTAssertEqual(urlComponents?.queryItems?[5].value, "paypal")
     }
 
@@ -1030,7 +1030,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "ecs")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
         XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
-        XCTAssertEqual(urlComponents?.queryItems?[5].name, "funding_source")
+        XCTAssertEqual(urlComponents?.queryItems?[5].name, "fundingSource")
         XCTAssertEqual(urlComponents?.queryItems?[5].value, "paypal")
     }
     
@@ -1074,7 +1074,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "ecs")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
         XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
-        XCTAssertEqual(urlComponents?.queryItems?[5].name, "funding_source")
+        XCTAssertEqual(urlComponents?.queryItems?[5].name, "fundingSource")
         XCTAssertEqual(urlComponents?.queryItems?[5].value, "credit")
     }
     
@@ -1118,7 +1118,7 @@ class BTPayPalClient_Tests: XCTestCase {
         XCTAssertEqual(urlComponents?.queryItems?[3].value, "ecs")
         XCTAssertEqual(urlComponents?.queryItems?[4].name, "merchant")
         XCTAssertEqual(urlComponents?.queryItems?[4].value, "testMerchantId")
-        XCTAssertEqual(urlComponents?.queryItems?[5].name, "funding_source")
+        XCTAssertEqual(urlComponents?.queryItems?[5].name, "fundingSource")
         XCTAssertEqual(urlComponents?.queryItems?[5].value, "paylater")
     }
     


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- Rename `funding_source` PayPal Universal link parameter 

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
