### PR TITLE
Fix Unit Test Failures 

### DIFF
--- a/UnitTests/BraintreeTestShared/FakeHTTP.swift
+++ b/UnitTests/BraintreeTestShared/FakeHTTP.swift
@@ -123,7 +123,6 @@ import Foundation
     public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil) async throws -> (BTJSON?, HTTPURLResponse?) {
         POSTRequestCount += 1
         lastRequestParameters = try? parameters?.toDictionary()
-        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        return (self.cannedConfiguration, httpResponse)
+        return (self.cannedConfiguration, nil)
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add async/await post equivalent method in `FakeGraphQLHTTP` to address failing unit tests in `BTAPIClient_Tests`

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
