### PR TITLE
BTPayPalMessagingview - Update to async/await

### DIFF
--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -44,7 +44,7 @@ public class BTPayPalMessagingView: UIView {
         
         apiClient.sendAnalyticsEvent(BTPayPalMessagingAnalytics.started)
 
-        Task {
+        Task { @MainActor in
             do {
                 let configuration = try await apiClient.fetchOrReturnRemoteConfiguration()
                 

--- a/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
+++ b/Sources/BraintreePayPalMessaging/BTPayPalMessagingView.swift
@@ -22,7 +22,7 @@ public class BTPayPalMessagingView: UIView {
     ///  Initializes a `BTPayPalMessagingView`.
     /// - Parameter authorization: A valid client token or tokenization key used to authorize API calls.
     public init(authorization: String) {
-        self.apiClient = BTAPIClient(authorization: authorization)
+        apiClient = BTAPIClient(authorization: authorization)
 
         super.init(frame: .zero)
     }
@@ -49,7 +49,7 @@ public class BTPayPalMessagingView: UIView {
                 let configuration = try await apiClient.fetchOrReturnRemoteConfiguration()
                 
                 guard let clientID = configuration.json?["paypal"]["clientId"].asString() else {
-                    self.notifyFailure(with: BTPayPalMessagingError.payPalClientIDNotFound)
+                    notifyFailure(with: BTPayPalMessagingError.payPalClientIDNotFound)
                     return
                 }
 
@@ -72,9 +72,9 @@ public class BTPayPalMessagingView: UIView {
                     )
                 )
 
-                self.setupMessageView(with: messageConfig)
+                setupMessageView(with: messageConfig)
             } catch {
-                self.notifyFailure(with: error)
+                notifyFailure(with: error)
             }
         }
     }
@@ -126,7 +126,7 @@ public extension BTPayPalMessagingView {
             request: BTPayPalMessagingRequest = BTPayPalMessagingRequest(),
             delegate: BTPayPalMessagingDelegate? = nil
         ) {
-            self.apiClient = BTAPIClient(authorization: authorization)
+            apiClient = BTAPIClient(authorization: authorization)
             self.request = request
             self.delegate = delegate
         }

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -41,7 +41,9 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
 
         await fulfillment(of: [expectation], timeout: 2)
 
-        XCTAssertNotNil(mockDelegate.error)
+        XCTAssertEqual((mockDelegate.error as? BTPayPalMessagingError)?.errorDescription, "Failed to fetch Braintree configuration.")
+        XCTAssertEqual(mockDelegate.error as? BTPayPalMessagingError, BTPayPalMessagingError.fetchConfigurationFailed)
+        XCTAssertEqual((mockDelegate.error as? BTPayPalMessagingError)?.errorCode, 0)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.failed))
     }

--- a/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/BTPayPalMessagingView_Tests.swift
@@ -9,32 +9,45 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
     var mockDelegate = MockBTPayPalMessagingDelegate()
     let mockTokenizationKey = "development_tokenization_key"
 
-    func testStart_withConfigurationError_callsDelegateWithError() {
+    @MainActor
+    func testStart_withConfigurationError_callsDelegateWithError() async {
         mockAPIClient.cannedConfigurationResponseError = NSError(domain: "SomeError", code: 999)
 
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.apiClient = mockAPIClient
         payPalMessageView.delegate = mockDelegate
+
+        let expectation = expectation(description: "Delegate receives error")
+        mockDelegate.didReceiveErrorExpectation = expectation
+
         payPalMessageView.start()
+
+        await fulfillment(of: [expectation], timeout: 2)
 
         XCTAssertEqual((mockDelegate.error as? NSError)?.domain, "SomeError")
         XCTAssertEqual((mockDelegate.error as? NSError)?.code, 999)
     }
 
-    func testStart_withNilConfiguration_callsDelegateWithErrorAndSendsAnalytics() {
+    @MainActor
+    func testStart_withNilConfiguration_callsDelegateWithErrorAndSendsAnalytics() async {
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.apiClient = mockAPIClient
+
+        let expectation = expectation(description: "Delegate receives error")
+        mockDelegate.didReceiveErrorExpectation = expectation
+
         payPalMessageView.start()
 
-        XCTAssertEqual(mockDelegate.error as? BTPayPalMessagingError, BTPayPalMessagingError.fetchConfigurationFailed)
-        XCTAssertEqual((mockDelegate.error as? BTPayPalMessagingError)?.errorCode, 0)
-        XCTAssertEqual((mockDelegate.error as? BTPayPalMessagingError)?.errorDescription, "Failed to fetch Braintree configuration.")
+        await fulfillment(of: [expectation], timeout: 2)
+
+        XCTAssertNotNil(mockDelegate.error)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.failed))
     }
 
-    func testStart_withNoClientID_callsDelegateWithError() {
+    @MainActor
+    func testStart_withNoClientID_callsDelegateWithError() async {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(
             value: [
                 "paypal": ["clientId": nil]
@@ -44,7 +57,13 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.apiClient = mockAPIClient
+
+        let expectation = expectation(description: "Delegate receives error")
+        mockDelegate.didReceiveErrorExpectation = expectation
+
         payPalMessageView.start()
+
+        await fulfillment(of: [expectation], timeout: 2)
 
         XCTAssertEqual(mockDelegate.error as? BTPayPalMessagingError, BTPayPalMessagingError.payPalClientIDNotFound)
         XCTAssertEqual((mockDelegate.error as? NSError)?.domain, "com.braintreepayments.BTPayPalMessagingErrorDomain")
@@ -52,7 +71,8 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         XCTAssertEqual((mockDelegate.error as? BTPayPalMessagingError)?.errorDescription, "Could not find PayPal client ID in Braintree configuration.")
     }
 
-    func testStart_withClientID_firesWillAppearAndSendsAnalytics() {
+    @MainActor
+    func testStart_withClientID_firesWillAppearAndSendsAnalytics() async {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(
             value: [
                 "paypal": ["clientId": "a-fake-client-id"]
@@ -62,32 +82,44 @@ final class BTPayPalMessagingView_Tests: XCTestCase {
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.apiClient = mockAPIClient
+
+        let expectation = expectation(description: "Delegate will appear")
+        mockDelegate.willAppearExpectation = expectation
+
         payPalMessageView.start()
+
+        await fulfillment(of: [expectation], timeout: 2)
 
         XCTAssertTrue(mockDelegate.willAppear)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
     }
     
-    func testStart_withClientID_callingMultipleTimes_doesNotIncreaseNumberOfSubviews() {
+    @MainActor
+    func testStart_withClientID_callingMultipleTimes_doesNotIncreaseNumberOfSubviews() async {
         mockAPIClient.cannedConfigurationResponseBody = BTJSON(
             value: [
                 "paypal": ["clientId": "a-fake-client-id"]
             ] as [String: Any?]
         )
-        
+
         let payPalMessageView = BTPayPalMessagingView(authorization: mockTokenizationKey)
         payPalMessageView.delegate = mockDelegate
         payPalMessageView.apiClient = mockAPIClient
         XCTAssertEqual(payPalMessageView.subviews.count, 0)
-        
+
+        let expectation = expectation(description: "First delegate will appear")
+        mockDelegate.willAppearExpectation = expectation
+
         payPalMessageView.start()
-        
+
+        await fulfillment(of: [expectation], timeout: 2)
+
         XCTAssertTrue(mockDelegate.willAppear)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
         XCTAssertEqual(payPalMessageView.subviews.count, 1)
 
         payPalMessageView.start()
-        
+
         XCTAssertTrue(mockDelegate.willAppear)
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTPayPalMessagingAnalytics.started))
         XCTAssertEqual(payPalMessageView.subviews.count, 1)

--- a/UnitTests/BraintreePayPalMessagingTests/MockBTPayPalMessagingDelegate.swift
+++ b/UnitTests/BraintreePayPalMessagingTests/MockBTPayPalMessagingDelegate.swift
@@ -1,9 +1,12 @@
+import XCTest
 import BraintreePayPalMessaging
 
 class MockBTPayPalMessagingDelegate: BTPayPalMessagingDelegate {
 
     var willAppear: Bool = false
     var error: Error?
+    var willAppearExpectation: XCTestExpectation?
+    var didReceiveErrorExpectation: XCTestExpectation?
 
     func didSelect(_ payPalMessagingView: BTPayPalMessagingView) {
         // not unit testable
@@ -15,6 +18,7 @@ class MockBTPayPalMessagingDelegate: BTPayPalMessagingDelegate {
     
     func willAppear(_ payPalMessagingView: BTPayPalMessagingView) {
         willAppear = true
+        willAppearExpectation?.fulfill()
     }
     
     func didAppear(_ payPalMessagingView: BTPayPalMessagingView) {
@@ -23,5 +27,6 @@ class MockBTPayPalMessagingDelegate: BTPayPalMessagingDelegate {
     
     func onError(_ payPalMessagingView: BTPayPalMessagingView, error: Error) {
         self.error = error
+        didReceiveErrorExpectation?.fulfill()
     }
 }


### PR DESCRIPTION
### Summary of changes

- Convert the internal completion handlers in BTPayPalMessagingView to use the async/await
- Tested PayPal Messaging in Demo app and works as expected

### Checklist

- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu
