### PR TITLE
Convert Completion Handlers in BTHTTP to Async Functions

### DIFF
--- a/IntegrationTests/Braintree-API-Integration-Specs/BTAPIClient_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTAPIClient_IntegrationTests.swift
@@ -3,43 +3,28 @@ import XCTest
 
 final class BTAPIClient_IntegrationTests: XCTestCase {
 
-    func testFetchConfiguration_withTokenizationKey_returnsTheConfiguration() {
+    func testFetchConfiguration_withTokenizationKey_returnsTheConfiguration() async throws {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxTokenizationKey)
-        let expectation = expectation(description: "Fetch configuration")
 
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
-            XCTAssertEqual(configuration?.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
+        let configuration = try await apiClient.fetchOrReturnRemoteConfiguration()
+        XCTAssertEqual(configuration.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")
     }
 
-    func testFetchConfiguration_withClientToken_returnsTheConfiguration() {
+    func testFetchConfiguration_withClientToken_returnsTheConfiguration() async throws {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
-        let expectation = expectation(description: "Fetch configuration")
 
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
-            // Note: client token uses a different merchant ID than the merchant whose tokenization key
-            // we use in the other test
-            XCTAssertEqual(configuration?.json?["merchantId"].asString(), "348pk9cgf3bgyw2b")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        let configuration = try await apiClient.fetchOrReturnRemoteConfiguration()
+        // Note: client token uses a different merchant ID than the merchant whose tokenization key
+        // we use in the other test
+        XCTAssertEqual(configuration.json?["merchantId"].asString(), "348pk9cgf3bgyw2b")
     }
 
-    func testFetchConfiguration_withVersionThreeClientToken_returnsTheConfiguration() {
+    func testFetchConfiguration_withVersionThreeClientToken_returnsTheConfiguration() async throws {
         let apiClient = BTAPIClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
-        let expectation = expectation(description: "Fetch configuration")
 
-        apiClient.fetchOrReturnRemoteConfiguration { configuration, error in
-            // Note: client token uses a different merchant ID than the merchant whose tokenization key
-            // we use in the other test
-            XCTAssertEqual(configuration?.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
+        let configuration = try await apiClient.fetchOrReturnRemoteConfiguration()
+        // Note: client token uses a different merchant ID than the merchant whose tokenization key
+        // we use in the other test
+        XCTAssertEqual(configuration.json?["merchantId"].asString(), "dcpspy2brwdjr3qn")
     }
 }

--- a/IntegrationTests/Braintree-API-Integration-Specs/BTGraphQLHTTP_SSLPinning_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTGraphQLHTTP_SSLPinning_IntegrationTests.swift
@@ -2,34 +2,18 @@ import Foundation
 import XCTest
 @testable import BraintreeCore
 
-class BTGraphQLHTTP_SSLPinning_IntegrationTests : XCTestCase {
+final class BTGraphQLHTTP_SSLPinning_IntegrationTests: XCTestCase {
 
-    func testBTGraphQLHTTP_whenUsingProductionEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication_toBraintreeAPI() {
+    func testBTGraphQLHTTP_whenUsingProductionEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication_toBraintreeAPI() async throws {
         let url = URL(string: "https://payments.braintree-api.com")!
-
-        let expectation = self.expectation(description: "Callback invoked")
-        
-        let graphqlHttp = BTGraphQLHTTP(authorization: try! TokenizationKey("production_testing_merchant-id"), customBaseURL: url)
-        graphqlHttp.post("/ping") { body, response, error in
-            XCTAssertNil(error)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5, handler: nil)
+        let graphqlHttp = BTGraphQLHTTP(authorization: try TokenizationKey("production_testing_merchant-id"), customBaseURL: url)
+        _ = try await graphqlHttp.post("/ping")
     }
 
-    func testBTGraphQLHTTP_whenUsingSandboxEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication_toBraintreeAPI() {
+    func testBTGraphQLHTTP_whenUsingSandboxEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication_toBraintreeAPI() async throws {
         let url = URL(string: "https://payments.sandbox.braintree-api.com")!
-        
-        let expectation = self.expectation(description: "Callback invoked")
-
-        let graphqlHttp = BTGraphQLHTTP(authorization: try! TokenizationKey("sandbox_testing_merchant-id"), customBaseURL: url)
-        graphqlHttp.post("/ping") { body, response, error in
-            XCTAssertNil(error)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5, handler: nil)
+        let graphqlHttp = BTGraphQLHTTP(authorization: try TokenizationKey("sandbox_testing_merchant-id"), customBaseURL: url)
+        _ = try await graphqlHttp.post("/ping")
     }
-
 }
+

--- a/IntegrationTests/Braintree-API-Integration-Specs/BTHTTP_SSLPinning_IntegrationTests.swift
+++ b/IntegrationTests/Braintree-API-Integration-Specs/BTHTTP_SSLPinning_IntegrationTests.swift
@@ -3,49 +3,30 @@ import XCTest
 
 final class BTHTTP_SSLPinning_IntegrationTests: XCTestCase {
 
-    func testBTHTTP_whenUsingProductionEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication() {
+    func testBTHTTP_whenUsingProductionEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication() async throws {
         let url = URL(string: "https://api.braintreegateway.com")!
-        let http = BTHTTP(authorization: try! TokenizationKey("development_testing_integration_merchant_id"), customBaseURL: url)
-        let expectation = expectation(description: "Callback invoked")
-
-        http.get("/heartbeat.json") { body, _, error in
-            XCTAssertNil(error)
-            XCTAssertEqual(body?["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-production")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        let http = BTHTTP(authorization: try TokenizationKey("development_testing_integration_merchant_id"), customBaseURL: url)
+        let (body, _) = try await http.get("/heartbeat.json")
+        XCTAssertEqual(body["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-production")
     }
 
-    func testBTHTTP_whenUsingSandboxEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication() {
+    func testBTHTTP_whenUsingSandboxEnvironmentWithTrustedSSLCertificates_allowsNetworkCommunication() async throws {
         let url = URL(string: "https://api.sandbox.braintreegateway.com")!
-        let http = BTHTTP(authorization: try! TokenizationKey("sandbox_testing_integration_merchant_id"), customBaseURL: url)
-        let expectation = expectation(description: "Callback invoked")
-
-        http.get("/heartbeat.json") { body, _, error in
-            XCTAssertNil(error)
-            XCTAssertEqual(body?["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-sandbox")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        let http = BTHTTP(authorization: try TokenizationKey("sandbox_testing_integration_merchant_id"), customBaseURL: url)
+        let (body, _) = try await http.get("/heartbeat.json")
+        XCTAssertEqual(body["heartbeat"].asString(), "d2765eaa0dad9b300b971f074-sandbox")
     }
 
-    func testBTHTTP_whenUsingAServerWithValidCertificateChainWithARootCAThatWeDoNotExplicitlyTrust_doesNotAllowNetworkCommunication() {
+    func testBTHTTP_whenUsingAServerWithValidCertificateChainWithARootCAThatWeDoNotExplicitlyTrust_doesNotAllowNetworkCommunication() async {
         let url = URL(string: "https://www.globalsign.com")!
         let http = BTHTTP(authorization: try! TokenizationKey("development_testing_integration_merchant_id"), customBaseURL: url)
-        let expectation = expectation(description: "Callback invoked")
 
-        http.get("/heartbeat.json") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-
-            let error = error as NSError?
-            XCTAssertEqual(error?.domain, URLError.errorDomain)
-            XCTAssertEqual(error?.code, URLError.serverCertificateUntrusted.rawValue)
-            expectation.fulfill()
+        do {
+            _ = try await http.get("/heartbeat.json")
+            XCTFail("Expected SSL error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, URLError.errorDomain)
+            XCTAssertEqual(error.code, URLError.serverCertificateUntrusted.rawValue)
         }
-
-        waitForExpectations(timeout: 5)
     }
 }

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -99,45 +99,7 @@ import UIKit
             throw error
         }
     }
-    
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    ///
-    /// Perfom an HTTP GET on a URL composed of the configured from environment and the given path.
-    /// - Parameters:
-    ///   - path: The endpoint URI path.
-    ///   - parameters: Optional set of query parameters to be encoded with the request.
-    ///   - httpType: The underlying `BTAPIClientHTTPService` of the HTTP request. Defaults to `.gateway`.
-    ///   - completion:  A block object to be executed when the request finishes.
-    ///   On success, `body` and `response` will contain the JSON body response and the
-    ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
-    ///   `nil` and `error` will contain the error that occurred.
-    @_documentation(visibility: private)
-    public func get(
-        _ path: String,
-        parameters: Encodable? = nil,
-        httpType: BTAPIClientHTTPService = .gateway,
-        completion: @escaping RequestCompletion
-    ) {
-        if authorization.type == .invalidAuthorization {
-            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
-            return
-        }
-
-        fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
-            guard let self else {
-                completion(nil, nil, BTAPIClientError.deallocated)
-                return
-            }
-
-            if let error {
-                completion(nil, nil, error)
-                return
-            }
-
-            http(for: httpType)?.get(path, configuration: configuration, parameters: parameters, completion: completion)
-        }
-    }
-    
+       
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     ///
     /// Perfom an HTTP GET on a URL composed of the configured from environment and the given path.
@@ -166,52 +128,6 @@ import UIKit
             configuration: configuration,
             parameters: parameters
         )
-    }
-    
-    /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    ///
-    /// Perfom an HTTP POST on a URL composed of the configured from environment and the given path.
-    /// - Parameters:
-    ///   - path: The endpoint URI path.
-    ///   - parameters: Optional set of query parameters to be encoded with the request.
-    ///   - httpType: The underlying `BTAPIClientHTTPService` of the HTTP request. Defaults to `.gateway`.
-    ///   - completion:  A block object to be executed when the request finishes.
-    ///   On success, `body` and `response` will contain the JSON body response and the
-    ///   HTTP response and `error` will be `nil`; on failure, `body` and `response` will be
-    ///   `nil` and `error` will contain the error that occurred.
-    @_documentation(visibility: private)
-    public func post(
-        _ path: String,
-        parameters: Encodable? = nil,
-        headers: [String: String]? = nil,
-        httpType: BTAPIClientHTTPService = .gateway,
-        completion: @escaping RequestCompletion
-    ) {
-        if authorization.type == .invalidAuthorization {
-            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
-            return
-        }
-
-        fetchOrReturnRemoteConfiguration { [weak self] configuration, error in
-            guard let self else {
-                completion(nil, nil, BTAPIClientError.deallocated)
-                return
-            }
-
-            if let error {
-                completion(nil, nil, error)
-                return
-            }
-
-            let postParameters = BTAPIRequest(requestBody: parameters, metadata: metadata, httpType: httpType)
-            http(for: httpType)?.post(
-                path,
-                configuration: configuration,
-                parameters: postParameters,
-                headers: headers,
-                completion: completion
-            )
-        }
     }
     
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -4,10 +4,6 @@ import UIKit
 /// - Note: It also manages authentication via tokenization key and provides access to a merchant's gateway configuration.
 @objcMembers public class BTAPIClient: NSObject, BTHTTPNetworkTiming {
 
-    /// :nodoc: This typealias is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    @_documentation(visibility: private)
-    public typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
-
     // MARK: - Public Properties
 
     /// The TokenizationKey or ClientToken used to authorize the APIClient
@@ -77,7 +73,6 @@ import UIKit
     /// cached on subsequent calls for better performance.
     @_documentation(visibility: private)
     public func fetchOrReturnRemoteConfiguration(_ completion: @escaping (BTConfiguration?, Error?) -> Void) {
-        // TODO: - Consider updating all feature clients to use async version of this method and remove this method once done
         Task { @MainActor in
             do {
                 let configuration = try await configurationLoader.getConfig()

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-// swiftlint:disable type_body_length file_length
 /// This class acts as the entry point for accessing the Braintree APIs via common HTTP methods performed on API endpoints.
 /// - Note: It also manages authentication via tokenization key and provides access to a merchant's gateway configuration.
 @objcMembers public class BTAPIClient: NSObject, BTHTTPNetworkTiming {

--- a/Sources/BraintreeCore/BTGraphQLHTTP.swift
+++ b/Sources/BraintreeCore/BTGraphQLHTTP.swift
@@ -4,53 +4,12 @@ class BTGraphQLHTTP: BTHTTP {
 
     // MARK: - Overrides
     
-    // TODO: Remove this version of get once BTAPIClient converted to async/await
-    override func get(
-        _ path: String,
-        configuration: BTConfiguration? = nil,
-        parameters: Encodable? = nil,
-        completion: @escaping RequestCompletion
-    ) {
-        dispatchQueue.async {
-            completion(nil, nil, BTGraphQLHTTPError.unsupportedOperation)
-        }
-    }
-    
     override func get(
         _ path: String,
         configuration: BTConfiguration? = nil,
         parameters: Encodable? = nil
-    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+    ) async throws -> (BTJSON, HTTPURLResponse) {
         throw BTGraphQLHTTPError.unsupportedOperation
-    }
-
-    // TODO: Remove this version of post once BTAPIClient converted to async/await
-    override func post(
-        _ path: String,
-        configuration: BTConfiguration? = nil,
-        parameters: Encodable? = nil,
-        headers: [String: String]? = nil,
-        completion: @escaping RequestCompletion
-    ) {
-        Task { [self] in
-            do {
-                let (body, response) = try await httpRequest(method: "POST", configuration: configuration, parameters: parameters)
-                let bodyDict = body?.asDictionary() as? [String: Any]
-                dispatchQueue.async {
-                    let reconstructedBody = bodyDict.map { BTJSON(value: $0) }
-                    completion(reconstructedBody, response, nil)
-                }
-            } catch {
-                let bodyFromError = (error as NSError).userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON
-                let bodyDict = bodyFromError?.asDictionary() as? [String: Any]
-                let response = (error as NSError).userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse
-                let capturedError = error
-                dispatchQueue.async {
-                    let reconstructedBody = bodyDict.map { BTJSON(value: $0) }
-                    completion(reconstructedBody, response, capturedError)
-                }
-            }
-        }
     }
 
     override func post(
@@ -58,7 +17,7 @@ class BTGraphQLHTTP: BTHTTP {
         configuration: BTConfiguration? = nil,
         parameters: Encodable? = nil,
         headers: [String: String]? = nil
-    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+    ) async throws -> (BTJSON, HTTPURLResponse) {
         try await httpRequest(method: "POST", configuration: configuration, parameters: parameters)
     }
 
@@ -68,7 +27,7 @@ class BTGraphQLHTTP: BTHTTP {
         method: String,
         configuration: BTConfiguration? = nil,
         parameters: Encodable? = nil
-    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+    ) async throws -> (BTJSON, HTTPURLResponse) {
         var errorUserInfo: [String: Any] = [:]
 
         guard

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -67,16 +67,12 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
     }
 
     // MARK: - HTTP Methods
-
-    func get(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, completion: @escaping RequestCompletion) {
-        httpRequest(method: .get, path: path, configuration: configuration, parameters: parameters, completion: completion)
-    }
     
     func get(
         _ path: String,
         configuration: BTConfiguration? = nil,
         parameters: Encodable? = nil
-    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+    ) async throws -> (BTJSON, HTTPURLResponse) {
         try await httpRequest(
             method: .get,
             path: path,
@@ -89,30 +85,8 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
         _ path: String,
         configuration: BTConfiguration? = nil,
         parameters: Encodable? = nil,
-        headers: [String: String]? = nil,
-        completion: @escaping RequestCompletion
-    ) {
-        if authorization.type == .invalidAuthorization {
-            completion(nil, nil, BTAPIClientError.invalidAuthorization(authorization.originalValue))
-            return
-        }
-        
-        httpRequest(
-            method: .post,
-            path: path,
-            configuration: configuration,
-            parameters: parameters,
-            headers: headers,
-            completion: completion
-        )
-    }
-    
-    func post(
-        _ path: String,
-        configuration: BTConfiguration? = nil,
-        parameters: Encodable? = nil,
         headers: [String: String]? = nil
-    ) async throws -> (BTJSON?, HTTPURLResponse?) {
+    ) async throws -> (BTJSON, HTTPURLResponse) {
         try await httpRequest(
             method: .post,
             path: path,
@@ -123,52 +97,6 @@ class BTHTTP: NSObject, URLSessionTaskDelegate {
     }
 
     // MARK: - HTTP Method Helpers
-
-    // TODO: Remove once code calling completion handler version is removed.
-    func httpRequest(
-        method: BTHTTPMethod,
-        path: String,
-        configuration: BTConfiguration? = nil,
-        parameters: Encodable? = nil,
-        headers: [String: String]? = nil,
-        completion: RequestCompletion?
-    ) {
-        guard let completion else { return }
-
-        Task { [weak self] in
-            guard let self else {
-                completion(nil, nil, BTHTTPError.deallocated("BTHTTP"))
-                return
-            }
-
-            do {
-                let (json, httpResponse) = try await httpRequest(
-                    method: method,
-                    path: path,
-                    configuration: configuration,
-                    parameters: parameters,
-                    headers: headers
-                )
-                let jsonDict = json.asDictionary() as? [String: Any]
-                let jsonValue = json.value
-                let capturedResponse = httpResponse
-                self.dispatchQueue.async {
-                    let reconstructedJSON = jsonDict.map { BTJSON(value: $0) } ?? BTJSON(value: jsonValue)
-                    completion(reconstructedJSON, capturedResponse, nil)
-                }
-            } catch {
-                let bodyFromError = (error as NSError).userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON
-                let bodyDict = bodyFromError?.asDictionary() as? [String: Any]
-                let response = (error as NSError).userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse
-                let capturedError = error
-
-                self.dispatchQueue.async {
-                    let reconstructedBody = bodyDict.map { BTJSON(value: $0) }
-                    completion(reconstructedBody, response, capturedError)
-                }
-            }
-        }
-    }
     
     func httpRequest(
         method: BTHTTPMethod,

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Security
 
-// swiftlint:disable type_body_length file_length
+// swiftlint:disable type_body_length
 /// Performs HTTP methods on the Braintree Client API
 class BTHTTP: NSObject, URLSessionTaskDelegate {
 

--- a/Sources/BraintreeCore/BTHTTP.swift
+++ b/Sources/BraintreeCore/BTHTTP.swift
@@ -5,15 +5,10 @@ import Security
 /// Performs HTTP methods on the Braintree Client API
 class BTHTTP: NSObject, URLSessionTaskDelegate {
 
-    typealias RequestCompletion = (BTJSON?, HTTPURLResponse?, Error?) -> Void
-
     // MARK: - Internal Properties
 
     /// An array of pinned certificates, each a Data instance consisting of DER encoded x509 certificates
     let pinnedCertificates: [Data] = BTAPIPinnedCertificates.trustedCertificates()
-
-    /// DispatchQueue on which asynchronous code will be executed. Defaults to `DispatchQueue.main`.
-    var dispatchQueue = DispatchQueue.main
     
     /// A URL set to override the URLs derived from the ClientAuthorization or BTConfiguration response
     let customBaseURL: URL?

--- a/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
+++ b/Sources/BraintreeCore/Configuration/ConfigurationLoader.swift
@@ -60,7 +60,7 @@ class ConfigurationLoader {
             do {
                 let (body, response) = try await http.get(configPath, parameters: BTConfigurationRequest())
 
-                if response?.statusCode != 200 || body == nil {
+                if response.statusCode != 200 {
                     throw BTAPIClientError.configurationUnavailable
                 } else {
                     let configuration = BTConfiguration(json: body)

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -55,39 +55,23 @@ class BTAPIClient_Tests: XCTestCase {
 
     // MARK: - Dispatch Queue
 
-    func testCallbacks_useMainDispatchQueue() {
+    func testCallbacks_useMainDispatchQueue() async throws {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
         let mockHTTP = FakeHTTP.fakeHTTP()
 
-        // Override apiClient.http so that requests don't fail
         apiClient.http = mockHTTP
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
 
-        let expectation1 = expectation(description: "Fetch configuration")
-        apiClient.fetchOrReturnRemoteConfiguration() { _, _ in
-            XCTAssert(Thread.isMainThread)
-            expectation1.fulfill()
-        }
+        _ = try await apiClient.fetchOrReturnRemoteConfiguration()
+        XCTAssertTrue(Thread.isMainThread)
 
-        let expectation2 = expectation(description: "GET request")
-        apiClient.get("/endpoint", parameters: nil) { _, response, error in
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-            XCTAssert(Thread.isMainThread)
-            expectation2.fulfill()
-        }
+        _ = try await apiClient.get("/endpoint", parameters: nil)
+        XCTAssertTrue(Thread.isMainThread)
 
-        let expectation3 = expectation(description: "POST request")
-        apiClient.post("/endpoint", parameters: nil) { _, response, error in
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-            XCTAssert(Thread.isMainThread)
-            expectation3.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        _ = try await apiClient.post("/endpoint", parameters: nil)
+        XCTAssertTrue(Thread.isMainThread)
     }
 
     // MARK: - Analytics
@@ -169,7 +153,7 @@ class BTAPIClient_Tests: XCTestCase {
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
-        
+
         _ = try await apiClient.post("/", parameters: nil, httpType: .gateway)
 
         let metaParameters = mockHTTP.lastRequestParameters?["_meta"] as? [String: Any]
@@ -183,7 +167,7 @@ class BTAPIClient_Tests: XCTestCase {
         let mockGraphQLHTTP = FakeGraphQLHTTP.fakeHTTP()
         let mockHTTP = FakeHTTP.fakeHTTP()
         let metadata = apiClient.metadata
-        
+
         apiClient.graphQLHTTP = mockGraphQLHTTP
         apiClient.http = mockHTTP
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
@@ -197,7 +181,7 @@ class BTAPIClient_Tests: XCTestCase {
         XCTAssertEqual(metaParameters?["source"] as? String, metadata.source.stringValue)
         XCTAssertEqual(metaParameters?["sessionId"] as? String, metadata.sessionID)
     }
-    
+
     func testPOST_withEncodableParams_whenUsingGateway_includesMetadata() async throws {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
         let mockHTTP = FakeHTTP.fakeHTTP()
@@ -207,7 +191,7 @@ class BTAPIClient_Tests: XCTestCase {
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
-        
+
         let postParameters = FakeRequest(testValue: "fake-value")
         _ = try await apiClient.post("/", parameters: postParameters, httpType: .gateway)
 
@@ -228,7 +212,7 @@ class BTAPIClient_Tests: XCTestCase {
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
         mockHTTP.cannedStatusCode = 200
-        
+
         let postParameters = FakeRequest(testValue: "fake-value")
         _ = try await apiClient.post("/", parameters: postParameters, httpType: .graphQLAPI)
 
@@ -238,58 +222,19 @@ class BTAPIClient_Tests: XCTestCase {
         XCTAssertEqual(metaParameters?["sessionId"] as? String, metadata.sessionID)
     }
 
-    // MARK: - Timeouts
+    // MARK: - Config fetch errors
 
-    func testGETCallback_returnFetchConfigErrors() {
+    func testGET_returnsFetchConfigErrors() async throws {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockHTTP: FakeHTTP = FakeHTTP.fakeHTTP()
+        let mockHTTP = FakeHTTP.fakeHTTP()
         apiClient.http = mockHTTP
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
-        
-        let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
-        let expectation = expectation(description: "GET request")
-        apiClient.get("/example", parameters: nil) { body, response, error in
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            XCTAssertEqual(mockError, error as NSError?)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 5)
-    }
-
-    func testPOSTCallback_returnFetchConfigErrors() {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockHTTP: FakeHTTP = FakeHTTP.fakeHTTP()
-        apiClient.http = mockHTTP
-        apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
-        
-        let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
-        mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
-
-        let expectation = expectation(description: "GET request")
-        apiClient.post("/example", parameters: nil) { body, response, error in
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            XCTAssertEqual(mockError, error as NSError?)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 5)
-
-    }
-    
-    func testGET_withAsyncAwait_returnFetchConfigErrors() async throws {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockHTTP: FakeHTTP = FakeHTTP.fakeHTTP()
-        apiClient.http = mockHTTP
-        apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
-        
-        let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
+        let mockError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
 
         do {
-            let _ = try await apiClient.get("/example", parameters: nil)
+            _ = try await apiClient.get("/example", parameters: nil)
             XCTFail("Expected error to be thrown")
         } catch {
             let nsError = error as NSError
@@ -297,18 +242,18 @@ class BTAPIClient_Tests: XCTestCase {
             XCTAssertEqual(nsError.code, mockError.code)
         }
     }
-        
-    func testPOST_withAsyncAwait_returnFetchConfigErrors() async throws {
+
+    func testPOST_returnsFetchConfigErrors() async throws {
         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockHTTP: FakeHTTP = FakeHTTP.fakeHTTP()
+        let mockHTTP = FakeHTTP.fakeHTTP()
         apiClient.http = mockHTTP
         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
-        
-        let mockError: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
+
+        let mockError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
         mockHTTP.stubRequest(withMethod: "GET", toEndpoint: "/client_api/v1/configuration", respondWithError: mockError)
-        
+
         do {
-            let _ = try await apiClient.post("/example", parameters: nil)
+            _ = try await apiClient.post("/example", parameters: nil)
             XCTFail("Expected error to be thrown")
         } catch {
             let nsError = error as NSError

--- a/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTAPIClient_Tests.swift
@@ -56,23 +56,23 @@ class BTAPIClient_Tests: XCTestCase {
     // MARK: - Dispatch Queue
 
     func testCallbacks_useMainDispatchQueue() async throws {
-        let apiClient = BTAPIClient(authorization: "development_tokenization_key")
-        let mockHTTP = FakeHTTP.fakeHTTP()
+         let apiClient = BTAPIClient(authorization: "development_tokenization_key")
+         let mockHTTP = FakeHTTP.fakeHTTP()
 
-        apiClient.http = mockHTTP
-        apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
-        mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
-        mockHTTP.cannedStatusCode = 200
+         apiClient.http = mockHTTP
+         apiClient.configurationLoader = MockConfigurationLoader(http: mockHTTP)
+         mockHTTP.cannedConfiguration = BTJSON(value: ["test": true])
+         mockHTTP.cannedStatusCode = 200
 
-        _ = try await apiClient.fetchOrReturnRemoteConfiguration()
-        XCTAssertTrue(Thread.isMainThread)
+         _ = try await apiClient.fetchOrReturnRemoteConfiguration()
+         await MainActor.run { XCTAssertTrue(Thread.isMainThread) }
 
-        _ = try await apiClient.get("/endpoint", parameters: nil)
-        XCTAssertTrue(Thread.isMainThread)
+         _ = try await apiClient.get("/endpoint", parameters: nil)
+         await MainActor.run { XCTAssertTrue(Thread.isMainThread) }
 
-        _ = try await apiClient.post("/endpoint", parameters: nil)
-        XCTAssertTrue(Thread.isMainThread)
-    }
+         _ = try await apiClient.post("/endpoint", parameters: nil)
+         await MainActor.run { XCTAssertTrue(Thread.isMainThread) }
+     }
 
     // MARK: - Analytics
 

--- a/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTGraphQLHTTP_Tests.swift
@@ -12,7 +12,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
         testConfiguration.protocolClasses = [BTHTTPTestProtocol.self]
         return URLSession(configuration: testConfiguration)
     }
-    
+
     var fakeConfiguration: BTConfiguration {
         let json = BTJSON(value: [
             "clientApiUrl": "https://fake-client-api-url.com/path",
@@ -34,196 +34,130 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
 
     // MARK: - Basic request handling
 
-    func testRequests_usesGraphQLURLFromConfig() {
-        let expectation = expectation(description: "GET callback")
+    func testRequests_usesGraphQLURLFromConfig() async throws {
         http?.session = fakeSession
-
-        http?.post("", configuration: fakeConfiguration) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-
-            XCTAssertTrue(httpRequest.url!.absoluteString.contains("bt-http-test://base.example.com:1234/base/path"))
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertTrue(httpRequest.url!.absoluteString.contains("bt-http-test://base.example.com:1234/base/path"))
     }
-    
-    func testRequests_whenNilConfig_throwsError() {
-        let expectation = expectation(description: "callback")
-        http?.session = fakeSession
 
-        http?.post("") { _, _, error in
-            let error = error! as NSError
+    func testRequests_whenNilConfig_throwsError() async {
+        http?.session = fakeSession
+        do {
+            _ = try await http!.post("")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, "com.braintreepayments.BTHTTPErrorDomain")
             XCTAssertEqual(error.code, 4)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1)
     }
-    
-    func testRequests_whenConfigMissingGraphQLURL_throwsError() {
+
+    func testRequests_whenConfigMissingGraphQLURL_throwsError() async {
         let json = BTJSON(value: [
             "clientApiUrl": "https://fake-client-api-url.com/path",
-            "graphQL": [ ]
+            "graphQL": []
         ])
         let fakeConfiguration = BTConfiguration(json: json)
-        
-        let expectation = expectation(description: "callback")
         http?.session = fakeSession
 
-        http?.post("", configuration: fakeConfiguration) { _, _, error in
-            let error = error! as NSError
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, "com.braintreepayments.BTHTTPErrorDomain")
             XCTAssertEqual(error.code, 4)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1)
     }
 
-    func testRequests_ignoreThePath() {
-        let expectation = expectation(description: "GET callback")
+    func testRequests_ignoreThePath() async throws {
         http?.session = fakeSession
-
-        http?.post("hey/go/here.html", configuration: fakeConfiguration) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-
-            XCTAssertEqual(httpRequest.url!.absoluteString, "bt-http-test://base.example.com:1234/base/path")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("hey/go/here.html", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url!.absoluteString, "bt-http-test://base.example.com:1234/base/path")
     }
-    
+
     // MARK: - Unsupported requests
 
-    func testGETRequests_areUnsupported() {
-        let expectation = expectation(description: "GET callback")
-        http?.get("") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-            XCTAssertEqual((error as? BTGraphQLHTTPError), BTGraphQLHTTPError.unsupportedOperation)
-            expectation.fulfill()
+    func testGETRequests_areUnsupported() async {
+        do {
+            _ = try await http!.get("")
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? BTGraphQLHTTPError, BTGraphQLHTTPError.unsupportedOperation)
         }
-        waitForExpectations(timeout: 2)
     }
 
     // MARK: - POST requests
-    
-    func testPOSTRequests_sendsParametersInBody() {
-        let expectation = expectation(description: "POST callback")
+
+    func testPOSTRequests_sendsParametersInBody() async throws {
         http?.session = fakeSession
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration, parameters: ["hey": "now"])
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let bodyJSONData = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body).data(using: .utf8)
+        let bodyJSON = try? JSONSerialization.jsonObject(with: bodyJSONData!) as? [String: String] ?? [:]
 
-        http?.post("", configuration: fakeConfiguration, parameters: ["hey": "now"]) { body, _, error in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let bodyJSONData = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!).data(using: .utf8)
-
-            let bodyJSON = try? JSONSerialization.jsonObject(with: bodyJSONData!) as? [String: String] ?? [:]
-
-            XCTAssertEqual(httpRequest.url!.absoluteString, "bt-http-test://base.example.com:1234/base/path")
-            XCTAssertEqual(bodyJSON, ["hey": "now"])
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        XCTAssertEqual(httpRequest.url!.absoluteString, "bt-http-test://base.example.com:1234/base/path")
+        XCTAssertEqual(bodyJSON, ["hey": "now"])
     }
 
-    func testPOSTRequests_whenSuccessful_returnsData() {
-        let expectation = expectation(description: "POST callback")
+    func testPOSTRequests_whenSuccessful_returnsData() async throws {
         let stubResponseData: [String: Any] = ["success": true]
-
-        HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubResponseData, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration, parameters: ["hey": "now"]) { body, _, _ in
-            XCTAssertEqual(body?.asDictionary(), stubResponseData as NSDictionary)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration, parameters: ["hey": "now"])
+        XCTAssertEqual(body.asDictionary(), stubResponseData as NSDictionary)
     }
 
     // MARK: - Headers
 
-    func testRequests_sendUserAgentHeader() {
-        let expectation = expectation(description: "POST callback")
+    func testRequests_sendUserAgentHeader() async throws {
         http?.session = fakeSession
-
-        http?.post("", configuration: fakeConfiguration, parameters: nil) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let requestHeaders = httpRequest.allHTTPHeaderFields
-            XCTAssertTrue((requestHeaders!["User-Agent"])!.matches("^Braintree/iOS/\\d+\\.\\d+\\.\\d+(-[0-9a-zA-Z-]+)?$"))
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertTrue((httpRequest.allHTTPHeaderFields!["User-Agent"])!.matches("^Braintree/iOS/\\d+\\.\\d+\\.\\d+(-[0-9a-zA-Z-]+)?$"))
     }
 
-    func testRequests_sendBraintreeVersionHeader() {
-        let expectation = expectation(description: "POST callback")
+    func testRequests_sendBraintreeVersionHeader() async throws {
         http?.session = fakeSession
-
-        http?.post("", configuration: fakeConfiguration, parameters: nil) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let requestHeaders = httpRequest.allHTTPHeaderFields
-            XCTAssertEqual(requestHeaders!["Braintree-Version"], "2018-03-06")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields!["Braintree-Version"], "2018-03-06")
     }
 
-    func testRequests_whenUsingTokenizationKey_sendsItInHeaders() {
-        let expectation = expectation(description: "POST callback")
+    func testRequests_whenUsingTokenizationKey_sendsItInHeaders() async throws {
         let fakeTokenizationKey = try! TokenizationKey("development_testing_key")
         http = BTGraphQLHTTP(authorization: fakeTokenizationKey, customBaseURL: BTHTTPTestProtocol.testBaseURL())
         http?.session = fakeSession
 
-        http?.post("", parameters: nil) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let requestHeaders = httpRequest.allHTTPHeaderFields
-            XCTAssertEqual(requestHeaders!["Authorization"], "Bearer development_testing_key")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", parameters: nil)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields!["Authorization"], "Bearer development_testing_key")
     }
 
-    func testRequests_whenUsingAuthorizationFingerprint_sendsItInHeaders() {
-        let expectation = expectation(description: "POST callback")
+    func testRequests_whenUsingAuthorizationFingerprint_sendsItInHeaders() async throws {
         http?.session = fakeSession
-
-        http?.post("", configuration: fakeConfiguration, parameters: nil) { body, _, _ in
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let requestHeaders = httpRequest.allHTTPHeaderFields
-            XCTAssertEqual(requestHeaders!["Authorization"], "Bearer test-authorization-fingerprint")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, _) = try await http!.post("", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields!["Authorization"], "Bearer test-authorization-fingerprint")
     }
 
     // MARK: - Error handling
 
-    func testErrorResponse_whenErrorTypeIsUserError_containsExpectedError() {
-        let expectation = expectation(description: "POST callback")
+    func testErrorResponse_whenErrorTypeIsUserError_containsExpectedError() async {
         let stubGraphQLErrorResponse: [String: Any?] = [
             "data": ["tokenizeCreditCard": nil] as [String: Any?],
             "errors": [
                 [
                     "message": "Expiration month is invalid",
                     "path": ["tokenizeCreditCard"],
-                    "locations": [
-                        ["line": 1, "column": 66]
-                    ],
+                    "locations": [["line": 1, "column": 66]],
                     "extensions": [
                         "errorType": "user_error",
                         "legacyCode": "81712",
@@ -233,9 +167,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                 [
                     "message": "Expiration year is invalid",
                     "path": ["tokenizeCreditCard"],
-                    "locations": [
-                        ["line": 1, "column": 66]
-                    ],
+                    "locations": [["line": 1, "column": 66]],
                     "extensions": [
                         "errorType": "user_error",
                         "legacyCode": "81713",
@@ -245,9 +177,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                 [
                     "message": "CVV verification failed",
                     "path": ["tokenizeCreditCard"],
-                    "locations": [
-                        ["line": 1, "column": 66]
-                    ],
+                    "locations": [["line": 1, "column": 66]],
                     "extensions": [
                         "errorType": "user_error",
                         "legacyCode": "81736",
@@ -257,9 +187,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                 [
                     "message": "Street address verification failed",
                     "path": ["tokenizeCreditCard"],
-                    "locations": [
-                        ["line": 1, "column": 66]
-                    ],
+                    "locations": [["line": 1, "column": 66]],
                     "extensions": [
                         "errorType": "user_error",
                         "legacyCode": "12345",
@@ -276,29 +204,13 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                 [
                     "field": "creditCard",
                     "fieldErrors": [
-                        [
-                            "field": "expirationMonth",
-                            "code": "81712",
-                            "message": "Expiration month is invalid"
-                        ],
-                        [
-                            "field": "expirationYear",
-                            "code": "81713",
-                            "message": "Expiration year is invalid"
-                        ],
-                        [
-                            "field": "cvv",
-                            "code": "81736",
-                            "message": "CVV verification failed"
-                        ] as [String: Any],
+                        ["field": "expirationMonth", "code": "81712", "message": "Expiration month is invalid"],
+                        ["field": "expirationYear", "code": "81713", "message": "Expiration year is invalid"],
+                        ["field": "cvv", "code": "81736", "message": "CVV verification failed"] as [String: Any],
                         [
                             "field": "billingAddress",
                             "fieldErrors": [
-                                [
-                                    "field": "streetAddress",
-                                    "code": "12345",
-                                    "message": "Street address verification failed"
-                                ]
+                                ["field": "streetAddress", "code": "12345", "message": "Street address verification failed"]
                             ]
                         ]
                     ]
@@ -306,39 +218,36 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             ]
         ]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
+            XCTAssertEqual(error.code, BTHTTPError.clientError([:]).errorCode)
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response body in error userInfo")
             }
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testErrorResponse_whenErrorTypeIsNotUserError_containsExpectedError() {
-        let expectation = expectation(description: "POST callback")
+    func testErrorResponse_whenErrorTypeIsNotUserError_containsExpectedError() async {
         let stubGraphQLErrorResponse: [String: Any?] = [
             "data": ["tokenizeCard": nil] as [String: Any?],
             "errors": [
                 [
                     "message": "Validation is not supported for requests authorized with a tokenization key.",
-                    "locations": [
-                        ["line": 2, "column": 9]
-                    ],
+                    "locations": [["line": 2, "column": 9]],
                     "path": ["tokenizeCreditCard"],
                     "extensions": [
                         "errorType": "developer_error",
@@ -353,90 +262,80 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             "error": ["message": "Validation is not supported for requests authorized with a tokenization key."]
         ]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String : Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response body in error userInfo")
             }
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testErrorResponse_withNoErrorType_containsGenericMessage() {
-        let expectation = expectation(description: "POST callback")
+    func testErrorResponse_withNoErrorType_containsGenericMessage() async {
         let stubGraphQLErrorResponse: [String: Any] = [
             "data": NSNull(), "errors": [["message": "This is a bad error message"]]
         ]
-
         let expectedErrorBody = ["error": ["message": "An unexpected error occurred"]]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response body in error userInfo")
             }
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testErrorResponse_withGarbage_containsGenericMessage() {
-        let expectation = expectation(description: "POST callback")
-        let stubGraphQLErrorResponse = "something went wrong"
-
+    func testErrorResponse_withGarbage_containsGenericMessage() async {
         let expectedErrorBody = ["error": ["message": "An unexpected error occurred"]]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
-                data: stubGraphQLErrorResponse.data(using: .utf8)!,
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
+                data: "something went wrong".data(using: .utf8)!,
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response body in error userInfo")
             }
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testErrorResponse_correctlyMapsErrorTypeToStatusCode() {
+    func testErrorResponse_correctlyMapsErrorTypeToStatusCode() async {
         let errorTypes = ["user_error": 422, "developer_error": 403, "unknown_error": 500]
         let errorCodes: [String: Int] = [
             "user_error": BTHTTPError.clientError([:]).errorCode,
@@ -444,58 +343,38 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
             "unknown_error": BTHTTPError.serverError([:]).errorCode
         ]
 
-        for (errorType, _) in errorTypes {
+        for (errorType, expectedStatusCode) in errorTypes {
             HTTPStubs.removeAllStubs()
 
-            let expectedStatusCode = errorTypes[errorType]
-            let stubGraphQLErrorResponse = [
-                "errors": [
-                    [
-                        "extensions": ["errorType": errorType]
-                    ]
-                ]
-            ]
-
-            HTTPStubs.stubRequests { request in
-              return true
-            } withStubResponse: { request in
+            let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+                let body = ["errors": [["extensions": ["errorType": errorType]]]]
                 return HTTPStubsResponse(
-                    data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
+                    data: try! JSONSerialization.data(withJSONObject: body, options: .prettyPrinted),
                     statusCode: 200,
                     headers: ["Content-Type": "application/json"]
                 )
             }
+            defer { HTTPStubs.removeStub(stub) }
 
-            let expectation = expectation(description: "POST callback \(errorType)")
             let fakeClientToken = try! BTClientToken(clientToken: TestClientTokenFactory.stubbedURLClientToken)
             let testHttp = BTGraphQLHTTP(authorization: fakeClientToken)
 
-            testHttp.post("", configuration: fakeConfiguration) { body, _, error in
-                guard let error = error as NSError? else {
-                    XCTFail("Expected error but got nil for errorType: \(errorType)")
-                    expectation.fulfill()
-                    return
+            do {
+                _ = try await testHttp.post("", configuration: fakeConfiguration)
+                XCTFail("Expected error for errorType: \(errorType)")
+            } catch let error as NSError {
+                guard let urlResponse = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse else {
+                    XCTFail("Expected urlResponseKey in error.userInfo for errorType: \(errorType)")
+                    continue
                 }
-
-                guard let errorDictionary = error.userInfo[BTCoreConstants.urlResponseKey] as? HTTPURLResponse else {
-                    XCTFail("Expected urlResponseKey in error.userInfo for errorType: \(errorType). Error: \(error), userInfo: \(error.userInfo)")
-                    expectation.fulfill()
-                    return
-                }
-
-                XCTAssertEqual(errorDictionary.statusCode, expectedStatusCode)
+                XCTAssertEqual(urlResponse.statusCode, expectedStatusCode, "Mismatch for errorType: \(errorType)")
                 XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
                 XCTAssertEqual(error.code, errorCodes[errorType])
-
-                expectation.fulfill()
             }
-
-            waitForExpectations(timeout: 2)
         }
     }
 
-    func testErrorResponse_whenErrorIsMissingLegacyCode_doesNotSetCodeNumber() {
-        let expectation = expectation(description: "POST callback")
+    func testErrorResponse_whenErrorIsMissingLegacyCode_doesNotSetCodeNumber() async {
         let stubGraphQLErrorResponse: [String: Any?] = [
             "data": ["tokenizeCreditCard": nil] as [String: Any?],
             "errors": [
@@ -507,7 +386,7 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                         "inputPath": ["input", "creditCard", "expirationMonth"]
                     ] as [String: Any]
                 ] as [String: Any]
-            ],
+            ]
         ]
 
         let expectedErrorBody: [String: Any?] = [
@@ -516,249 +395,73 @@ final class BTGraphQLHTTP_Tests: XCTestCase {
                 [
                     "field": "creditCard",
                     "fieldErrors": [
-                        [
-                            "field": "expirationMonth",
-                            "message": "Expiration month is invalid"
-                        ]
+                        ["field": "expirationMonth", "message": "Expiration month is invalid"]
                     ]
                 ] as [String: Any]
             ]
         ]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
+        do {
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
+            } else {
+                XCTFail("Expected JSON response body in error userInfo")
             }
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testErrorResponse_withNoErrorTypeAndContainsExtension_sendsErrorMessage() {
-        let expectation = expectation(description: "POST callback")
+    func testErrorResponse_withNoErrorTypeAndContainsExtension_sendsErrorMessage() async {
         let stubGraphQLErrorResponse: [String: Any?] = [
             "errors": [["message": "Error message that is helpful"]],
             "extensions": ["requestId": "a-fake-request-id"]
         ]
-
         let expectedErrorBody = ["error": ["message": "Error message that is helpful"]]
 
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
-
-        http?.post("", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertEqual(body?.asDictionary(), expectedErrorBody as NSDictionary)
-
-            let error = error as NSError?
-            if let errorDictionary = error?.userInfo[BTCoreConstants.jsonResponseBodyKey] as? [String: Any] {
-                XCTAssertEqual(errorDictionary as NSDictionary, expectedErrorBody as NSDictionary)
-            }
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
-
-    func testNetworkError_returnsError() {
-        let expectation = expectation(description: "POST callback")
-
-        HTTPStubs.stubRequests { request in
-          return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: -1002, userInfo: [:]))
-        }
-
-        http?.post("", configuration: fakeConfiguration) { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-
-            let error = error as NSError?
-            XCTAssertEqual(error?.domain, URLError.errorDomain)
-            XCTAssertEqual(error?.code, -1002)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
-
-    // MARK: - Async/Await Tests
-
-    func testAsyncPost_whenSuccessful_returnsData() async throws {
-        let stubResponseData: [String: Any] = ["success": true]
-
-        HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
-                data: try! JSONSerialization.data(withJSONObject: stubResponseData, options: .prettyPrinted),
-                statusCode: 200,
-                headers: ["Content-Type": "application/json"]
-            )
-        }
-
-        let (body, response) = try await http!.post("", configuration: fakeConfiguration, parameters: ["hey": "now"])
-
-        XCTAssertEqual(body?.asDictionary(), stubResponseData as NSDictionary)
-        XCTAssertNotNil(response)
-    }
-
-    func testAsyncPost_whenNilConfig_throwsError() async {
-        do {
-            _ = try await http!.post("", configuration: nil, parameters: nil as Encodable?)
-            XCTFail("Should have thrown an error")
-        } catch {
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, "com.braintreepayments.BTHTTPErrorDomain")
-            XCTAssertEqual(nsError.code, 4)
-        }
-    }
-
-    func testAsyncPost_whenNetworkError_throwsError() async {
-        HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: -1002, userInfo: [:]))
-        }
+        defer { HTTPStubs.removeStub(stub) }
 
         do {
-            _ = try await http!.post("", configuration: fakeConfiguration, parameters: nil as Encodable?)
-            XCTFail("Should have thrown an error")
-        } catch {
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, URLError.errorDomain)
-            XCTAssertEqual(nsError.code, -1002)
-        }
-    }
-
-    func testAsyncPost_whenErrorTypeIsUserError_throwsErrorWithExpectedDetails() async {
-        let stubGraphQLErrorResponse: [String: Any?] = [
-            "data": ["tokenizeCreditCard": nil] as [String: Any?],
-            "errors": [
-                [
-                    "message": "Expiration month is invalid",
-                    "path": ["tokenizeCreditCard"],
-                    "locations": [
-                        ["line": 1, "column": 66]
-                    ],
-                    "extensions": [
-                        "errorType": "user_error",
-                        "legacyCode": "81712",
-                        "inputPath": ["input", "creditCard", "expirationMonth"]
-                    ] as [String: Any]
-                ] as [String: Any]
-            ]
-        ]
-
-        let expectedErrorBody: [String: Any] = [
-            "error": ["message": "Input is invalid"],
-            "fieldErrors": [
-                [
-                    "field": "creditCard",
-                    "fieldErrors": [
-                        [
-                            "field": "expirationMonth",
-                            "code": "81712",
-                            "message": "Expiration month is invalid"
-                        ]
-                    ]
-                ] as [String: Any]
-            ]
-        ]
-
-        HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
-                data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
-                statusCode: 200,
-                headers: ["Content-Type": "application/json"]
-            )
-        }
-
-        do {
-            _ = try await http!.post("", configuration: fakeConfiguration, parameters: nil as Encodable?)
-            XCTFail("Should have thrown an error")
-        } catch {
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, BTHTTPError.errorDomain)
-            XCTAssertEqual(nsError.code, BTHTTPError.clientError([:]).errorCode)
-
-            if let errorJSON = nsError.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON,
-               let errorDictionary = errorJSON.asDictionary() {
-                XCTAssertEqual(errorDictionary, expectedErrorBody as NSDictionary)
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            if let errorJSON = error.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON {
+                XCTAssertEqual(errorJSON.asDictionary(), expectedErrorBody as NSDictionary)
             } else {
-                XCTFail("Expected error user info to contain JSON response body")
+                XCTFail("Expected JSON response body in error userInfo")
             }
         }
     }
 
-    func testAsyncPost_whenErrorTypeIsDeveloperError_throwsErrorWithExpectedDetails() async {
-        let stubGraphQLErrorResponse: [String: Any?] = [
-            "data": ["tokenizeCard": nil] as [String: Any?],
-            "errors": [
-                [
-                    "message": "Validation is not supported for requests authorized with a tokenization key.",
-                    "locations": [
-                        ["line": 2, "column": 9]
-                    ],
-                    "path": ["tokenizeCreditCard"],
-                    "extensions": [
-                        "errorType": "developer_error",
-                        "legacyCode": "50000",
-                        "inputPath": ["input", "options", "validate"]
-                    ] as [String: Any]
-                ] as [String: Any]
-            ]
-        ]
-
-        let expectedErrorBody = [
-            "error": ["message": "Validation is not supported for requests authorized with a tokenization key."]
-        ]
-
-        HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
-                data: try! JSONSerialization.data(withJSONObject: stubGraphQLErrorResponse, options: .prettyPrinted),
-                statusCode: 200,
-                headers: ["Content-Type": "application/json"]
-            )
+    func testNetworkError_returnsError() async {
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: -1002, userInfo: [:]))
         }
+        defer { HTTPStubs.removeStub(stub) }
 
         do {
-            _ = try await http!.post("", configuration: fakeConfiguration, parameters: nil as Encodable?)
-            XCTFail("Should have thrown an error")
-        } catch {
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, BTHTTPError.errorDomain)
-
-            if let errorJSON = nsError.userInfo[BTCoreConstants.jsonResponseBodyKey] as? BTJSON,
-               let errorDictionary = errorJSON.asDictionary() {
-                XCTAssertEqual(errorDictionary, expectedErrorBody as NSDictionary)
-            } else {
-                XCTFail("Expected error user info to contain JSON response body")
-            }
+            _ = try await http!.post("", configuration: fakeConfiguration)
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, URLError.errorDomain)
+            XCTAssertEqual(error.code, -1002)
         }
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -15,17 +15,17 @@ final class BTHTTP_Tests: XCTestCase {
         testConfiguration.protocolClasses = [BTHTTPTestProtocol.self]
         return URLSession(configuration: testConfiguration)
     }
-    
+
     let fakeClientToken = try! BTClientToken(clientToken: TestClientTokenFactory.stubbedURLClientToken)
     let fakeTokenizationKey = try! TokenizationKey("development_tokenization_key")
-    
+
     var fakeConfiguration: BTConfiguration {
         let json = BTJSON(value: [
             "clientApiUrl": "https://fake-client-api-url.com/base/path"
         ])
         return BTConfiguration(json: json)
     }
-    
+
     // MARK: - Configuration
 
     override func setUp() {
@@ -40,324 +40,229 @@ final class BTHTTP_Tests: XCTestCase {
     }
 
     // MARK: - Base URL tests
-        
-    func testRequests_whenNoConfigurationSet_usesConfigURLOnAuthorization() {
+
+    func testRequests_whenNoConfigurationSet_usesConfigURLOnAuthorization() async throws {
         let http = BTHTTP(authorization: fakeTokenizationKey)
         http.session = testURLSession
-        let expectation = expectation(description: "GET callback")
 
-        http.httpRequest(method: .get, path: "200.json") { body, _, error in
-            XCTAssertNil(error)
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.host, self.fakeTokenizationKey.configURL.host)
-            XCTAssertEqual(httpRequest.url?.path, self.fakeTokenizationKey.configURL.path)
-            XCTAssertEqual(httpRequest.url?.scheme, self.fakeTokenizationKey.configURL.scheme)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+        let (body, _) = try await http.httpRequest(method: .get, path: "200.json")
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.host, fakeTokenizationKey.configURL.host)
+        XCTAssertEqual(httpRequest.url?.path, fakeTokenizationKey.configURL.path)
+        XCTAssertEqual(httpRequest.url?.scheme, fakeTokenizationKey.configURL.scheme)
     }
-    
-    func testRequests_whenNoConfigurationSet_doesNotAppendPath() {
-        let expectation = expectation(description: "callback")
 
-        http?.httpRequest(method: .get, path: "/some-really-long-path") { body, _, error in
-            XCTAssertNil(error)
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, self.fakeClientToken.configURL.path)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+    func testRequests_whenNoConfigurationSet_doesNotAppendPath() async throws {
+        let (body, _) = try await http!.httpRequest(method: .get, path: "/some-really-long-path")
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, fakeClientToken.configURL.path)
     }
-    
-    func testRequests_whenConfigurationSet_usesClientAPIURLOnConfig() {
+
+    func testRequests_whenConfigurationSet_usesClientAPIURLOnConfig() async throws {
         let http = BTHTTP(authorization: fakeTokenizationKey)
         http.session = testURLSession
-        let expectation = expectation(description: "callback")
 
-        http.httpRequest(method: .get, path: "", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertNil(error)
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.scheme, self.fakeConfiguration.clientAPIURL?.scheme)
-            XCTAssertEqual(httpRequest.url?.host, self.fakeConfiguration.clientAPIURL?.host)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+        let (body, _) = try await http.httpRequest(method: .get, path: "", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.scheme, fakeConfiguration.clientAPIURL?.scheme)
+        XCTAssertEqual(httpRequest.url?.host, fakeConfiguration.clientAPIURL?.host)
     }
-    
-    func testRequests_whenConfigurationSet_appendsPath() {
-        let expectation = expectation(description: "callback")
 
-        http?.httpRequest(method: .get, path: "/some-really-long-path", configuration: fakeConfiguration) { body, _, error in
-            XCTAssertNil(error)
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url!.path, "\(self.fakeConfiguration.clientAPIURL!.path)/some-really-long-path")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+    func testRequests_whenConfigurationSet_appendsPath() async throws {
+        let (body, _) = try await http!.httpRequest(method: .get, path: "/some-really-long-path", configuration: fakeConfiguration)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "\(fakeConfiguration.clientAPIURL!.path)/some-really-long-path")
     }
-    
-    func testRequests_useTheSpecifiedURLScheme() {
-        let expectation = expectation(description: "GET callback")
 
-        http?.get("200.json") { body, _, error in
-            XCTAssertNil(error)
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.scheme, "bt-http-test")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+    func testRequests_useTheSpecifiedURLScheme() async throws {
+        let (body, _) = try await http!.get("200.json")
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.scheme, "bt-http-test")
     }
 
     // MARK: - HTTP Method tests
 
-    func testSendsGETRequest() {
-        let expectation = expectation(description: "GET request")
-        
-        http?.get("200.json", configuration: fakeConfiguration) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+    func testSendsGETRequest() async throws {
+        let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration)
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
-            XCTAssertEqual(httpRequest.httpMethod, "GET")
-            XCTAssertNil(httpRequest.httpBody)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
+        XCTAssertEqual(httpRequest.httpMethod, "GET")
+        XCTAssertNil(httpRequest.httpBody)
     }
 
-    func testSendsGETRequestWithParameters() {
-        let expectation = expectation(description: "GET request")
+    func testSendsGETRequestWithParameters() async throws {
+        let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration, parameters: ["param": "value"])
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        http?.get("200.json", configuration: fakeConfiguration, parameters: ["param": "value"]) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
-            XCTAssertEqual(httpRequest.url?.query, "param=value&authorization_fingerprint=test-authorization-fingerprint")
-            XCTAssertEqual(httpRequest.httpMethod, "GET")
-            XCTAssertNil(httpRequest.httpBody)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
+        XCTAssertEqual(httpRequest.url?.query, "param=value&authorization_fingerprint=test-authorization-fingerprint")
+        XCTAssertEqual(httpRequest.httpMethod, "GET")
+        XCTAssertNil(httpRequest.httpBody)
     }
 
-    func testSendsPOSTRequest() {
-        let expectation = expectation(description: "POST request")
+    func testSendsPOSTRequest() async throws {
+        let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration)
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        http?.post("200.json", configuration: fakeConfiguration) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
-            XCTAssertEqual(httpRequest.httpMethod, "POST")
-            XCTAssertNil(httpRequest.url?.query)
-            XCTAssertNil(httpRequest.httpBody)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
+        XCTAssertEqual(httpRequest.httpMethod, "POST")
+        XCTAssertNil(httpRequest.url?.query)
+        XCTAssertNil(httpRequest.httpBody)
     }
-    
-    func testSendsPOSTRequestWithCodableParameters() {
+
+    func testSendsPOSTRequestWithCodableParameters() async throws {
         struct FakeCodable: Codable {
             let param: String
         }
         let parameters = FakeCodable(param: "value")
-        
-        let expectation = expectation(description: "POST request")
 
-        http?.post("200.json", configuration: fakeConfiguration, parameters: parameters) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration, parameters: parameters)
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
-            XCTAssertEqual(httpRequest.httpMethod, "POST")
-            XCTAssertNil(httpRequest.url?.query)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
+        XCTAssertEqual(httpRequest.httpMethod, "POST")
+        XCTAssertNil(httpRequest.url?.query)
 
-            let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
-            XCTAssertEqual(json["param"].asString(), "value")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
+        XCTAssertEqual(json["param"].asString(), "value")
     }
 
-    func testSendsPOSTRequestWithDictionaryParameters() {
-        let expectation = expectation(description: "POST request")
+    func testSendsPOSTRequestWithDictionaryParameters() async throws {
+        let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration, parameters: ["param": "value"])
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        http?.post("200.json", configuration: fakeConfiguration, parameters: ["param": "value"]) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
+        XCTAssertEqual(httpRequest.httpMethod, "POST")
+        XCTAssertNil(httpRequest.url?.query)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
-            XCTAssertEqual(httpRequest.httpMethod, "POST")
-            XCTAssertNil(httpRequest.url?.query)
-
-            let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
-            XCTAssertEqual(json["param"].asString(), "value")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
+        XCTAssertEqual(json["param"].asString(), "value")
     }
 
     // MARK: - Authentication
 
-    func testGETRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInQueryParams() {
-        let expectation = expectation(description: "Request with authorization")
+    func testGETRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInQueryParams() async throws {
+        let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration)
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        http?.get("200.json", configuration: fakeConfiguration) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.url?.query, "authorization_fingerprint=test-authorization-fingerprint")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.url?.query, "authorization_fingerprint=test-authorization-fingerprint")
     }
 
-    func testGETRequests_whenBTHTTPInitializedWithTokenizationKey_sendTokenizationKeyInHeader() {
+    func testGETRequests_whenBTHTTPInitializedWithTokenizationKey_sendTokenizationKeyInHeader() async throws {
         http = BTHTTP(authorization: fakeTokenizationKey)
         http?.session = testURLSession
 
-        let expectation = expectation(description: "GET callback")
-        http?.get("200.json") {body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let (body, response) = try await http!.get("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
     }
 
-    func testPOSTRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInBody() {
-        let expectation = expectation(description: "POST callback")
+    func testPOSTRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInBody() async throws {
+        let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration)
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        http?.post("200.json", configuration: fakeConfiguration) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequestBody, "{\"authorization_fingerprint\":\"test-authorization-fingerprint\"}")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
+        XCTAssertEqual(httpRequestBody, "{\"authorization_fingerprint\":\"test-authorization-fingerprint\"}")
     }
-    
-    func testPOSTRequests_whenBTHTTPInitializedWithPayPalAPIURL_sendsAuthorizationInHeader() {
-        let expectation = expectation(description: "POST callback")
 
+    func testPOSTRequests_whenBTHTTPInitializedWithPayPalAPIURL_sendsAuthorizationInHeader() async throws {
         let http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "https://api.paypal.com")!)
         http.session = testURLSession
-        
-        http.post("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Authorization"], "Bearer test-authorization-fingerprint")
-            expectation.fulfill()
-        }
+        let (body, response) = try await http.post("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Authorization"], "Bearer test-authorization-fingerprint")
     }
 
-    func testPOSTRequests_whenBTHTTPInitializedWithTokenizationKey_sendAuthorization() {
+    func testPOSTRequests_whenBTHTTPInitializedWithTokenizationKey_sendAuthorization() async throws {
         http = BTHTTP(authorization: fakeTokenizationKey)
         http?.session = testURLSession
 
-        let expectation = expectation(description: "POST callback")
-        http?.post("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let (body, response) = try await http!.post("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
     }
 
     // MARK: - Default headers tests
 
-    func testIncludeAccept() {
-        withStub() {
-            http?.get("stub://200/resource") { body, response, error in
-                XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
-                XCTAssertNil(error)
-
-                let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-                let requestHeaders = httpRequest.allHTTPHeaderFields
-                XCTAssertEqual(requestHeaders?["Accept"], "application/json")
-            }
+    func testIncludeAccept() async throws {
+        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
+            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
+            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
+
+        let (body, response) = try await http!.get("stub://200/resource")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Accept"], "application/json")
     }
 
-    func testIncludeUserAgent() {
-        withStub {
-            http?.get("stub://200/resource") { body, response, error in
-                XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
-                XCTAssertNil(error)
-
-                let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-                let requestHeaders = httpRequest.allHTTPHeaderFields
-                XCTAssertEqual(requestHeaders?["User-Agent"], "Braintree/iOS/\(BTCoreConstants.braintreeSDKVersion)")
-            }
+    func testIncludeUserAgent() async throws {
+        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
+            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
+            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
+
+        let (body, response) = try await http!.get("stub://200/resource")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["User-Agent"], "Braintree/iOS/\(BTCoreConstants.braintreeSDKVersion)")
     }
 
-    func testIncludeAcceptLanguage() {
-        withStub {
-            http?.get("stub://200/resource") { body, response, error in
-                XCTAssertNotNil(body)
-                XCTAssertNotNil(response)
-                XCTAssertNil(error)
-
-                let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-                let requestHeaders = httpRequest.allHTTPHeaderFields
-                let locale = Locale.current
-                let countryCode = (locale as NSLocale).object(forKey: .countryCode) as? String
-                let expectedLanguageString = "\(locale.language.languageCode?.identifier ?? "")-\(countryCode ?? "")"
-                XCTAssertEqual(requestHeaders?["Accept-Language"], expectedLanguageString)
-            }
+    func testIncludeAcceptLanguage() async throws {
+        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
+            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
+            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
+
+        let (body, response) = try await http!.get("stub://200/resource")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let locale = Locale.current
+        let countryCode = (locale as NSLocale).object(forKey: .countryCode) as? String
+        let expectedLanguageString = "\(locale.language.languageCode?.identifier ?? "")-\(countryCode ?? "")"
+        XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Accept-Language"], expectedLanguageString)
     }
 
     // MARK: - Parameters tests
-    
+
     struct SampleRequest: Encodable {
         enum CodingKeys: String, CodingKey {
             case stringParameter
@@ -368,7 +273,7 @@ final class BTHTTP_Tests: XCTestCase {
             case dictionaryParameter
             case arrayParameter
         }
-        
+
         let stringParameter = "value"
         let crazyStringParameter = "crazy%20and&value"
         let numericParameter = 42
@@ -378,8 +283,7 @@ final class BTHTTP_Tests: XCTestCase {
         let arrayParameter = ["arrayItem1", "arrayItem2"]
     }
 
-    func testTransmitsTheParametersAsURLEncodedQueryParameters() {
-        let expectation = expectation(description: "GET request")
+    func testTransmitsTheParametersAsURLEncodedQueryParameters() async throws {
         let expectedQueryParameters = [
             "numericParameter=42",
             "falseBooleanParameter=0",
@@ -391,26 +295,18 @@ final class BTHTTP_Tests: XCTestCase {
             "arrayParameter%5B%5D=arrayItem2"
         ]
 
-        http?.get("200.json", parameters: SampleRequest()) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let (body, response) = try await http!.get("200.json", parameters: SampleRequest())
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let actualQueryComponents = httpRequest.url?.query?.components(separatedBy: "&")
-
-            expectedQueryParameters.forEach { expectedComponent in
-                XCTAssertTrue(actualQueryComponents!.contains(expectedComponent))
-            }
-
-            expectation.fulfill()
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let actualQueryComponents = httpRequest.url?.query?.components(separatedBy: "&")
+        expectedQueryParameters.forEach { expectedComponent in
+            XCTAssertTrue(actualQueryComponents!.contains(expectedComponent))
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testTransmitsTheParametersAsJSON() {
-        let expectation = expectation(description: "POST request")
+    func testTransmitsTheParametersAsJSON() async throws {
         let expectedParameters: [String: Any] = [
             "numericParameter": 42,
             "falseBooleanParameter": false,
@@ -418,343 +314,219 @@ final class BTHTTP_Tests: XCTestCase {
             "trueBooleanParameter": true,
             "stringParameter": "value",
             "crazyStringParameter[]": "crazy%20and&value",
-            "arrayParameter": [ "arrayItem1", "arrayItem2" ],
+            "arrayParameter": ["arrayItem1", "arrayItem2"],
             "authorization_fingerprint": "test-authorization-fingerprint"
         ]
 
-        http?.post("200.json", parameters: SampleRequest()) { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        let (body, response) = try await http!.post("200.json", parameters: SampleRequest())
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
 
-            let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body!)
-            let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body!)
-            XCTAssertEqual(httpRequest.value(forHTTPHeaderField: "Content-Type"), "application/json; charset=utf-8")
+        let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
+        let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
+        XCTAssertEqual(httpRequest.value(forHTTPHeaderField: "Content-Type"), "application/json; charset=utf-8")
 
-            let actualParameters = try? JSONSerialization.jsonObject(with: httpRequestBody.data(using: .utf8)!) as? [String: Any] ?? [:]
-            XCTAssertTrue(actualParameters! == expectedParameters)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let actualParameters = try? JSONSerialization.jsonObject(with: httpRequestBody.data(using: .utf8)!) as? [String: Any] ?? [:]
+        XCTAssertTrue(actualParameters! == expectedParameters)
     }
 
     // MARK: - DispatchQueue tests
 
-    func testCallsBackOnMainQueue() {
-        let expectation = expectation(description: "Receive callback")
-
-        http?.get("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let name = __dispatch_queue_get_label(nil)
-            let currentQueue = String(cString: name, encoding: .utf8)
-            XCTAssertEqual(currentQueue, DispatchQueue.main.label)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
-
-    func testCallsBackOnSpecifiedQueue() {
-        let expectation = expectation(description: "Receive callback")
-        http?.dispatchQueue = DispatchQueue(label: "com.braintreepayments.BTHTTPSpec.callbackQueueTest")
-
-        http?.get("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-
-            let name = __dispatch_queue_get_label(nil)
-            let currentQueue = String(cString: name, encoding: .utf8)
-            XCTAssertEqual(currentQueue, self.http?.dispatchQueue.label)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+    func testCallsBackOnMainQueue() async throws {
+        let (body, response) = try await http!.get("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+        XCTAssertTrue(Thread.isMainThread)
     }
 
     // MARK: - Response Code Parser tests
 
-    func testInterprets2xxAsACompletionWithSuccess() {
-        let expectation = expectation(description: "GET callback")
+    func testInterprets2xxAsACompletionWithSuccess() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: [] as [Any?], options: .prettyPrinted),
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-            XCTAssertEqual(response?.statusCode, 200)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, response) = try await http!.get("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+        XCTAssertEqual(response.statusCode, 200)
     }
 
-    func testResponseCodeParsing_whenStatusCodeIs4xx_returnsError() {
-        let expectation = expectation(description: "GET callback")
-        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
+    func testResponseCodeParsing_whenStatusCodeIs4xx_returnsError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: errorBody, options: .prettyPrinted),
                 statusCode: 403,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("403.json") { body, response, error in
-            XCTAssertEqual(body?.asDictionary(), errorBody as NSDictionary)
-            XCTAssertNotNil(response)
-
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("403.json")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
             XCTAssertEqual(error.code, BTHTTPError.clientError([:]).errorCode)
             XCTAssertEqual(error.localizedDescription, "This is an error message from the gateway")
             XCTAssertNotNil(error.userInfo[NSLocalizedFailureReasonErrorKey])
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testResponseCodeParsing_whenStatusCodeIs429_returnsRateLimitError() {
-        let expectation = expectation(description: "GET callback")
+    func testResponseCodeParsing_whenStatusCodeIs429_returnsRateLimitError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: [:] as [String: Any?], options: .prettyPrinted),
                 statusCode: 429,
                 headers: ["Content-Type": "application/json"]
-                )
+            )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("429.json") { body, response, error in
-            XCTAssertEqual(body?.asDictionary(), [:])
-            XCTAssertNotNil(response)
-
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("429.json")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
             XCTAssertEqual(error.code, BTHTTPError.rateLimitError([:]).errorCode)
             XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String, "You are being rate-limited.")
             XCTAssertEqual(error.userInfo[NSLocalizedRecoverySuggestionErrorKey] as! String, "Please try again in a few minutes.")
             XCTAssertNotNil(error.userInfo[NSLocalizedFailureReasonErrorKey])
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testResponseCodeParsing_whenStatusCodeIs5xx_returnsError() {
-        let expectation = expectation(description: "GET callback")
-        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
+    func testResponseCodeParsing_whenStatusCodeIs5xx_returnsError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(
+        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(
                 data: try! JSONSerialization.data(withJSONObject: errorBody, options: .prettyPrinted),
                 statusCode: 503,
                 headers: ["Content-Type": "application/json"]
             )
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("503.json") { body, response, error in
-            XCTAssertEqual(body?.asDictionary(), errorBody as NSDictionary)
-            XCTAssertNotNil(response)
-
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("503.json")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
             XCTAssertEqual(error.code, BTHTTPError.serverError([:]).errorCode)
             XCTAssertTrue(error.userInfo[BTCoreConstants.urlResponseKey] is HTTPURLResponse)
             XCTAssertEqual(error.localizedDescription, "This is an error message from the gateway")
             XCTAssertEqual(error.localizedRecoverySuggestion, "Please try again later.")
             XCTAssertNotNil(error.userInfo[NSLocalizedFailureReasonErrorKey])
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testInterpretsTheNetworkBeingDownAsAnError() {
-        let expectation = expectation(description: "GET callback")
+    func testInterpretsTheNetworkBeingDownAsAnError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.notConnectedToInternet.rawValue))
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.notConnectedToInternet.rawValue))
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("network-down") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("network-down")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, URLError.errorDomain)
             XCTAssertEqual(error.code, URLError.notConnectedToInternet.rawValue)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testInterpretsTheServerBeingUnavailableAsAnError() {
-        let expectation = expectation(description: "GET callback")
+    func testInterpretsTheServerBeingUnavailableAsAnError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.cannotConnectToHost.rawValue))
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(error: NSError(domain: URLError.errorDomain, code: URLError.cannotConnectToHost.rawValue))
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("gateway-down") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("gateway-down")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, URLError.errorDomain)
             XCTAssertEqual(error.code, URLError.cannotConnectToHost.rawValue)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
     // MARK: - Response Body Parser tests
 
-    func testParsesAJSONResponseBody() {
-        let expectation = expectation(description: "GET callback")
+    func testParsesAJSONResponseBody() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(data: "{\"status\": \"OK\"}".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(data: "{\"status\": \"OK\"}".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("200.json") { body, response, error in
-            XCTAssertNotNil(body)
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
-            XCTAssertEqual(body?["status"].asString(), "OK")
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, response) = try await http!.get("200.json")
+        XCTAssertNotNil(body)
+        XCTAssertNotNil(response)
+        XCTAssertEqual(body["status"].asString(), "OK")
     }
 
-    func testAcceptsEmptyResponses() {
-        let expectation = expectation(description: "GET callback")
+    func testAcceptsEmptyResponses() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: ["Content-Type": "application/json"])
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("empty.json") { body, response, error in
-            XCTAssertEqual(response?.statusCode, 200)
-            XCTAssertNotNil(body)
-            XCTAssertEqual(body?.asDictionary()?.count, 0)
-            XCTAssertNil(error)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
+        let (body, response) = try await http!.get("empty.json")
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertNotNil(body)
+        XCTAssertEqual(body.asDictionary()?.count, 0)
     }
 
-    func testInterpretsInvalidJSONResponsesAsAJSONError() {
-        let expectation = expectation(description: "GET callback")
+    func testInterpretsInvalidJSONResponsesAsAJSONError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(data: "{ really invalid json ]".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(data: "{ really invalid json ]".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("invalid.json") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("invalid.json")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, NSCocoaErrorDomain)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 2)
     }
 
-    func testInterpretsNonJSONResponsesAsAContentTypeNotAcceptableError() {
-        let expectation = expectation(description: "GET callback")
+    func testInterpretsNonJSONResponsesAsAContentTypeNotAcceptableError() async throws {
         http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            return HTTPStubsResponse(data: "<html>response</html>".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "text/html"])
+        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
+            HTTPStubsResponse(data: "<html>response</html>".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "text/html"])
         }
+        defer { HTTPStubs.removeStub(stub) }
 
-        http?.get("200.html") { body, response, error in
-            XCTAssertNil(body)
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            guard let error = error as NSError? else { return }
+        do {
+            _ = try await http!.get("200.html")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
             XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
             XCTAssertEqual(error.code, BTHTTPError.responseContentTypeNotAcceptable([:]).errorCode)
-            HTTPStubs.removeStub(stub)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
-
-    func testNoopsForANilCompletionBlock() {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-
-        http?.get("200.json") { body, response, error in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                // no-op
-            }
         }
     }
-    
+
+    // MARK: - URLSession metrics tests
+
     @available(iOS, deprecated: 13.0, message: "Required for mocking URLSessionTaskMetrics in tests")
     func testURLSessionTaskDidFinishCollectingMetrics() {
         let mockDelegate = MockNetworkTimingDelegate()
         http?.networkTimingDelegate = mockDelegate
-        
+
         var originalRequest = URLRequest(url: URL(string: "https://example.com/graphql")!)
         originalRequest.httpBody = """
             {
@@ -769,11 +541,11 @@ final class BTHTTP_Tests: XCTestCase {
         transactionMetrics.mockFetchStartDate = Date()
         transactionMetrics.mockResponseEndDate = Date().addingTimeInterval(1)
         transactionMetrics.mockRequest = URLRequest(url: URL(string: "https://example.com/graphql")!)
-        
+
         let metrics = MockURLSessionTaskMetrics(transactionMetrics: [transactionMetrics])
-        
+
         http?.urlSession(testURLSession, task: task, didFinishCollecting: metrics)
-        
+
         XCTAssertTrue(mockDelegate.didCallFetchAPITiming)
         XCTAssertEqual(mockDelegate.receivedPath, "mutation TestMutation")
         XCTAssertNotNil(mockDelegate.receivedConnectionStartTime)
@@ -781,126 +553,16 @@ final class BTHTTP_Tests: XCTestCase {
         XCTAssertNotNil(mockDelegate.receivedStartTime)
         XCTAssertNotNil(mockDelegate.receivedEndTime)
     }
-    
+
     func testURLSessionConfiguration_hasCustomTimeoutSettings() {
         let sut = BTHTTP(authorization: fakeTokenizationKey)
         XCTAssertEqual(sut.session.configuration.timeoutIntervalForRequest, 30)
-        XCTAssertEqual(sut.session.configuration.timeoutIntervalForRequest, 30)
-    }
-    
-    // MARK: - Async Method Tests
-    
-    func testAsyncGetRequest_success() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: "{\"status\": \"OK\"}".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration)
-        print("DEBUG: BTJSON value =", String(describing: body?.value))
-        print("DEBUG: BTJSON asDictionary =", body?.asDictionary() ?? "nil")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-        XCTAssertEqual(body?["status"].asString(), "OK")
-        XCTAssertEqual(response?.statusCode, 200)
-    }
-    
-    func testAsyncGetRequest_4xxError() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: try! JSONSerialization.data(withJSONObject: errorBody, options: .prettyPrinted), statusCode: 403, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        do {
-            _ = try await http!.get("403.json", configuration: fakeConfiguration)
-            XCTFail("Expected error to be thrown")
-        } catch let error as NSError {
-            XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
-            XCTAssertEqual(error.code, BTHTTPError.clientError([:]).errorCode)
-            XCTAssertEqual(error.localizedDescription, "This is an error message from the gateway")
-        }
-    }
-    
-    func testAsyncGetRequest_5xxError() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let errorBody: [String: Any] = ["error": ["message": "This is an error message from the gateway"]]
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: try! JSONSerialization.data(withJSONObject: errorBody, options: .prettyPrinted), statusCode: 503, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        do {
-            _ = try await http!.get("503.json", configuration: fakeConfiguration)
-            XCTFail("Expected error to be thrown")
-        } catch let error as NSError {
-            XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
-            XCTAssertEqual(error.code, BTHTTPError.serverError([:]).errorCode)
-            XCTAssertEqual(error.localizedDescription, "This is an error message from the gateway")
-        }
-    }
-    
-    func testAsyncGetRequest_emptyResponse() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: Data(), statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        let (body, response) = try await http!.get("empty.json", configuration: fakeConfiguration)
-        XCTAssertNotNil(body)
-        XCTAssertEqual(body?.asDictionary()?.count, 0)
-        XCTAssertEqual(response?.statusCode, 200)
-    }
-    
-    func testAsyncGetRequest_invalidJSON() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: "{ really invalid json ]".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        do {
-            _ = try await http!.get("invalid.json", configuration: fakeConfiguration)
-            XCTFail("Expected error to be thrown")
-        } catch let error as NSError {
-            XCTAssertEqual(error.domain, NSCocoaErrorDomain)
-        }
-    }
-    
-    func testAsyncGetRequest_nonJSONContentType() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { _ in
-            HTTPStubsResponse(data: "<html>response</html>".data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "text/html"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-        do {
-            _ = try await http!.get("200.html", configuration: fakeConfiguration)
-            XCTFail("Expected error to be thrown")
-        } catch let error as NSError {
-            XCTAssertEqual(error.domain, BTHTTPError.errorDomain)
-            XCTAssertEqual(error.code, BTHTTPError.responseContentTypeNotAcceptable([:]).errorCode)
-        }
-    }
-    
-    // MARK: - Helper Methods
-
-    func withStub(_ completion: () -> Void) {
-        let stub = HTTPStubs.stubRequests { request in
-            return true
-        } withStubResponse: { request in
-            let jsonResponse: Data = try! JSONSerialization.data(
-                withJSONObject: ["requestHeaders": request.allHTTPHeaderFields],
-                options: .prettyPrinted
-            )
-
-            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-
-        HTTPStubs.removeStub(stub)
-        completion()
+        XCTAssertEqual(sut.session.configuration.timeoutIntervalForResource, 30)
     }
 }
 
 extension [String: Any] {
-    static func ==(lhs: [String: Any], rhs: [String: Any] ) -> Bool {
+    static func ==(lhs: [String: Any], rhs: [String: Any]) -> Bool {
         return NSDictionary(dictionary: lhs).isEqual(to: rhs)
     }
 }

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -29,7 +29,7 @@ final class BTHTTP_Tests: XCTestCase {
     // MARK: - Configuration
 
     override func setUp() {
-        http = BTHTTP(authorization: fakeClientToken)
+        http = BTHTTP(authorization: fakeClientToken, customBaseURL: BTHTTPTestProtocol.testBaseURL())
         http?.session = testURLSession
         URLCache.shared.removeAllCachedResponses()
     }
@@ -84,37 +84,31 @@ final class BTHTTP_Tests: XCTestCase {
 
     func testSendsGETRequest() async throws {
         let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration)
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
         XCTAssertEqual(httpRequest.httpMethod, "GET")
         XCTAssertNil(httpRequest.httpBody)
+        XCTAssertEqual(response.statusCode, 200)
     }
 
     func testSendsGETRequestWithParameters() async throws {
         let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration, parameters: ["param": "value"])
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
         XCTAssertEqual(httpRequest.url?.query, "param=value&authorization_fingerprint=test-authorization-fingerprint")
         XCTAssertEqual(httpRequest.httpMethod, "GET")
         XCTAssertNil(httpRequest.httpBody)
+        XCTAssertEqual(response.statusCode, 200)
     }
 
     func testSendsPOSTRequest() async throws {
         let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration)
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
         XCTAssertEqual(httpRequest.httpMethod, "POST")
         XCTAssertNil(httpRequest.url?.query)
         XCTAssertNil(httpRequest.httpBody)
+        XCTAssertEqual(response.statusCode, 200)
     }
 
     func testSendsPOSTRequestWithCodableParameters() async throws {
@@ -124,41 +118,36 @@ final class BTHTTP_Tests: XCTestCase {
         let parameters = FakeCodable(param: "value")
 
         let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration, parameters: parameters)
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
         XCTAssertEqual(httpRequest.httpMethod, "POST")
         XCTAssertNil(httpRequest.url?.query)
+        XCTAssertEqual(response.statusCode, 200)
 
-        let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
+        guard let bodyData = httpRequestBody.data(using: .utf8) else { return XCTFail("Failed to encode request body as UTF-8") }
+        let json = BTJSON(data: bodyData)
         XCTAssertEqual(json["param"].asString(), "value")
     }
 
     func testSendsPOSTRequestWithDictionaryParameters() async throws {
         let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration, parameters: ["param": "value"])
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.path, "/base/path/200.json")
         XCTAssertEqual(httpRequest.httpMethod, "POST")
         XCTAssertNil(httpRequest.url?.query)
+        XCTAssertEqual(response.statusCode, 200)
 
-        let json = BTJSON(data: httpRequestBody.data(using: .utf8)!)
+        guard let bodyData = httpRequestBody.data(using: .utf8) else { return XCTFail("Failed to encode request body as UTF-8") }
+        let json = BTJSON(data: bodyData)
         XCTAssertEqual(json["param"].asString(), "value")
     }
 
     // MARK: - Authentication
 
     func testGETRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInQueryParams() async throws {
-        let (body, response) = try await http!.get("200.json", configuration: fakeConfiguration)
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.get("200.json", configuration: fakeConfiguration)
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.url?.query, "authorization_fingerprint=test-authorization-fingerprint")
     }
@@ -167,19 +156,13 @@ final class BTHTTP_Tests: XCTestCase {
         http = BTHTTP(authorization: fakeTokenizationKey)
         http?.session = testURLSession
 
-        let (body, response) = try await http!.get("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.get("200.json")
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
     }
 
     func testPOSTRequests_whenBTHTTPInitializedWithAuthorizationFingerprint_sendAuthorizationInBody() async throws {
-        let (body, response) = try await http!.post("200.json", configuration: fakeConfiguration)
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.post("200.json", configuration: fakeConfiguration)
         let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
         XCTAssertEqual(httpRequestBody, "{\"authorization_fingerprint\":\"test-authorization-fingerprint\"}")
     }
@@ -188,10 +171,7 @@ final class BTHTTP_Tests: XCTestCase {
         let http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "https://api.paypal.com")!)
         http.session = testURLSession
 
-        let (body, response) = try await http.post("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http.post("200.json")
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Authorization"], "Bearer test-authorization-fingerprint")
     }
@@ -200,10 +180,7 @@ final class BTHTTP_Tests: XCTestCase {
         http = BTHTTP(authorization: fakeTokenizationKey)
         http?.session = testURLSession
 
-        let (body, response) = try await http!.post("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.post("200.json")
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Client-Key"], "development_tokenization_key")
     }
@@ -211,49 +188,20 @@ final class BTHTTP_Tests: XCTestCase {
     // MARK: - Default headers tests
 
     func testIncludeAccept() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
-            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
-            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-
-        let (body, response) = try await http!.get("stub://200/resource")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        // BTHTTPTestProtocol echoes request headers back in the response body — no stub needed
+        let (body, _) = try await http!.get("200.json", configuration: fakeConfiguration)
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.allHTTPHeaderFields?["Accept"], "application/json")
     }
 
     func testIncludeUserAgent() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
-            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
-            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-
-        let (body, response) = try await http!.get("stub://200/resource")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.get("200.json", configuration: fakeConfiguration)
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.allHTTPHeaderFields?["User-Agent"], "Braintree/iOS/\(BTCoreConstants.braintreeSDKVersion)")
     }
 
     func testIncludeAcceptLanguage() async throws {
-        http = BTHTTP(authorization: fakeClientToken, customBaseURL: URL(string: "stub://stub")!)
-        let stub = HTTPStubs.stubRequests { _ in true } withStubResponse: { request in
-            let jsonResponse = try! JSONSerialization.data(withJSONObject: ["requestHeaders": request.allHTTPHeaderFields], options: .prettyPrinted)
-            return HTTPStubsResponse(data: jsonResponse, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        defer { HTTPStubs.removeStub(stub) }
-
-        let (body, response) = try await http!.get("stub://200/resource")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.get("200.json", configuration: fakeConfiguration)
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         let locale = Locale.current
         let countryCode = (locale as NSLocale).object(forKey: .countryCode) as? String
@@ -295,10 +243,7 @@ final class BTHTTP_Tests: XCTestCase {
             "arrayParameter%5B%5D=arrayItem2"
         ]
 
-        let (body, response) = try await http!.get("200.json", parameters: SampleRequest())
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.get("200.json", parameters: SampleRequest())
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         let actualQueryComponents = httpRequest.url?.query?.components(separatedBy: "&")
         expectedQueryParameters.forEach { expectedComponent in
@@ -318,25 +263,23 @@ final class BTHTTP_Tests: XCTestCase {
             "authorization_fingerprint": "test-authorization-fingerprint"
         ]
 
-        let (body, response) = try await http!.post("200.json", parameters: SampleRequest())
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-
+        let (body, _) = try await http!.post("200.json", parameters: SampleRequest())
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
         let httpRequestBody = BTHTTPTestProtocol.parseRequestBodyFromTestResponseBody(body)
         XCTAssertEqual(httpRequest.value(forHTTPHeaderField: "Content-Type"), "application/json; charset=utf-8")
 
-        let actualParameters = try? JSONSerialization.jsonObject(with: httpRequestBody.data(using: .utf8)!) as? [String: Any] ?? [:]
-        XCTAssertTrue(actualParameters! == expectedParameters)
+        guard let bodyData = httpRequestBody.data(using: .utf8) else { return XCTFail("Failed to encode request body as UTF-8") }
+        let actualParameters = (try? JSONSerialization.jsonObject(with: bodyData)) as? [String: Any] ?? [:]
+        XCTAssertTrue(actualParameters == expectedParameters)
     }
 
     // MARK: - DispatchQueue tests
 
     func testCallsBackOnMainQueue() async throws {
-        let (body, response) = try await http!.get("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
-        XCTAssertTrue(Thread.isMainThread)
+        let (_, _) = try await http!.get("200.json")
+        await MainActor.run {
+            XCTAssertTrue(Thread.isMainThread)
+        }
     }
 
     // MARK: - Response Code Parser tests
@@ -352,9 +295,7 @@ final class BTHTTP_Tests: XCTestCase {
         }
         defer { HTTPStubs.removeStub(stub) }
 
-        let (body, response) = try await http!.get("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
+        let (_, response) = try await http!.get("200.json")
         XCTAssertEqual(response.statusCode, 200)
     }
 
@@ -471,9 +412,8 @@ final class BTHTTP_Tests: XCTestCase {
         defer { HTTPStubs.removeStub(stub) }
 
         let (body, response) = try await http!.get("200.json")
-        XCTAssertNotNil(body)
-        XCTAssertNotNil(response)
         XCTAssertEqual(body["status"].asString(), "OK")
+        XCTAssertEqual(response.statusCode, 200)
     }
 
     func testAcceptsEmptyResponses() async throws {
@@ -485,7 +425,6 @@ final class BTHTTP_Tests: XCTestCase {
 
         let (body, response) = try await http!.get("empty.json")
         XCTAssertEqual(response.statusCode, 200)
-        XCTAssertNotNil(body)
         XCTAssertEqual(body.asDictionary()?.count, 0)
     }
 

--- a/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
+++ b/UnitTests/BraintreeCoreTests/BTHTTP_Tests.swift
@@ -53,9 +53,12 @@ final class BTHTTP_Tests: XCTestCase {
     }
 
     func testRequests_whenNoConfigurationSet_doesNotAppendPath() async throws {
-        let (body, _) = try await http!.httpRequest(method: .get, path: "/some-really-long-path")
+        let http = BTHTTP(authorization: fakeTokenizationKey)
+        http.session = testURLSession
+
+        let (body, _) = try await http.httpRequest(method: .get, path: "/some-really-long-path")
         let httpRequest = BTHTTPTestProtocol.parseRequestFromTestResponseBody(body)
-        XCTAssertEqual(httpRequest.url?.path, fakeClientToken.configURL.path)
+        XCTAssertEqual(httpRequest.url?.path, fakeTokenizationKey.configURL.path)
     }
 
     func testRequests_whenConfigurationSet_usesClientAPIURLOnConfig() async throws {

--- a/UnitTests/BraintreeTestShared/FakeHTTP.swift
+++ b/UnitTests/BraintreeTestShared/FakeHTTP.swift
@@ -10,8 +10,8 @@ import Foundation
     @objc public nonisolated(unsafe) var lastRequestParameters: [String: Any]?
     nonisolated(unsafe) var stubMethod: String?
     nonisolated(unsafe) var stubEndpoint: String?
-    public nonisolated(unsafe) var cannedResponse: BTJSON?
-    @objc public nonisolated(unsafe) var cannedConfiguration: BTJSON?
+    public nonisolated(unsafe) var cannedResponse: BTJSON = BTJSON(value: [:])
+    @objc public nonisolated(unsafe) var cannedConfiguration: BTJSON = BTJSON(value: [:])
     @objc public nonisolated(unsafe) var cannedStatusCode: Int = 0
     public nonisolated(unsafe) var cannedError: Error?
 
@@ -33,29 +33,7 @@ import Foundation
         cannedError = error
     }
     
-    public override func get(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, completion: BTHTTP.RequestCompletion?) {
-        GETRequestCount += 1
-        lastRequestEndpoint = path
-        lastRequestParameters = try? parameters?.toDictionary()
-        lastRequestMethod = "GET"
-
-        if cannedError != nil {
-            dispatchQueue.async {
-                completion?(nil, nil, self.cannedError)
-            }
-        } else {
-            let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
-            dispatchQueue.async {
-                if path.contains("v1/configuration") {
-                    completion?(self.cannedConfiguration, httpResponse, nil)
-                } else {
-                    completion?(self.cannedResponse, httpResponse, nil)
-                }
-            }
-        }
-    }
-
-    public override func get(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil) async throws -> (BTJSON?, HTTPURLResponse?) {
+    public override func get(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil) async throws -> (BTJSON, HTTPURLResponse) {
         GETRequestCount += 1
         lastRequestEndpoint = path
         lastRequestParameters = try? parameters?.toDictionary()
@@ -64,33 +42,15 @@ import Foundation
         if let error = cannedError {
             throw error
         }
-        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
+        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)!
         if path.contains("v1/configuration") {
             return (cannedConfiguration, httpResponse)
         } else {
             return (cannedResponse, httpResponse)
         }
     }
-
-    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        POSTRequestCount += 1
-        lastRequestEndpoint = path
-        lastRequestParameters = try? parameters?.toDictionary()
-        lastRequestMethod = "POST"
-        lastPOSTRequestHeaders = headers
-        if cannedError != nil {
-            dispatchQueue.async {
-                completion?(nil, nil, self.cannedError)
-            }
-        } else {
-            let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
-            dispatchQueue.async {
-                completion?(self.cannedResponse, httpResponse, nil)
-            }
-        }
-    }
     
-    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil) async throws -> (BTJSON?, HTTPURLResponse?) {
+    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil) async throws -> (BTJSON, HTTPURLResponse) {
         POSTRequestCount += 1
         lastRequestEndpoint = path
         lastRequestParameters = try? parameters?.toDictionary()
@@ -99,7 +59,7 @@ import Foundation
         if let error = cannedError {
             throw error
         }
-        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)
+        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: cannedStatusCode, httpVersion: nil, headerFields: nil)!
         return (cannedResponse, httpResponse)
     }
 }
@@ -113,16 +73,12 @@ import Foundation
         let fakeTokenizationKey = try! TokenizationKey("development_tokenization_key")
         return self.init(authorization: fakeTokenizationKey, customBaseURL: URL(string: "http://fake.com")!)
     }
-
-    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil, completion: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        POSTRequestCount += 1
-        lastRequestParameters = try? parameters?.toDictionary()
-        completion?(self.cannedConfiguration, nil, nil)
-    }
     
-    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil) async throws -> (BTJSON?, HTTPURLResponse?) {
+    public override func post(_ path: String, configuration: BTConfiguration? = nil, parameters: Encodable? = nil, headers: [String: String]? = nil) async throws -> (BTJSON, HTTPURLResponse) {
         POSTRequestCount += 1
         lastRequestParameters = try? parameters?.toDictionary()
-        return (self.cannedConfiguration, nil)
+        let httpResponse = HTTPURLResponse(url: URL(string: path)!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (self.cannedConfiguration ?? BTJSON(value: [:]), httpResponse)
     }
 }
+

--- a/UnitTests/BraintreeTestShared/MockAPIClient.swift
+++ b/UnitTests/BraintreeTestShared/MockAPIClient.swift
@@ -41,17 +41,6 @@ public class MockAPIClient: BTAPIClient {
 
     var fetchedPaymentMethods = false
     var fetchPaymentMethodsSorting = false
-
-    public override func get(_ path: String, parameters: Encodable?, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        lastGETPath = path
-        lastGETParameters = try? parameters?.toDictionary()
-        lastGETAPIClientHTTPType = httpType
-        
-        guard let completionBlock = completionBlock else {
-            return
-        }
-        completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
-    }
     
     public override func get(
         _ path: String,
@@ -66,18 +55,6 @@ public class MockAPIClient: BTAPIClient {
             throw error
         }
         return (cannedResponseBody, cannedHTTPURLResponse)
-    }
-    
-    public override func post(_ path: String, parameters: Encodable? = nil, headers: [String: String]? = nil, httpType: BTAPIClientHTTPService, completion completionBlock: ((BTJSON?, HTTPURLResponse?, Error?) -> Void)? = nil) {
-        lastPOSTPath = path
-        lastPOSTParameters = try? parameters?.toDictionary()
-        lastPOSTAPIClientHTTPType = httpType
-        lastPOSTAdditionalHeaders = headers
-        
-        guard let completionBlock = completionBlock else {
-            return
-        }
-        completionBlock(cannedResponseBody, cannedHTTPURLResponse, cannedResponseError)
     }
 
     public override func post(


### PR DESCRIPTION
### Summary of changes

-  Remove all the completion-based versions of the HTTP methods.

### Checklist

- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
