### PR TITLE
Add Card Fields project skeleton

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		08F6DB112F69FD27002FA6EE /* CVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB102F69FD27002FA6EE /* CVVFieldView.swift */; };
 		08F6DB142F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */; };
 		08F6DB162F6AE18E002FA6EE /* CVVFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */; };
-		08F6DB182F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */; };
+		08F6DB182F6AE1F7002FA6EE /* ExpirationDateFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB172F6AE1F7002FA6EE /* ExpirationDateFieldValidator.swift */; };
 		08F6DB1A2F6AE222002FA6EE /* CardNumberFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB192F6AE222002FA6EE /* CardNumberFieldValidator.swift */; };
 		08F6DB1E2F6AE2EA002FA6EE /* CardBrandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB1D2F6AE2EA002FA6EE /* CardBrandView.swift */; };
 		08F6DB202F6AE3D5002FA6EE /* BTCardFieldsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB1F2F6AE3D5002FA6EE /* BTCardFieldsRequest.swift */; };
@@ -833,7 +833,7 @@
 		08F6DB102F69FD27002FA6EE /* CVVFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldView.swift; sourceTree = "<group>"; };
 		08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsValidatorProtocol.swift; sourceTree = "<group>"; };
 		08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldValidator.swift; sourceTree = "<group>"; };
-		08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationDaterFieldValidator.swift; sourceTree = "<group>"; };
+		08F6DB172F6AE1F7002FA6EE /* ExpirationDateFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationDateFieldValidator.swift; sourceTree = "<group>"; };
 		08F6DB192F6AE222002FA6EE /* CardNumberFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberFieldValidator.swift; sourceTree = "<group>"; };
 		08F6DB1D2F6AE2EA002FA6EE /* CardBrandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandView.swift; sourceTree = "<group>"; };
 		08F6DB1F2F6AE3D5002FA6EE /* BTCardFieldsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardFieldsRequest.swift; sourceTree = "<group>"; };
@@ -1577,7 +1577,7 @@
 			isa = PBXGroup;
 			children = (
 				08F6DB0D2F69FD0C002FA6EE /* ExpirationDateFieldView.swift */,
-				08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */,
+				08F6DB172F6AE1F7002FA6EE /* ExpirationDateFieldValidator.swift */,
 				08F6DB272F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift */,
 			);
 			path = ExpirationDateField;
@@ -3614,7 +3614,7 @@
 				046F007C2ED6406000F08512 /* PayPalButtonColor.swift in Sources */,
 				08F6DB142F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift in Sources */,
 				08A83F5D2EE096860076BD28 /* UIComponentsAnalytics.swift in Sources */,
-				08F6DB182F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift in Sources */,
+				08F6DB182F6AE1F7002FA6EE /* ExpirationDateFieldValidator.swift in Sources */,
 				0452416C2EC4F80F00C25EA6 /* PayPalButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -40,6 +40,22 @@
 		08A83F5D2EE096860076BD28 /* UIComponentsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A83F5C2EE096860076BD28 /* UIComponentsAnalytics.swift */; };
 		08A83F672EE72F440076BD28 /* BTSessionIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A83F662EE72F440076BD28 /* BTSessionIDManager.swift */; };
 		08CA32AA2F0C5EFF0000CFCB /* BTGraphQLRequestResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CA32A92F0C5EFF0000CFCB /* BTGraphQLRequestResult.swift */; };
+		08F6DB052F69FBC7002FA6EE /* CardFieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB042F69FBC7002FA6EE /* CardFieldsView.swift */; };
+		08F6DB072F69FBE9002FA6EE /* CardFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB062F69FBE9002FA6EE /* CardFieldsViewModel.swift */; };
+		08F6DB0A2F69FCE3002FA6EE /* CardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB092F69FCE3002FA6EE /* CardNumberFieldView.swift */; };
+		08F6DB0E2F69FD0C002FA6EE /* ExpirationDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB0D2F69FD0C002FA6EE /* ExpirationDateFieldView.swift */; };
+		08F6DB112F69FD27002FA6EE /* CVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB102F69FD27002FA6EE /* CVVFieldView.swift */; };
+		08F6DB142F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */; };
+		08F6DB162F6AE18E002FA6EE /* CVVFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */; };
+		08F6DB182F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */; };
+		08F6DB1A2F6AE222002FA6EE /* CardNumberFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB192F6AE222002FA6EE /* CardNumberFieldValidator.swift */; };
+		08F6DB1E2F6AE2EA002FA6EE /* CardBrandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB1D2F6AE2EA002FA6EE /* CardBrandView.swift */; };
+		08F6DB202F6AE3D5002FA6EE /* BTCardFieldsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB1F2F6AE3D5002FA6EE /* BTCardFieldsRequest.swift */; };
+		08F6DB222F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB212F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift */; };
+		08F6DB242F6AE47D002FA6EE /* CardBrandImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB232F6AE47D002FA6EE /* CardBrandImage.swift */; };
+		08F6DB262F6AEC30002FA6EE /* CVVFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB252F6AEC30002FA6EE /* CVVFieldViewModel.swift */; };
+		08F6DB282F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB272F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift */; };
+		08F6DB2A2F6AEC83002FA6EE /* CardNumberFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6DB292F6AEC83002FA6EE /* CardNumberFieldViewModel.swift */; };
 		0917F6E42A27BDC700ACED2E /* BTVenmoLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */; };
 		1FEB89E614CB6BF0B9858EE4 /* Pods_Tests_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85BD589D380436A0C9D1DEC1 /* Pods_Tests_IntegrationTests.framework */; };
 		28873D59EF44EE6327794A6D /* Pods_Tests_BraintreeCoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9239C9FE850C3587DE61A3A2 /* Pods_Tests_BraintreeCoreTests.framework */; };
@@ -810,6 +826,22 @@
 		08A83F5C2EE096860076BD28 /* UIComponentsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponentsAnalytics.swift; sourceTree = "<group>"; };
 		08A83F662EE72F440076BD28 /* BTSessionIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSessionIDManager.swift; sourceTree = "<group>"; };
 		08CA32A92F0C5EFF0000CFCB /* BTGraphQLRequestResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLRequestResult.swift; sourceTree = "<group>"; };
+		08F6DB042F69FBC7002FA6EE /* CardFieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsView.swift; sourceTree = "<group>"; };
+		08F6DB062F69FBE9002FA6EE /* CardFieldsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsViewModel.swift; sourceTree = "<group>"; };
+		08F6DB092F69FCE3002FA6EE /* CardNumberFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberFieldView.swift; sourceTree = "<group>"; };
+		08F6DB0D2F69FD0C002FA6EE /* ExpirationDateFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationDateFieldView.swift; sourceTree = "<group>"; };
+		08F6DB102F69FD27002FA6EE /* CVVFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldView.swift; sourceTree = "<group>"; };
+		08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsValidatorProtocol.swift; sourceTree = "<group>"; };
+		08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldValidator.swift; sourceTree = "<group>"; };
+		08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationDaterFieldValidator.swift; sourceTree = "<group>"; };
+		08F6DB192F6AE222002FA6EE /* CardNumberFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberFieldValidator.swift; sourceTree = "<group>"; };
+		08F6DB1D2F6AE2EA002FA6EE /* CardBrandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandView.swift; sourceTree = "<group>"; };
+		08F6DB1F2F6AE3D5002FA6EE /* BTCardFieldsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardFieldsRequest.swift; sourceTree = "<group>"; };
+		08F6DB212F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsViewModelProtocol.swift; sourceTree = "<group>"; };
+		08F6DB232F6AE47D002FA6EE /* CardBrandImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandImage.swift; sourceTree = "<group>"; };
+		08F6DB252F6AEC30002FA6EE /* CVVFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldViewModel.swift; sourceTree = "<group>"; };
+		08F6DB272F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationDateFieldViewModel.swift; sourceTree = "<group>"; };
+		08F6DB292F6AEC83002FA6EE /* CardNumberFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberFieldViewModel.swift; sourceTree = "<group>"; };
 		096C6B2529CCDCEB00912863 /* BTVenmoLineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTVenmoLineItem.swift; sourceTree = "<group>"; };
 		162174E1192D9220008DC35D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		16CD2E9E1B4077FC00E68495 /* BTJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSON_Tests.swift; sourceTree = "<group>"; };
@@ -1490,6 +1522,7 @@
 		0452416A2EC4F80F00C25EA6 /* BraintreeUIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				08F6DB032F69FB34002FA6EE /* CardFields */,
 				0841353F2ED0CBAD00884FE9 /* Resources */,
 				045241682EC4F80F00C25EA6 /* PayPalButton.swift */,
 				046F007B2ED6404C00F08512 /* PayPalButtonColor.swift */,
@@ -1513,6 +1546,61 @@
 				0841353E2ED0CBAD00884FE9 /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		08F6DB032F69FB34002FA6EE /* CardFields */ = {
+			isa = PBXGroup;
+			children = (
+				08F6DB122F69FD3B002FA6EE /* Shared */,
+				08F6DB0F2F69FD16002FA6EE /* CVVField */,
+				08F6DB0C2F69FCFB002FA6EE /* ExpirationDateField */,
+				08F6DB082F69FCC7002FA6EE /* CardNumberField */,
+				08F6DB042F69FBC7002FA6EE /* CardFieldsView.swift */,
+				08F6DB062F69FBE9002FA6EE /* CardFieldsViewModel.swift */,
+				08F6DB1F2F6AE3D5002FA6EE /* BTCardFieldsRequest.swift */,
+			);
+			path = CardFields;
+			sourceTree = "<group>";
+		};
+		08F6DB082F69FCC7002FA6EE /* CardNumberField */ = {
+			isa = PBXGroup;
+			children = (
+				08F6DB092F69FCE3002FA6EE /* CardNumberFieldView.swift */,
+				08F6DB192F6AE222002FA6EE /* CardNumberFieldValidator.swift */,
+				08F6DB1D2F6AE2EA002FA6EE /* CardBrandView.swift */,
+				08F6DB292F6AEC83002FA6EE /* CardNumberFieldViewModel.swift */,
+			);
+			path = CardNumberField;
+			sourceTree = "<group>";
+		};
+		08F6DB0C2F69FCFB002FA6EE /* ExpirationDateField */ = {
+			isa = PBXGroup;
+			children = (
+				08F6DB0D2F69FD0C002FA6EE /* ExpirationDateFieldView.swift */,
+				08F6DB172F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift */,
+				08F6DB272F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift */,
+			);
+			path = ExpirationDateField;
+			sourceTree = "<group>";
+		};
+		08F6DB0F2F69FD16002FA6EE /* CVVField */ = {
+			isa = PBXGroup;
+			children = (
+				08F6DB102F69FD27002FA6EE /* CVVFieldView.swift */,
+				08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */,
+				08F6DB252F6AEC30002FA6EE /* CVVFieldViewModel.swift */,
+			);
+			path = CVVField;
+			sourceTree = "<group>";
+		};
+		08F6DB122F69FD3B002FA6EE /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */,
+				08F6DB212F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift */,
+				08F6DB232F6AE47D002FA6EE /* CardBrandImage.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		2D941D391B59C76A0016EFB4 /* BraintreePayPal */ = {
@@ -3503,14 +3591,30 @@
 			files = (
 				0889DB142ED4C0350023AA64 /* PaymentButtonStyle.swift in Sources */,
 				084135412ED0CBAD00884FE9 /* PaymentButtonView.swift in Sources */,
+				08F6DB282F6AEC67002FA6EE /* ExpirationDateFieldViewModel.swift in Sources */,
+				08F6DB0E2F69FD0C002FA6EE /* ExpirationDateFieldView.swift in Sources */,
+				08F6DB0A2F69FCE3002FA6EE /* CardNumberFieldView.swift in Sources */,
+				08F6DB202F6AE3D5002FA6EE /* BTCardFieldsRequest.swift in Sources */,
 				084135422ED0CBAD00884FE9 /* VenmoButtonColor.swift in Sources */,
 				084135432ED0CBAD00884FE9 /* UIComponents+Color.swift in Sources */,
 				046F00802ED6905F00F08512 /* UIComponents+Bundle.swift in Sources */,
 				046F007E2ED64E8D00F08512 /* PaymentButtonStyle.swift in Sources */,
+				08F6DB1E2F6AE2EA002FA6EE /* CardBrandView.swift in Sources */,
+				08F6DB222F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift in Sources */,
+				08F6DB2A2F6AEC83002FA6EE /* CardNumberFieldViewModel.swift in Sources */,
+				08F6DB242F6AE47D002FA6EE /* CardBrandImage.swift in Sources */,
 				084135442ED0CBAD00884FE9 /* VenmoButton.swift in Sources */,
+				08F6DB072F69FBE9002FA6EE /* CardFieldsViewModel.swift in Sources */,
+				08F6DB262F6AEC30002FA6EE /* CVVFieldViewModel.swift in Sources */,
+				08F6DB052F69FBC7002FA6EE /* CardFieldsView.swift in Sources */,
+				08F6DB162F6AE18E002FA6EE /* CVVFieldValidator.swift in Sources */,
+				08F6DB112F69FD27002FA6EE /* CVVFieldView.swift in Sources */,
 				084135472ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift in Sources */,
+				08F6DB1A2F6AE222002FA6EE /* CardNumberFieldValidator.swift in Sources */,
 				046F007C2ED6406000F08512 /* PayPalButtonColor.swift in Sources */,
+				08F6DB142F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift in Sources */,
 				08A83F5D2EE096860076BD28 /* UIComponentsAnalytics.swift in Sources */,
+				08F6DB182F6AE1F7002FA6EE /* ExpirationDaterFieldValidator.swift in Sources */,
 				0452416C2EC4F80F00C25EA6 /* PayPalButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BraintreeUIComponents/CardFields/BTCardFieldsRequest.swift
+++ b/Sources/BraintreeUIComponents/CardFields/BTCardFieldsRequest.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+struct BTCardFieldsRequest {}

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldValidator.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldValidator.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class CVVFieldValidator: CardFieldsValidatorProtocol {
+    
+    func isValid(_ subject: String) -> Bool {
+        return false
+    }
+}

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct CVVFieldView: View {
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CVVFieldView()
+}

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+class CVVFieldViewModel: CardFieldsViewModelProtocol {
+    
+    var state: String = ""
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardFieldsView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFieldsView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct CardFieldsView: View {
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CardFieldsView()
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardFieldsViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFieldsViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+final class CardFieldsViewModel: CardFieldsViewModelProtocol {
+    
+    var state: String = ""
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardBrandView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardBrandView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct CardBrandView: View {
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CardBrandView()
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldValidator.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldValidator.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class CardNumberFieldValidator: CardFieldsValidatorProtocol {
+    
+    func isValid(_ text: String) -> Bool {
+        return false
+    }
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct CardNumberFieldView: View {
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CardNumberFieldView()
+}

--- a/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+class CardNumberFieldViewModel: CardFieldsViewModelProtocol {
+    
+    var state: String = ""
+}

--- a/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldValidator.swift
+++ b/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldValidator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class ExpirationDaterFieldValidator: CardFieldsValidatorProtocol {
+final class ExpirationDateFieldValidator: CardFieldsValidatorProtocol {
     
     func isValid(_ subject: String) -> Bool {
         return false

--- a/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ExpirationDateFieldView: View {
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ExpirationDateFieldView()
+}

--- a/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+class ExpirationDateFieldViewModel: CardFieldsViewModelProtocol {
+    
+    var state: String = ""
+}

--- a/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDaterFieldValidator.swift
+++ b/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDaterFieldValidator.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class ExpirationDaterFieldValidator: CardFieldsValidatorProtocol {
+    
+    func isValid(_ subject: String) -> Bool {
+        return false
+    }
+}

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardBrandImage.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardBrandImage.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum CardBrandImage {
+    case visa
+}

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsValidatorProtocol.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsValidatorProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol CardFieldsValidatorProtocol {
+    func isValid(_ subject: String) -> Bool
+}

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsViewModelProtocol.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsViewModelProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol CardFieldsViewModelProtocol {
+    var state: String { get }
+}


### PR DESCRIPTION

### Summary of changes

- This PR sets up the basic file and directory structure of what the Card Fields will look like. Here is a basic mockup:

  Sources/BraintreeCardFields/
  │
  ├── CardFieldsView.swift              (public container view of all fields together to make one form, coordinates all fields)
  ├── CardFieldsViewModel.swift         (orchestrates tokenization, analytics, form state)
  ├── BTCardFieldsRequest.swift         (public type developer passes in for desired customer information)
  │
  ├── CardNumberField/
  │   ├── CardNumberFieldView.swift         (SwiftUI view)
  |.   |---- CardBrandView.swift (SwiftUI view of card brand image)
  │   ├── CardNumberFieldViewModel.swift (state, validation, formatting, analytics)
  │   └── CardNumberValidator.swift     (Luhn check, brand detection)
  │
  ├── ExpirationField/
  │   ├── ExpirationField.swift         (SwiftUI view)
  │   ├── ExpirationFieldViewModel.swift (state, validation, formatting, analytics)
  │   └── ExpirationValidator.swift     (MM/YY or MM/YYYY format, expiry check)
  │
  ├── CVVField/
  │   ├── CVVField.swift                (SwiftUI view)
  │   ├── CVVFieldViewModel.swift       (state, validation, formatting, analytics)
  │   └── CVVValidator.swift            (numeric, 3-4 digit)
  │
  ├── Shared/
  │   ├── CardFieldValidator.swift      (shared protocol)
  │   ├── CardFieldViewModel.swift      (shared protocol/base for field VMs)

### Checklist

- [] Added a changelog entry
- [] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
