### PR TITLE
Add Unit Tests For 3DS InitializeChallenge Method

### DIFF
--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -525,6 +525,115 @@ class BTThreeDSecureClient_Tests: XCTestCase {
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifyFailed))
     }
 
+    // MARK: - initializeChallenge
+
+    func testInitializeChallenge_whenFetchingConfigurationFails_throwsError() async {
+        mockAPIClient.cannedConfigurationResponseError = NSError(domain: "BTError", code: 0, userInfo: nil)
+        mockAPIClient.cannedConfigurationResponseBody = nil
+
+        do {
+            _ = try await client.initializeChallenge(lookupResponse: "{}", request: threeDSecureRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as NSError, mockAPIClient.cannedConfigurationResponseError!)
+        }
+    }
+
+    func testInitializeChallenge_whenAuthenticationNotRequired_returnsResult() async {
+        let lookupResponse =
+            """
+            {
+                "paymentMethod": {
+                    "nonce": "a-nonce",
+                    "threeDSecureInfo": {
+                        "liabilityShiftPossible": true,
+                        "liabilityShifted": true
+                    }
+                },
+                "threeDSecureInfo": {
+                    "liabilityShiftPossible": true,
+                    "liabilityShifted": true
+                }
+            }
+            """
+
+        do {
+            let result = try await client.initializeChallenge(lookupResponse: lookupResponse, request: threeDSecureRequest)
+            XCTAssertNotNil(result)
+            XCTAssertNil(result.lookup)
+        } catch {
+            XCTFail("Expected success but got error: \(error)")
+        }
+
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifySucceeded))
+    }
+
+    func testInitializeChallenge_whenV1ReturnedInLookup_throwsError() async {
+        let lookupResponse =
+            """
+            {
+                "lookup": {
+                    "acsUrl": "http://www.someAcsUrl.com",
+                    "pareq": "somePareq",
+                    "termUrl": "http://www.someTermUrl.com",
+                    "threeDSecureVersion": "1.0.2"
+                },
+                "paymentMethod": {
+                    "nonce": "a-nonce",
+                    "threeDSecureInfo": {
+                        "liabilityShiftPossible": true,
+                        "liabilityShifted": false
+                    }
+                }
+            }
+            """
+
+        do {
+            _ = try await client.initializeChallenge(lookupResponse: lookupResponse, request: threeDSecureRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            let e = error as NSError
+            XCTAssertEqual(e.domain, BTThreeDSecureError.errorDomain)
+            XCTAssertEqual(e.code, BTThreeDSecureError.configuration("").errorCode)
+            XCTAssertEqual(e.localizedDescription, "3D Secure v1 is deprecated and no longer supported. See https://developer.paypal.com/braintree/docs/guides/3d-secure/client-side for more information.")
+        }
+
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifyFailed))
+    }
+
+    func testInitializeChallenge_whenV2ChallengeRequired_throwsError() async {
+        let lookupResponse =
+            """
+            {
+                "lookup": {
+                    "acsUrl": "http://www.someAcsUrl.com",
+                    "pareq": "somePareq",
+                    "termUrl": "http://www.someTermUrl.com",
+                    "threeDSecureVersion": "2.1.0",
+                    "transactionId": "someTransactionId"
+                },
+                "paymentMethod": {
+                    "nonce": "a-nonce",
+                    "threeDSecureInfo": {
+                        "liabilityShiftPossible": true,
+                        "liabilityShifted": false
+                    }
+                }
+            }
+            """
+
+        do {
+            _ = try await client.initializeChallenge(lookupResponse: lookupResponse, request: threeDSecureRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            let e = error as NSError
+            XCTAssertEqual(e.domain, BTThreeDSecureError.errorDomain)
+            XCTAssertEqual(e.code, BTThreeDSecureError.failedLookup([:]).errorCode)
+        }
+
+        XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifyFailed))
+    }
+
     // MARK: - prepareLookup
 
     func testPrepareLookup_getsJsonString() async {

--- a/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
+++ b/UnitTests/BraintreeThreeDSecureTests/BTThreeDSecureClient_Tests.swift
@@ -592,10 +592,10 @@ class BTThreeDSecureClient_Tests: XCTestCase {
             _ = try await client.initializeChallenge(lookupResponse: lookupResponse, request: threeDSecureRequest)
             XCTFail("Expected error to be thrown")
         } catch {
-            let e = error as NSError
-            XCTAssertEqual(e.domain, BTThreeDSecureError.errorDomain)
-            XCTAssertEqual(e.code, BTThreeDSecureError.configuration("").errorCode)
-            XCTAssertEqual(e.localizedDescription, "3D Secure v1 is deprecated and no longer supported. See https://developer.paypal.com/braintree/docs/guides/3d-secure/client-side for more information.")
+            let error = error as NSError
+            XCTAssertEqual(error.domain, BTThreeDSecureError.errorDomain)
+            XCTAssertEqual(error.code, BTThreeDSecureError.configuration("").errorCode)
+            XCTAssertEqual(error.localizedDescription, "3D Secure v1 is deprecated and no longer supported. See https://developer.paypal.com/braintree/docs/guides/3d-secure/client-side for more information.")
         }
 
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifyFailed))
@@ -626,9 +626,9 @@ class BTThreeDSecureClient_Tests: XCTestCase {
             _ = try await client.initializeChallenge(lookupResponse: lookupResponse, request: threeDSecureRequest)
             XCTFail("Expected error to be thrown")
         } catch {
-            let e = error as NSError
-            XCTAssertEqual(e.domain, BTThreeDSecureError.errorDomain)
-            XCTAssertEqual(e.code, BTThreeDSecureError.failedLookup([:]).errorCode)
+            let error = error as NSError
+            XCTAssertEqual(error.domain, BTThreeDSecureError.errorDomain)
+            XCTAssertEqual(error.code, BTThreeDSecureError.failedLookup([:]).errorCode)
         }
 
         XCTAssertTrue(mockAPIClient.postedAnalyticsEvents.contains(BTThreeDSecureAnalytics.verifyFailed))


### PR DESCRIPTION

### Summary of changes

- Added unit tests for the `initializeChallenge()` method within `BTThreeDSecureClient`

### Checklist

- [] Added a changelog entry
- [] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
