### PR TITLE
Create BTCard extension for allowing card data to be optional

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		084135442ED0CBAD00884FE9 /* VenmoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0841353D2ED0CBAD00884FE9 /* VenmoButton.swift */; };
 		084135452ED0CBAD00884FE9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0841353E2ED0CBAD00884FE9 /* Assets.xcassets */; };
 		084135472ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084135462ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift */; };
+		087831322F7B0359003BB460 /* BTCard+CardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087831312F7B0359003BB460 /* BTCard+CardFields.swift */; };
 		087CA76E2F0D72E80065D89B /* BTGraphQLHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087CA76D2F0D72E80065D89B /* BTGraphQLHTTPError.swift */; };
 		0889DB142ED4C0350023AA64 /* PaymentButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0889DB132ED4C0350023AA64 /* PaymentButtonStyle.swift */; };
 		08A83F5D2EE096860076BD28 /* UIComponentsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A83F5C2EE096860076BD28 /* UIComponentsAnalytics.swift */; };
@@ -821,6 +822,7 @@
 		0841353E2ED0CBAD00884FE9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		084135402ED0CBAD00884FE9 /* VenmoButtonColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VenmoButtonColor.swift; sourceTree = "<group>"; };
 		084135462ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonColorProtocol.swift; sourceTree = "<group>"; };
+		087831312F7B0359003BB460 /* BTCard+CardFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BTCard+CardFields.swift"; sourceTree = "<group>"; };
 		087CA76D2F0D72E80065D89B /* BTGraphQLHTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLHTTPError.swift; sourceTree = "<group>"; };
 		0889DB132ED4C0350023AA64 /* PaymentButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonStyle.swift; sourceTree = "<group>"; };
 		08A83F5C2EE096860076BD28 /* UIComponentsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponentsAnalytics.swift; sourceTree = "<group>"; };
@@ -1599,6 +1601,7 @@
 				08F6DB132F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift */,
 				08F6DB212F6AE410002FA6EE /* CardFieldsViewModelProtocol.swift */,
 				08F6DB232F6AE47D002FA6EE /* CardBrandImage.swift */,
+				087831312F7B0359003BB460 /* BTCard+CardFields.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -3595,6 +3598,7 @@
 				08F6DB0E2F69FD0C002FA6EE /* ExpirationDateFieldView.swift in Sources */,
 				08F6DB0A2F69FCE3002FA6EE /* CardNumberFieldView.swift in Sources */,
 				08F6DB202F6AE3D5002FA6EE /* BTCardFieldsRequest.swift in Sources */,
+				087831322F7B0359003BB460 /* BTCard+CardFields.swift in Sources */,
 				084135422ED0CBAD00884FE9 /* VenmoButtonColor.swift in Sources */,
 				084135432ED0CBAD00884FE9 /* UIComponents+Color.swift in Sources */,
 				046F00802ED6905F00F08512 /* UIComponents+Bundle.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		084135452ED0CBAD00884FE9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0841353E2ED0CBAD00884FE9 /* Assets.xcassets */; };
 		084135472ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084135462ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift */; };
 		087831322F7B0359003BB460 /* BTCard+CardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087831312F7B0359003BB460 /* BTCard+CardFields.swift */; };
+		087831332F7B09CE003BB460 /* BraintreeCard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7C889901B5F043B007A0E9C /* BraintreeCard.framework */; platformFilter = ios; };
 		087CA76E2F0D72E80065D89B /* BTGraphQLHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087CA76D2F0D72E80065D89B /* BTGraphQLHTTPError.swift */; };
 		0889DB142ED4C0350023AA64 /* PaymentButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0889DB132ED4C0350023AA64 /* PaymentButtonStyle.swift */; };
 		08A83F5D2EE096860076BD28 /* UIComponentsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A83F5C2EE096860076BD28 /* UIComponentsAnalytics.swift */; };
@@ -468,6 +469,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 2D941D371B59C76A0016EFB4;
 			remoteInfo = BraintreePayPal;
+		};
+		087831352F7B09CE003BB460 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A75DA344192138F000D997A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A7C8898F1B5F043B007A0E9C;
+			remoteInfo = BraintreeCard;
 		};
 		804698432B27C5530090878E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1254,6 +1262,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				045241772EC7F15400C25EA6 /* BraintreeVenmo.framework in Frameworks */,
+				087831332F7B09CE003BB460 /* BraintreeCard.framework in Frameworks */,
 				045241762EC7F14D00C25EA6 /* BraintreePayPal.framework in Frameworks */,
 				045241302EBEBAD200C25EA6 /* BraintreeCore.framework in Frameworks */,
 			);
@@ -2588,6 +2597,7 @@
 				045241732EC6AD0D00C25EA6 /* PBXTargetDependency */,
 				045241712EC6AD0900C25EA6 /* PBXTargetDependency */,
 				045241332EBEBAD200C25EA6 /* PBXTargetDependency */,
+				087831362F7B09CE003BB460 /* PBXTargetDependency */,
 			);
 			name = BraintreeUIComponents;
 			productName = BraintreeUIComponents;
@@ -4143,6 +4153,12 @@
 			isa = PBXTargetDependency;
 			target = 2D941D371B59C76A0016EFB4 /* BraintreePayPal */;
 			targetProxy = 045241722EC6AD0D00C25EA6 /* PBXContainerItemProxy */;
+		};
+		087831362F7B09CE003BB460 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = A7C8898F1B5F043B007A0E9C /* BraintreeCard */;
+			targetProxy = 087831352F7B09CE003BB460 /* PBXContainerItemProxy */;
 		};
 		804698442B27C5530090878E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Sources/BraintreeUIComponents/CardFields/Shared/BTCard+CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/BTCard+CardFields.swift
@@ -1,0 +1,51 @@
+#if canImport(BraintreeCard)
+import BraintreeCard
+#endif
+
+extension BTCard {
+
+    /// Creates a `BTCard` with only optional metadata fields for use with `BTCardFields`.
+    /// Card number, expiration month, expiration year, and CVV are managed internally
+    /// by the `BTCardFields` form and should not be set by the merchant.
+    public convenience init(
+        cardholderName: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        company: String? = nil,
+        postalCode: String? = nil,
+        streetAddress: String? = nil,
+        extendedAddress: String? = nil,
+        locality: String? = nil,
+        region: String? = nil,
+        countryName: String? = nil,
+        countryCodeAlpha2: String? = nil,
+        countryCodeAlpha3: String? = nil,
+        countryCodeNumeric: String? = nil,
+        shouldValidate: Bool = false,
+        authenticationInsightRequested: Bool = false,
+        merchantAccountID: String? = nil
+    ) {
+        self.init(
+            number: "",
+            expirationMonth: "",
+            expirationYear: "",
+            cvv: "",
+            postalCode: postalCode,
+            cardholderName: cardholderName,
+            firstName: firstName,
+            lastName: lastName,
+            company: company,
+            streetAddress: streetAddress,
+            extendedAddress: extendedAddress,
+            locality: locality,
+            region: region,
+            countryName: countryName,
+            countryCodeAlpha2: countryCodeAlpha2,
+            countryCodeAlpha3: countryCodeAlpha3,
+            countryCodeNumeric: countryCodeNumeric,
+            shouldValidate: shouldValidate,
+            authenticationInsightRequested: authenticationInsightRequested,
+            merchantAccountID: merchantAccountID
+        )
+    }
+}


### PR DESCRIPTION
### Summary of changes

- extended BTCard to allow card data values to be optional. This will allow a merchant integration using the Card Fields to pass in all optional data without the card data (which will be included with the Card Fields).
### Checklist

- [] Added a changelog entry
- [] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @buzzamus 
