### PR TITLE
Add PayPal Campaigns to the create/update session API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Fix inconsistency in minimum deployment target, which is now consistently iOS 16 (fixes #1757)
 * BraintreeShopperInsights
   * Add `payPalPayLater` case to `BTButtonType` enum
+    
+## 7.6.0 (2026-02-25)
+* BraintreeShopperInsights
+    * Added campaign id to be passed down to create/update session and recommendations endpoint.
 
 ## 7.5.0 (2026-02-25)
 * BraintreePayPal

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -53,6 +53,14 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         return view
     }()
     
+    lazy var campaignIds: TextFieldWithLabel = {
+        let view = TextFieldWithLabel()
+        view.label.text = "Campaign Ids"
+        view.textField.placeholder = "Campaign Ids"
+        view.textField.text = "1,2,3,4"
+        return view
+    }()
+    
     private let recommendationsLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -79,7 +87,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
     )
     
     lazy var shopperInsightsInputView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView, sessionIDView])
+        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView, sessionIDView, campaignIds])
         stackView.axis = .vertical
         stackView.spacing = 10
         stackView.distribution = .fillEqually
@@ -135,7 +143,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
                 purchaseUnits: [
                     BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-                ]
+                ],
+                payPalCampaigns: parseCampaignIds()
             )
 
             do {
@@ -162,7 +171,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
             venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
             purchaseUnits: [
                 BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-            ]
+            ],
+            payPalCampaigns: parseCampaignIds()
         )
 
         Task {
@@ -194,7 +204,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
             venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
             purchaseUnits: [
                 BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-            ]
+            ], 
+            payPalCampaigns: parseCampaignIds()
         )
 
         Task {
@@ -257,6 +268,15 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         let inputData = Data(input.utf8)
         let hashed = SHA256.hash(data: inputData)
         return hashed.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    private func parseCampaignIds() -> [BTPayPalCampaign]? {
+        guard let text = campaignIds.textField.text, !text.isEmpty else {
+            return nil
+        }
+        return text
+            .split(separator: ",")
+            .map { BTPayPalCampaign(id: String($0).trimmingCharacters(in: .whitespaces)) }
     }
     
     private func togglePayPalVaultButton(enabled: Bool) {
@@ -366,7 +386,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 shopperInsightsInputView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
                 shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-                shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 200)
+                shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 250)
             ]
         )
         

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -11,26 +11,26 @@ struct Variables: Encodable {
     
     struct InputParameters: Encodable {
         
-    let sessionID: String?
-    let customer: Customer?
-    let purchaseUnits: [PurchaseUnit]?
-    let payPalCampaigns: [BTPayPalCampaign]?
+        let sessionID: String?
+        let customer: Customer?
+        let purchaseUnits: [PurchaseUnit]?
+        let payPalCampaigns: [BTPayPalCampaign]?
         
-    init(request: BTCustomerSessionRequest?, sessionID: String?) {
-        self.sessionID = sessionID
-        customer = Customer(request: request)
-        purchaseUnits = request?.purchaseUnits?.compactMap {
-            PurchaseUnit(purchaseUnit: $0)
+        init(request: BTCustomerSessionRequest?, sessionID: String?) {
+            self.sessionID = sessionID
+            customer = Customer(request: request)
+            purchaseUnits = request?.purchaseUnits?.compactMap {
+                PurchaseUnit(purchaseUnit: $0)
+            }
+            payPalCampaigns = request?.payPalCampaigns
         }
-        payPalCampaigns = request?.payPalCampaigns
-    }
         
-    enum CodingKeys: String, CodingKey {
-        case sessionID = "sessionId"
-        case customer
-        case purchaseUnits
-        case payPalCampaigns = "paypal_campaigns"
-    }
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "sessionId"
+            case customer
+            case purchaseUnits
+            case payPalCampaigns = "paypal_campaigns"
+        }
         
         struct Customer: Encodable {
             

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -11,23 +11,26 @@ struct Variables: Encodable {
     
     struct InputParameters: Encodable {
         
-        let sessionID: String?
-        let customer: Customer?
-        let purchaseUnits: [PurchaseUnit]?
+    let sessionID: String?
+    let customer: Customer?
+    let purchaseUnits: [PurchaseUnit]?
+    let payPalCampaigns: [BTPayPalCampaign]?
         
-        init(request: BTCustomerSessionRequest?, sessionID: String?) {
-            self.sessionID = sessionID
-            customer = Customer(request: request)
-            purchaseUnits = request?.purchaseUnits?.compactMap {
-                PurchaseUnit(purchaseUnit: $0)
-            }
+    init(request: BTCustomerSessionRequest?, sessionID: String?) {
+        self.sessionID = sessionID
+        customer = Customer(request: request)
+        purchaseUnits = request?.purchaseUnits?.compactMap {
+            PurchaseUnit(purchaseUnit: $0)
         }
+        payPalCampaigns = request?.payPalCampaigns
+    }
         
-        enum CodingKeys: String, CodingKey {
-            case sessionID = "sessionId"
-            case customer
-            case purchaseUnits
-        }
+    enum CodingKeys: String, CodingKey {
+        case sessionID = "sessionId"
+        case customer
+        case purchaseUnits
+        case payPalCampaigns = "paypal_campaigns"
+    }
         
         struct Customer: Encodable {
             

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -1,34 +1,25 @@
-import Foundation
-
-/// A `BTCustomerSessionRequest`for creating a customer session.
-/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTCustomerSessionRequest {
-    
+
     let hashedEmail: String?
     let hashedPhoneNumber: String?
     let payPalAppInstalled: Bool?
     let venmoAppInstalled: Bool?
     let purchaseUnits: [BTPurchaseUnit]?
-    
-    /// Creates a BTCustomerSessionRequest
-    /// - Parameters:
-    ///   - hashedEmail: Optional: The customer's email address hashed via SHA256 algorithm.
-    ///   - hashedPhoneNumber: Optional: The customer's phone number hased via SHA256 algorithm.
-    ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
-    ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
-    ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
-    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    let payPalCampaigns: [BTPayPalCampaign]?
+
     public init(
         hashedEmail: String? = nil,
         hashedPhoneNumber: String? = nil,
         payPalAppInstalled: Bool? = nil,
         venmoAppInstalled: Bool? = nil,
-        purchaseUnits: [BTPurchaseUnit]? = nil
+        purchaseUnits: [BTPurchaseUnit]? = nil,
+        payPalCampaigns: [BTPayPalCampaign]? = nil
     ) {
         self.hashedEmail = hashedEmail
         self.hashedPhoneNumber = hashedPhoneNumber
         self.payPalAppInstalled = payPalAppInstalled
         self.venmoAppInstalled = venmoAppInstalled
         self.purchaseUnits = purchaseUnits
+        self.payPalCampaigns = payPalCampaigns
     }
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -17,6 +17,7 @@ public struct BTCustomerSessionRequest {
     ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
     ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
     ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
+    ///   - payPalCampaigns: Optional: List of campaign ids presented to end customer.
     /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
     
     public init(

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -1,3 +1,6 @@
+import Foundation
+
+/// A `BTCustomerSessionRequest`for creating a customer session.
 public struct BTCustomerSessionRequest {
 
     let hashedEmail: String?
@@ -7,6 +10,15 @@ public struct BTCustomerSessionRequest {
     let purchaseUnits: [BTPurchaseUnit]?
     let payPalCampaigns: [BTPayPalCampaign]?
 
+    /// Creates a BTCustomerSessionRequest
+    /// - Parameters:
+    ///   - hashedEmail: Optional: The customer's email address hashed via SHA256 algorithm.
+    ///   - hashedPhoneNumber: Optional: The customer's phone number hased via SHA256 algorithm.
+    ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
+    ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
+    ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
+    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    
     public init(
         hashedEmail: String? = nil,
         hashedPhoneNumber: String? = nil,

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -1,12 +1,11 @@
 import Foundation
-/// The PayPal campaign details.
 
+/// Creates a BTPayPalCampaign
+/// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
+/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTPayPalCampaign: Encodable {
     let id: String
     
-    /// Creates a BTPayPalCampaign
-    /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
-    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
     public init(id: String) {
         self.id = id
     }

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public struct BTPayPalCampaign: Encodable {
     let id: String
+    
     /// Creates a BTPayPalCampaign
     /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
     /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Creates a BTPayPalCampaign
 /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
-/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+
 public struct BTPayPalCampaign: Encodable {
     let id: String
     

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -1,0 +1,12 @@
+import Foundation
+/// The PayPal campaign details.
+
+public struct BTPayPalCampaign: Encodable {
+    let id: String
+    /// Creates a BTPayPalCampaign
+    /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
+    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    public init(id: String) {
+        self.id = id
+    }
+}

--- a/UnitTests/BraintreeShopperInsightsTests/BTCreateCustomerSessionAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTCreateCustomerSessionAPI_Tests.swift
@@ -24,6 +24,9 @@ class BTCreateCustomerSessionAPI_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123")
         ]
     )
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -21,6 +21,9 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123")
         ]
     )
     

--- a/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -18,8 +18,14 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
+    
+    
     let expectedQuery = """
             mutation CreateCustomerSession($input: CreateCustomerSessionInput!) {
                 createCustomerSession(input: $input) {
@@ -41,7 +47,11 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
@@ -67,7 +77,9 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
+        XCTAssertNil(payPalCampaigns)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
@@ -92,7 +104,9 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
-        
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+
+        XCTAssertNil(payPalCampaigns)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)

--- a/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
@@ -19,6 +19,10 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
                 amount: "12.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
     let expectedQuery = """
@@ -47,12 +51,17 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+
         
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
         XCTAssertEqual(amount?["value"] as? String, "5.00")
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
     }
     
     func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithNilData() {
@@ -74,11 +83,13 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
     
     func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithEmptyData() {

--- a/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -19,6 +19,10 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
                 amount: "12.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
     let expectedQuery = """
@@ -42,12 +46,16 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
         XCTAssertEqual(amount?["value"] as? String, "4.50")
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
     }
     
     func testEncodingUpdateCustomerSessionGraphQLBodyWithNilData() {
@@ -69,11 +77,13 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
     
     func testEncodingUpdateCustomerSessionGraphQLBodyWithEmptyData() {
@@ -95,10 +105,12 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

Add PayPal Campaigns to the create/update session API
- 

### Checklist

- [] Added a changelog entry
- [N/A] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- aaleid-paypal-public
