### PR TITLE
Add PayPal Campaigns to the create/update session API

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		BEFE6DAA27E28A0B002BE9C8 /* MockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE6DA927E28A0B002BE9C8 /* MockViewController.swift */; };
 		BEFE9A3B29C8EC6B00BF69AB /* BTCardClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE9A3A29C8EC6B00BF69AB /* BTCardClient.swift */; };
 		BEFE9A3D29C8ECAA00BF69AB /* BTCardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */; };
+		CA58E8CE2F86D0EC00F23295 /* BTPayPalCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA58E8CD2F86D0EC00F23295 /* BTPayPalCampaign.swift */; };
 		CE836AA02E4FDCE300AC7FCA /* UIApplication+ApplicationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE836A9F2E4FDCE000AC7FCA /* UIApplication+ApplicationState.swift */; };
 /* End PBXBuildFile section */
 
@@ -1194,6 +1195,7 @@
 		BEFE6DA927E28A0B002BE9C8 /* MockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewController.swift; sourceTree = "<group>"; };
 		BEFE9A3A29C8EC6B00BF69AB /* BTCardClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardClient.swift; sourceTree = "<group>"; };
 		BEFE9A3C29C8ECAA00BF69AB /* BTCardError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCardError.swift; sourceTree = "<group>"; };
+		CA58E8CD2F86D0EC00F23295 /* BTPayPalCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCampaign.swift; sourceTree = "<group>"; };
 		CE836A9F2E4FDCE000AC7FCA /* UIApplication+ApplicationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+ApplicationState.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2243,6 +2245,7 @@
 		BE5496EA2E313A4D003CCA60 /* V2 */ = {
 			isa = PBXGroup;
 			children = (
+				CA58E8CD2F86D0EC00F23295 /* BTPayPalCampaign.swift */,
 				62C458D22DD2918600B4F9B3 /* BTCreateCustomerSessionAPI.swift */,
 				621149D92E01E999006D7687 /* BTCustomerRecommendationsAPI.swift */,
 				455AA2752DEE0574008D99AB /* BTCustomerRecommendationsResult.swift */,
@@ -3655,6 +3658,7 @@
 				62EA90492B63071800DD79BC /* BTEligiblePaymentMethods.swift in Sources */,
 				804698392B27C53E0090878E /* BTShopperInsightsResult.swift in Sources */,
 				624454DE2DDE399D00A3383B /* CreateCustomerSessionMutationGraphQLBody.swift in Sources */,
+				CA58E8CE2F86D0EC00F23295 /* BTPayPalCampaign.swift in Sources */,
 				455AA2762DEE0577008D99AB /* BTCustomerRecommendationsResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Fix inconsistency in minimum deployment target, which is now consistently iOS 16 (fixes #1757)
 * BraintreeShopperInsights
   * Add `payPalPayLater` case to `BTButtonType` enum
+    
+## 7.6.0 (2026-02-25)
+* BraintreeShopperInsights
+    * Added campaign id to be passed down to create/update session and recommendations endpoint.
 
 ## 7.5.0 (2026-02-25)
 * BraintreePayPal

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -49,7 +49,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         let view = TextFieldWithLabel()
         view.label.text = "SessionID"
         view.textField.placeholder = "SessionID"
-        view.textField.text = "94f0b2db-5323-4d86-add3-paypalmsg000"
+        view.textField.text = ""
         return view
     }()
     

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -53,6 +53,14 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         return view
     }()
     
+    lazy var campaignIds: TextFieldWithLabel = {
+        let view = TextFieldWithLabel()
+        view.label.text = "Campaign Ids"
+        view.textField.placeholder = "Campaign Ids"
+        view.textField.text = "1,2,3,4"
+        return view
+    }()
+    
     private let recommendationsLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -79,7 +87,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
     )
     
     lazy var shopperInsightsInputView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView, sessionIDView])
+        let stackView = UIStackView(arrangedSubviews: [emailView, countryCodeView, nationalNumberView, sessionIDView, campaignIds])
         stackView.axis = .vertical
         stackView.spacing = 10
         stackView.distribution = .fillEqually
@@ -135,7 +143,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
                 purchaseUnits: [
                     BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-                ]
+                ],
+                payPalCampaigns: parseCampaignIds()
             )
 
             do {
@@ -162,7 +171,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
             venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
             purchaseUnits: [
                 BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-            ]
+            ],
+            payPalCampaigns: parseCampaignIds()
         )
 
         Task {
@@ -194,7 +204,8 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
             venmoAppInstalled: shopperInsightsClient.isVenmoAppInstalled(),
             purchaseUnits: [
                 BTPurchaseUnit(amount: "42.00", currencyCode: "USD")
-            ]
+            ], 
+            payPalCampaigns: parseCampaignIds()
         )
 
         Task {
@@ -257,6 +268,15 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         let inputData = Data(input.utf8)
         let hashed = SHA256.hash(data: inputData)
         return hashed.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    private func parseCampaignIds() -> [BTPayPalCampaign]? {
+        guard let text = campaignIds.textField.text, !text.isEmpty else {
+            return nil
+        }
+        return text
+            .split(separator: ",")
+            .map { BTPayPalCampaign(id: String($0).trimmingCharacters(in: .whitespaces)) }
     }
     
     private func togglePayPalVaultButton(enabled: Bool) {
@@ -366,7 +386,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 shopperInsightsInputView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 shopperInsightsInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
                 shopperInsightsInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-                shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 200)
+                shopperInsightsInputView.heightAnchor.constraint(equalToConstant: 250)
             ]
         )
         

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -11,26 +11,26 @@ struct Variables: Encodable {
     
     struct InputParameters: Encodable {
         
-    let sessionID: String?
-    let customer: Customer?
-    let purchaseUnits: [PurchaseUnit]?
-    let payPalCampaigns: [BTPayPalCampaign]?
+        let sessionID: String?
+        let customer: Customer?
+        let purchaseUnits: [PurchaseUnit]?
+        let payPalCampaigns: [BTPayPalCampaign]?
         
-    init(request: BTCustomerSessionRequest?, sessionID: String?) {
-        self.sessionID = sessionID
-        customer = Customer(request: request)
-        purchaseUnits = request?.purchaseUnits?.compactMap {
-            PurchaseUnit(purchaseUnit: $0)
+        init(request: BTCustomerSessionRequest?, sessionID: String?) {
+            self.sessionID = sessionID
+            customer = Customer(request: request)
+            purchaseUnits = request?.purchaseUnits?.compactMap {
+                PurchaseUnit(purchaseUnit: $0)
+            }
+            payPalCampaigns = request?.payPalCampaigns
         }
-        payPalCampaigns = request?.payPalCampaigns
-    }
         
-    enum CodingKeys: String, CodingKey {
-        case sessionID = "sessionId"
-        case customer
-        case purchaseUnits
-        case payPalCampaigns = "paypal_campaigns"
-    }
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "sessionId"
+            case customer
+            case purchaseUnits
+            case payPalCampaigns = "paypal_campaigns"
+        }
         
         struct Customer: Encodable {
             

--- a/Sources/BraintreeShopperInsights/Models/Variables.swift
+++ b/Sources/BraintreeShopperInsights/Models/Variables.swift
@@ -11,23 +11,26 @@ struct Variables: Encodable {
     
     struct InputParameters: Encodable {
         
-        let sessionID: String?
-        let customer: Customer?
-        let purchaseUnits: [PurchaseUnit]?
+    let sessionID: String?
+    let customer: Customer?
+    let purchaseUnits: [PurchaseUnit]?
+    let payPalCampaigns: [BTPayPalCampaign]?
         
-        init(request: BTCustomerSessionRequest?, sessionID: String?) {
-            self.sessionID = sessionID
-            customer = Customer(request: request)
-            purchaseUnits = request?.purchaseUnits?.compactMap {
-                PurchaseUnit(purchaseUnit: $0)
-            }
+    init(request: BTCustomerSessionRequest?, sessionID: String?) {
+        self.sessionID = sessionID
+        customer = Customer(request: request)
+        purchaseUnits = request?.purchaseUnits?.compactMap {
+            PurchaseUnit(purchaseUnit: $0)
         }
+        payPalCampaigns = request?.payPalCampaigns
+    }
         
-        enum CodingKeys: String, CodingKey {
-            case sessionID = "sessionId"
-            case customer
-            case purchaseUnits
-        }
+    enum CodingKeys: String, CodingKey {
+        case sessionID = "sessionId"
+        case customer
+        case purchaseUnits
+        case payPalCampaigns = "paypal_campaigns"
+    }
         
         struct Customer: Encodable {
             

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -1,34 +1,25 @@
-import Foundation
-
-/// A `BTCustomerSessionRequest`for creating a customer session.
-/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTCustomerSessionRequest {
-    
+
     let hashedEmail: String?
     let hashedPhoneNumber: String?
     let payPalAppInstalled: Bool?
     let venmoAppInstalled: Bool?
     let purchaseUnits: [BTPurchaseUnit]?
-    
-    /// Creates a BTCustomerSessionRequest
-    /// - Parameters:
-    ///   - hashedEmail: Optional: The customer's email address hashed via SHA256 algorithm.
-    ///   - hashedPhoneNumber: Optional: The customer's phone number hased via SHA256 algorithm.
-    ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
-    ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
-    ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
-    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    let payPalCampaigns: [BTPayPalCampaign]?
+
     public init(
         hashedEmail: String? = nil,
         hashedPhoneNumber: String? = nil,
         payPalAppInstalled: Bool? = nil,
         venmoAppInstalled: Bool? = nil,
-        purchaseUnits: [BTPurchaseUnit]? = nil
+        purchaseUnits: [BTPurchaseUnit]? = nil,
+        payPalCampaigns: [BTPayPalCampaign]? = nil
     ) {
         self.hashedEmail = hashedEmail
         self.hashedPhoneNumber = hashedPhoneNumber
         self.payPalAppInstalled = payPalAppInstalled
         self.venmoAppInstalled = venmoAppInstalled
         self.purchaseUnits = purchaseUnits
+        self.payPalCampaigns = payPalCampaigns
     }
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -17,6 +17,7 @@ public struct BTCustomerSessionRequest {
     ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
     ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
     ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
+    ///   - payPalCampaigns: Optional: List of campaign ids presented to end customer.
     /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
     
     public init(

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerSessionRequest.swift
@@ -1,3 +1,6 @@
+import Foundation
+
+/// A `BTCustomerSessionRequest`for creating a customer session.
 public struct BTCustomerSessionRequest {
 
     let hashedEmail: String?
@@ -7,6 +10,15 @@ public struct BTCustomerSessionRequest {
     let purchaseUnits: [BTPurchaseUnit]?
     let payPalCampaigns: [BTPayPalCampaign]?
 
+    /// Creates a BTCustomerSessionRequest
+    /// - Parameters:
+    ///   - hashedEmail: Optional: The customer's email address hashed via SHA256 algorithm.
+    ///   - hashedPhoneNumber: Optional: The customer's phone number hased via SHA256 algorithm.
+    ///   - payPalAppInstalled: Optional: Checks whether the PayPal app is installed on the device.
+    ///   - venmoAppInstalled: Optional: Checks whether the Venmo app is installed on the device.
+    ///   - purchaseUnits: Optional: The list of purchase units containing the amount and currency code.
+    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    
     public init(
         hashedEmail: String? = nil,
         hashedPhoneNumber: String? = nil,

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -1,12 +1,11 @@
 import Foundation
-/// The PayPal campaign details.
 
+/// Creates a BTPayPalCampaign
+/// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
+/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
 public struct BTPayPalCampaign: Encodable {
     let id: String
     
-    /// Creates a BTPayPalCampaign
-    /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
-    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
     public init(id: String) {
         self.id = id
     }

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public struct BTPayPalCampaign: Encodable {
     let id: String
+    
     /// Creates a BTPayPalCampaign
     /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
     /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Creates a BTPayPalCampaign
 /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
-/// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+
 public struct BTPayPalCampaign: Encodable {
     let id: String
     

--- a/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTPayPalCampaign.swift
@@ -1,0 +1,12 @@
+import Foundation
+/// The PayPal campaign details.
+
+public struct BTPayPalCampaign: Encodable {
+    let id: String
+    /// Creates a BTPayPalCampaign
+    /// - Parameter id: The campaign identifier associated between PayPal and the merchant/partner.
+    /// - Warning: This feature is in beta. It's public API may change or be removed in future releases.
+    public init(id: String) {
+        self.id = id
+    }
+}

--- a/UnitTests/BraintreeShopperInsightsTests/BTCreateCustomerSessionAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTCreateCustomerSessionAPI_Tests.swift
@@ -24,6 +24,9 @@ class BTCreateCustomerSessionAPI_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123")
         ]
     )
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTPayPalCampaign_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTPayPalCampaign_Tests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import BraintreeShopperInsights
+
+class BTPayPalCampaign_Tests: XCTestCase {
+    
+    func testBTPayPalCampaign_initializesWithId() {
+        let campaign = BTPayPalCampaign(id: "test-campaign-123")
+        
+        XCTAssertEqual(campaign.id, "test-campaign-123")
+    }
+    
+    func testBTPayPalCampaign_initializesWithEmptyId() {
+        let campaign = BTPayPalCampaign(id: "")
+        
+        XCTAssertEqual(campaign.id, "")
+    }
+    
+    func testBTPayPalCampaign_initializesWithSpecialCharacters() {
+        let campaign = BTPayPalCampaign(id: "campaign-with-special_chars-#123")
+        
+        XCTAssertEqual(campaign.id, "campaign-with-special_chars-#123")
+    }
+    
+    func testBTPayPalCampaign_encodesToJSON() throws {
+        let campaign = BTPayPalCampaign(id: "test-campaign-456")
+        let encoder = JSONEncoder()
+        
+        let jsonData = try encoder.encode(campaign)
+        let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
+        
+        XCTAssertNotNil(jsonObject)
+        XCTAssertEqual(jsonObject?["id"] as? String, "test-campaign-456")
+    }
+    
+    func testBTPayPalCampaign_encodesArrayToJSON() throws {
+        let campaigns = [
+            BTPayPalCampaign(id: "campaign-1"),
+            BTPayPalCampaign(id: "campaign-2"),
+            BTPayPalCampaign(id: "campaign-3")
+        ]
+        let encoder = JSONEncoder()
+        
+        let jsonData = try encoder.encode(campaigns)
+        let jsonArray = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [[String: Any]]
+        
+        XCTAssertNotNil(jsonArray)
+        XCTAssertEqual(jsonArray?.count, 3)
+        XCTAssertEqual(jsonArray?[0]["id"] as? String, "campaign-1")
+        XCTAssertEqual(jsonArray?[1]["id"] as? String, "campaign-2")
+        XCTAssertEqual(jsonArray?[2]["id"] as? String, "campaign-3")
+    }
+    
+    func testBTPayPalCampaign_encodesEmptyArrayToJSON() throws {
+        let campaigns: [BTPayPalCampaign] = []
+        let encoder = JSONEncoder()
+        
+        let jsonData = try encoder.encode(campaigns)
+        let jsonArray = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [[String: Any]]
+        
+        XCTAssertNotNil(jsonArray)
+        XCTAssertEqual(jsonArray?.count, 0)
+    }
+}

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -21,6 +21,9 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123")
         ]
     )
     

--- a/UnitTests/BraintreeShopperInsightsTests/BTUpdateCustomerSessionAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTUpdateCustomerSessionAPI_Tests.swift
@@ -25,6 +25,10 @@ class BTUpdateCustomerSessionApi_Test: XCTestCase {
                 amount: "12.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-456"),
+            BTPayPalCampaign(id: "campaign-789")
         ]
     )
     

--- a/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -111,4 +111,56 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)
     }
+    
+    func testEncodingCreateCustomerSessionGraphQLBodyWithEmptyCampaigns() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: []
+        )
+        
+        let body = CreateCustomerSessionMutationGraphQLBody(request: request)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertNotNil(payPalCampaigns)
+        XCTAssertEqual(payPalCampaigns?.count, 0)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
+    
+    func testEncodingCreateCustomerSessionGraphQLBodyWithSingleCampaign() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "single-campaign-789")
+            ]
+        )
+        
+        let body = CreateCustomerSessionMutationGraphQLBody(request: request)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertEqual(payPalCampaigns?.count, 1)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "single-campaign-789")
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/CreateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -18,8 +18,14 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
                 amount: "20.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
+    
+    
     let expectedQuery = """
             mutation CreateCustomerSession($input: CreateCustomerSessionInput!) {
                 createCustomerSession(input: $input) {
@@ -41,7 +47,11 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
@@ -67,7 +77,9 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
+        XCTAssertNil(payPalCampaigns)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
@@ -92,7 +104,9 @@ class CreateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
-        
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+
+        XCTAssertNil(payPalCampaigns)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)

--- a/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
@@ -111,9 +111,65 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
+    }
+    
+    func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithEmptyCampaigns() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: []
+        )
+        
+        let body = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertNotNil(payPalCampaigns)
+        XCTAssertEqual(payPalCampaigns?.count, 0)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
+    
+    func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithSingleCampaign() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "single-campaign-555")
+            ]
+        )
+        
+        let body = GenerateCustomerRecommendationsGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertEqual(payPalCampaigns?.count, 1)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "single-campaign-555")
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
     }

--- a/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
@@ -19,6 +19,10 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
                 amount: "12.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
     let expectedQuery = """
@@ -47,12 +51,17 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+
         
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
         XCTAssertEqual(amount?["value"] as? String, "5.00")
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
     }
     
     func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithNilData() {
@@ -74,11 +83,13 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
     
     func testEncodingGenerateCustomerRecommendationsGraphQLBodyWithEmptyData() {

--- a/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -113,4 +113,58 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertNil(payPalCampaigns)
     }
+    
+    func testEncodingUpdateCustomerSessionGraphQLBodyWithEmptyCampaigns() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: []
+        )
+        
+        let body = UpdateCustomerSessionMutationGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertNotNil(payPalCampaigns)
+        XCTAssertEqual(payPalCampaigns?.count, 0)
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
+    
+    func testEncodingUpdateCustomerSessionGraphQLBodyWithSingleCampaign() {
+        let request = BTCustomerSessionRequest(
+            hashedEmail: "test-hashed-email.com",
+            hashedPhoneNumber: nil,
+            payPalAppInstalled: true,
+            venmoAppInstalled: nil,
+            purchaseUnits: nil,
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "single-campaign-999")
+            ]
+        )
+        
+        let body = UpdateCustomerSessionMutationGraphQLBody(request: request, sessionID: sessionID)
+        guard let jsonObject = try? body.toDictionary() else {
+            XCTFail()
+            return
+        }
+        
+        let variables = jsonObject["variables"] as? [String: Any]
+        let input = variables?["input"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
+        
+        XCTAssertEqual(payPalCampaigns?.count, 1)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "single-campaign-999")
+        XCTAssertEqual(input?["sessionId"] as? String, sessionID)
+        XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+    }
 }

--- a/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/UpdateCustomerSessionMutationGraphQLBody_Tests.swift
@@ -19,6 +19,10 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
                 amount: "12.00",
                 currencyCode: "USD"
             )
+        ],
+        payPalCampaigns: [
+            BTPayPalCampaign(id: "campaign-123"),
+            BTPayPalCampaign(id: "campaign-456")
         ]
     )
     let expectedQuery = """
@@ -42,12 +46,16 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
         let amount = purchaseUnits?.first?["amount"] as? [String: Any]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(customer?["hashedEmail"] as? String, "test-hashed-email.com")
         XCTAssertEqual(customer?["paypalAppInstalled"] as? Bool, true)
         XCTAssertEqual(amount?["value"] as? String, "4.50")
+        XCTAssertEqual(payPalCampaigns?.count, 2)
+        XCTAssertEqual(payPalCampaigns?.first?["id"] as? String, "campaign-123")
+        XCTAssertEqual(payPalCampaigns?.last?["id"] as? String, "campaign-456")
     }
     
     func testEncodingUpdateCustomerSessionGraphQLBodyWithNilData() {
@@ -69,11 +77,13 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertNil(purchaseUnits)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
     
     func testEncodingUpdateCustomerSessionGraphQLBodyWithEmptyData() {
@@ -95,10 +105,12 @@ class UpdateCustomerSessionMutationGraphQLBody_Tests: XCTestCase {
         let input = variables?["input"] as? [String: Any]
         let customer = input?["customer"] as? [String: Any]
         let purchaseUnits = input?["purchaseUnits"] as? [[String: Any]]
+        let payPalCampaigns = input?["paypal_campaigns"] as? [[String: Any]]
         
         XCTAssertNotNil(customer)
         XCTAssertEqual(purchaseUnits?.count, 0)
         XCTAssertEqual(input?["sessionId"] as? String, sessionID)
         XCTAssertEqual(jsonObject["query"] as? String, expectedQuery)
+        XCTAssertNil(payPalCampaigns)
     }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
Add PayPal Campaigns to the create/update session API
- 

### Checklist

- [x ] Added a changelog entry
- [ x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
aaleid-paypal-public
vkspune

- 
