### PR TITLE
Hook up state management to CVV field

### DIFF
--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -11,6 +11,7 @@ struct CVVFieldView: View {
 
     @FocusState private var isFocused: Bool
     @State private var showCVVHint: Bool = false
+    @State private var textFieldText: String = ""
 
     // MARK: - View
 
@@ -25,15 +26,19 @@ struct CVVFieldView: View {
                     .foregroundColor(Color(.secondaryLabel))
 
                 ZStack(alignment: .leading) {
-                    TextField("", text: Binding(
-                        get: { viewModel.rawValue },
-                        set: { viewModel.updateValue($0) }
-                    ))
+                    TextField("", text: $textFieldText)
                     .keyboardType(.numberPad)
                     .focused($isFocused)
                     .foregroundColor(.clear)
                     .tint(Color(.label))
                     .font(.system(size: 16))
+                    .onChange(of: textFieldText) { _, newValue in
+                        let digits = String(newValue.filter { $0.isNumber }.prefix(viewModel.maxLength))
+                        if digits != textFieldText {
+                            textFieldText = digits
+                        }
+                        viewModel.updateValue(digits)
+                    }
 
                     if viewModel.characters.isEmpty {
                         Text("•••")

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
@@ -5,10 +5,18 @@ class CVVFieldViewModel: ObservableObject {
 
     @Published private(set) var value: String = ""
     @Published private(set) var validationState: ValidationResult = .valid
-    @Published var isFocused: Bool = false
+    @Published var isFocused: Bool = false {
+        didSet {
+            // Show validation errors only after the user leaves the field
+            if !isFocused {
+                validationState = validator.validate(rawValue)
+            }
+        }
+    }
 
-    // TODO: Implement auto-advance logic with state changes
-    var shouldAutoAdvance: Bool { false }
+    var shouldAutoAdvance: Bool { validationState == .valid && !rawValue.isEmpty }
+
+    var maxLength: Int { validator.expectedLength ?? 4 }
 
     // MARK: - Internal Properties
 
@@ -18,10 +26,25 @@ class CVVFieldViewModel: ObservableObject {
     /// Raw digits only — no masking, used for tokenization
     @Published private(set) var rawValue: String = ""
 
+    // MARK: - Private Properties
+
+    private let validator: CVVFieldValidator
+
+    init(validator: CVVFieldValidator = CVVFieldValidator()) {
+        self.validator = validator
+    }
+
+    // MARK: - Internal Methods
+
     func updateValue(_ newValue: String) {
         let digits = String(newValue.filter { $0.isNumber }.prefix(4))
         rawValue = digits
         value = digits
+
+        let result = validator.validate(digits)
+        if result == .valid {
+            validationState = .valid
+        }
 
         let oldCount = characters.count
         let newCount = digits.count
@@ -47,6 +70,8 @@ class CVVFieldViewModel: ObservableObject {
             }
         }
     }
+
+    // MARK: - Private Methods
 
     private func scheduleMasking(for characterID: UUID) {
         Task {

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsContainerView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsContainerView.swift
@@ -23,7 +23,7 @@ struct CardFieldsContainerView<Content: View>: View {
             if case .invalid(let message) = validationState {
                 Text(message)
                     .font(.caption)
-                    .foregroundColor(.red)
+                    .foregroundColor(.cardFieldErrorBorder)
                     .padding(.horizontal, 4)
             }
         }
@@ -31,7 +31,7 @@ struct CardFieldsContainerView<Content: View>: View {
     
     private var borderColor: Color {
         if case .invalid = validationState {
-            return .red
+            return .cardFieldErrorBorder
         }
         return isFocused ? Color(.systemBlue) : Color(.systemGray4)
     }

--- a/Sources/BraintreeUIComponents/UIComponents+Color.swift
+++ b/Sources/BraintreeUIComponents/UIComponents+Color.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 extension Color {
 
+    static let cardFieldErrorBorder = Color(hex: "9F111F")
+
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0


### PR DESCRIPTION

### Summary of changes
- This hooks up the validator to the view model for the cvv state handling. The actual usage of this state change (error handling and auto advancing to next field) will be handled in later tickets. This just exposes them for usage in the larger card field component

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Merge conflict handling, fixing small build issues

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 
