### PR TITLE
Make cc number optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Add `payPalPayLater` case to `BTButtonType` enum
 * BraintreeVenmo
   * Add analytics tracking for `createPaymentContext` GraphQL call
+* BraintreeCard
+  * Make `number` field optional in `BTCard`
 
 ## 7.5.0 (2026-02-25)
 * BraintreePayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Add analytics tracking for `createPaymentContext` GraphQL call
   * Add analytics tracking for `queryPaymentContext` GraphQL call
 * BraintreeCard
-  * Make `number` field optional in `BTCard`
+  * Add `BTCard(expirationMonth:expirationYear:cvv:)` to allow expiration date and cvv only tokenization
 
 ## 7.5.0 (2026-02-25)
 * BraintreePayPal

--- a/IntegrationTests/BTCardClient_IntegrationTests.swift
+++ b/IntegrationTests/BTCardClient_IntegrationTests.swift
@@ -162,7 +162,7 @@ class BTCardClient_IntegrationTests: XCTestCase {
 
     func testTokenizeCard_whenUsingVersionThreeClientTokenAndCardHasValidationEnabledAndCardIsValid_tokenizesSuccessfully() {
         let cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientTokenVersion3)
-        
+
         let card = BTCard(
             number: "4111111111111111",
             expirationMonth: "12",
@@ -186,5 +186,81 @@ class BTCardClient_IntegrationTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 5)
+    }
+
+    func testVerifyCard_withSavedPaymentMethodToken_cvvOnlyTokenizesSuccessfully() {
+        let cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
+
+        let card = BTCard(
+            number: "4111111111111111",
+            expirationMonth: "12",
+            expirationYear: Helpers.shared.futureYear(),
+            cvv: "123",
+            shouldValidate: true
+        )
+
+        let expectation = expectation(description: "Verify vaulted card with CVV-only nonce")
+
+        cardClient.tokenize(card) { tokenizedCard, error in
+            guard let tokenizedCard else {
+                XCTFail("Expected a payment method nonce to be returned from initial tokenization")
+                return
+            }
+
+            XCTAssertTrue(tokenizedCard.nonce.isValidNonce)
+            XCTAssertNil(error)
+
+            let cvvCard = BTCard(cvv: "123")
+            cardClient.tokenize(cvvCard) { cvvNonce, cvvError in
+                guard let cvvNonce else {
+                    XCTFail("Expected a CVV nonce to be returned")
+                    return
+                }
+
+                XCTAssertTrue(cvvNonce.nonce.isValidNonce)
+                XCTAssertNil(cvvError)
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testVerifyCard_withSavedPaymentMethodToken_cvvAndExpirationDateTokenizesSuccessfully() {
+        let cardClient = BTCardClient(authorization: BTIntegrationTestsConstants.sandboxClientToken)
+
+        let card = BTCard(
+            number: "4111111111111111",
+            expirationMonth: "12",
+            expirationYear: Helpers.shared.futureYear(),
+            cvv: "123",
+            shouldValidate: true
+        )
+
+        let expectation = expectation(description: "Verify vaulted card with CVV and expiration date nonce")
+
+        cardClient.tokenize(card) { tokenizedCard, error in
+            guard let tokenizedCard else {
+                XCTFail("Expected a payment method nonce to be returned from initial tokenization")
+                return
+            }
+
+            XCTAssertTrue(tokenizedCard.nonce.isValidNonce)
+            XCTAssertNil(error)
+
+            let cvvAndExpCard = BTCard(expirationMonth: "12", expirationYear: Helpers.shared.futureYear(), cvv: "123")
+            cardClient.tokenize(cvvAndExpCard) { cvvAndExpNonce, cvvAndExpError in
+                guard let cvvAndExpNonce else {
+                    XCTFail("Expected a CVV and expiration date nonce to be returned")
+                    return
+                }
+
+                XCTAssertTrue(cvvAndExpNonce.nonce.isValidNonce)
+                XCTAssertNil(cvvAndExpError)
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10)
     }
 }

--- a/Sources/BraintreeCard/BTCard.swift
+++ b/Sources/BraintreeCard/BTCard.swift
@@ -31,41 +31,12 @@ import BraintreeCore
     let authenticationInsightRequested: Bool
     let merchantAccountID: String?
 
-    // MARK: - Initializer
-    
-    /// Creates a Card
-    /// - Parameters:
-    ///   - number: Optional: The card number. If omitted, only the provided fields (e.g. expiration date and CVV) will be tokenized.
-    ///   - expirationMonth: Required: The expiration month as a one or two-digit number on the Gregorian calendar.
-    ///   - expirationYear: Required: The expiration year as a two or four-digit number on the Gregorian calendar.
-    ///   - cvv: Required: The card verification code (like CVV or CID).
-    ///   - postalCode: Optional: The postal code associated with the card's billing address.
-    ///   - cardholderName: Optional: The cardholder's name.
-    ///   - firstName: Optional: First name on the card.
-    ///   - lastName: Optional: Last name on the card.
-    ///   - company: Optional: Company name associated with the card.
-    ///   - streetAddress: Optional: The street address associated with the card's billing address.
-    ///   - extendedAddress: Optional: The extended address associated with the card's billing address.
-    ///   - locality: Optional: The city associated with the card's billing address.
-    ///   - region: Optional: Either a two-letter state code (for the US), or an ISO-3166-2 country subdivision code of up to three letters.
-    ///   - countryName: Optional: The country name associated with the card's billing address.
-    ///     - Note: Braintree only accepts specific country names.
-    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
-    ///   - countryCodeAlpha2: Optional: The ISO 3166-1 alpha-2 country code specified in the card's billing address.
-    ///     - Note: Braintree only accepts specific alpha-2 values.
-    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
-    ///   - countryCodeAlpha3: Optional: The ISO 3166-1 alpha-3 country code specified in the card's billing address.
-    ///     - Note: Braintree only accepts specific alpha-3 values.
-    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
-    ///   - countryCodeNumeric: Optional: The ISO 3166-1 numeric country code specified in the card's billing address.
-    ///     - Note: Braintree only accepts specific numeric values.
-    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
-    ///   - shouldValidate: Controls whether or not to return validations and/or verification results. By default, this is not enabled.
-    ///     - Note: Use this flag with caution. By enabling client-side validation, certain tokenize card requests may result in adding the card to the vault. These semantics are not currently documented.
-    ///   - authenticationInsightRequested: Optional: If authentication insight is requested. If this property is set to `true`, a `merchantAccountID` must be provided. Defaults to `false`.
-    ///   - merchantAccountID: Optional: The merchant account ID.
-    public init(
-        number: String? = nil,
+    // MARK: - Initializers
+
+    /// Internal designated initializer. Accepts an optional card number so that convenience
+    /// initializers can omit it entirely from the tokenization payload.
+    @nonobjc init(
+        number: String?,
         expirationMonth: String,
         expirationYear: String,
         cvv: String,
@@ -107,7 +78,95 @@ import BraintreeCore
         self.authenticationInsightRequested = authenticationInsightRequested
         self.merchantAccountID = merchantAccountID
     }
-    
+
+    /// Creates a Card
+    /// - Parameters:
+    ///   - number: Required: The card number.
+    ///   - expirationMonth: Required: The expiration month as a one or two-digit number on the Gregorian calendar.
+    ///   - expirationYear: Required: The expiration year as a two or four-digit number on the Gregorian calendar.
+    ///   - cvv: Required: The card verification code (like CVV or CID).
+    ///   - postalCode: Optional: The postal code associated with the card's billing address.
+    ///   - cardholderName: Optional: The cardholder's name.
+    ///   - firstName: Optional: First name on the card.
+    ///   - lastName: Optional: Last name on the card.
+    ///   - company: Optional: Company name associated with the card.
+    ///   - streetAddress: Optional: The street address associated with the card's billing address.
+    ///   - extendedAddress: Optional: The extended address associated with the card's billing address.
+    ///   - locality: Optional: The city associated with the card's billing address.
+    ///   - region: Optional: Either a two-letter state code (for the US), or an ISO-3166-2 country subdivision code of up to three letters.
+    ///   - countryName: Optional: The country name associated with the card's billing address.
+    ///     - Note: Braintree only accepts specific country names.
+    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
+    ///   - countryCodeAlpha2: Optional: The ISO 3166-1 alpha-2 country code specified in the card's billing address.
+    ///     - Note: Braintree only accepts specific alpha-2 values.
+    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
+    ///   - countryCodeAlpha3: Optional: The ISO 3166-1 alpha-3 country code specified in the card's billing address.
+    ///     - Note: Braintree only accepts specific alpha-3 values.
+    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
+    ///   - countryCodeNumeric: Optional: The ISO 3166-1 numeric country code specified in the card's billing address.
+    ///     - Note: Braintree only accepts specific numeric values.
+    ///     - SeeAlso: https://developer.paypal.com/braintree/docs/reference/general/countries#list-of-countries
+    ///   - shouldValidate: Controls whether or not to return validations and/or verification results. By default, this is not enabled.
+    ///     - Note: Use this flag with caution. By enabling client-side validation, certain tokenize card requests may result in adding the card to the vault. These semantics are not currently documented.
+    ///   - authenticationInsightRequested: Optional: If authentication insight is requested. If this property is set to `true`, a `merchantAccountID` must be provided. Defaults to `false`.
+    ///   - merchantAccountID: Optional: The merchant account ID.
+    public convenience init(
+        number: String,
+        expirationMonth: String,
+        expirationYear: String,
+        cvv: String,
+        postalCode: String? = nil,
+        cardholderName: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        company: String? = nil,
+        streetAddress: String? = nil,
+        extendedAddress: String? = nil,
+        locality: String? = nil,
+        region: String? = nil,
+        countryName: String? = nil,
+        countryCodeAlpha2: String? = nil,
+        countryCodeAlpha3: String? = nil,
+        countryCodeNumeric: String? = nil,
+        shouldValidate: Bool = false,
+        authenticationInsightRequested: Bool = false,
+        merchantAccountID: String? = nil
+    ) {
+        self.init(
+            number: number as String?,
+            expirationMonth: expirationMonth,
+            expirationYear: expirationYear,
+            cvv: cvv,
+            postalCode: postalCode,
+            cardholderName: cardholderName,
+            firstName: firstName,
+            lastName: lastName,
+            company: company,
+            streetAddress: streetAddress,
+            extendedAddress: extendedAddress,
+            locality: locality,
+            region: region,
+            countryName: countryName,
+            countryCodeAlpha2: countryCodeAlpha2,
+            countryCodeAlpha3: countryCodeAlpha3,
+            countryCodeNumeric: countryCodeNumeric,
+            shouldValidate: shouldValidate,
+            authenticationInsightRequested: authenticationInsightRequested,
+            merchantAccountID: merchantAccountID
+        )
+    }
+
+    /// Creates a `BTCard` with only expiration date and CVV, omitting the card number entirely.
+    /// Use this when updating the expiry of a card already stored in your Vault, without re-sending
+    /// the card number.
+    /// - Parameters:
+    ///   - expirationMonth: Required: The expiration month as a one or two-digit number on the Gregorian calendar.
+    ///   - expirationYear: Required: The expiration year as a two or four-digit number on the Gregorian calendar.
+    ///   - cvv: Required: The card verification code (like CVV or CID).
+    public convenience init(expirationMonth: String, expirationYear: String, cvv: String) {
+        self.init(number: nil, expirationMonth: expirationMonth, expirationYear: expirationYear, cvv: cvv)
+    }
+
     /// Creates a new instance of `BTCard` with only a CVV value,
     /// setting default values for all other parameters.
     /// This initializer should only be used if you wish to create a

--- a/Sources/BraintreeCard/BTCard.swift
+++ b/Sources/BraintreeCard/BTCard.swift
@@ -10,7 +10,7 @@ import BraintreeCore
 
     // MARK: - Internal Properties
 
-    let number: String
+    let number: String?
     let expirationMonth: String
     let expirationYear: String
     let cvv: String
@@ -35,7 +35,7 @@ import BraintreeCore
     
     /// Creates a Card
     /// - Parameters:
-    ///   - number: Required: The card number.
+    ///   - number: Optional: The card number. If omitted, only the provided fields (e.g. expiration date and CVV) will be tokenized.
     ///   - expirationMonth: Required: The expiration month as a one or two-digit number on the Gregorian calendar.
     ///   - expirationYear: Required: The expiration year as a two or four-digit number on the Gregorian calendar.
     ///   - cvv: Required: The card verification code (like CVV or CID).
@@ -65,7 +65,7 @@ import BraintreeCore
     ///   - authenticationInsightRequested: Optional: If authentication insight is requested. If this property is set to `true`, a `merchantAccountID` must be provided. Defaults to `false`.
     ///   - merchantAccountID: Optional: The merchant account ID.
     public init(
-        number: String,
+        number: String? = nil,
         expirationMonth: String,
         expirationYear: String,
         cvv: String,
@@ -115,7 +115,7 @@ import BraintreeCore
     /// - Parameters:
     ///   - cvv: The card verification code (like CVV or CID).
     public convenience init(cvv: String) {
-        self.init(number: "", expirationMonth: "", expirationYear: "", cvv: cvv)
+        self.init(number: nil, expirationMonth: "", expirationYear: "", cvv: cvv)
     }
     
     // MARK: - Internal Methods

--- a/UnitTests/BraintreeCardTests/BTCard_Tests.swift
+++ b/UnitTests/BraintreeCardTests/BTCard_Tests.swift
@@ -179,7 +179,7 @@ class BTCard_Tests: XCTestCase {
         let optionsDict = inputDict["options"] as! [String: Any]
 
         XCTAssertEqual(creditCardDict["cvv"] as? String, "321")
-        XCTAssertEqual(creditCardDict["number"] as? String, "")
+        XCTAssertNil(creditCardDict["number"])
         XCTAssertNil(creditCardDict["cardholderName"])
 
         let billingDict = creditCardDict["billingAddress"] as? [String: Any]
@@ -188,6 +188,23 @@ class BTCard_Tests: XCTestCase {
         XCTAssertEqual(optionsDict["validate"] as? Bool, false)
     }
     
+    func testGraphQLParameters_whenDoingExpiryAndCVVOnly_omitsNumberFromPayload() {
+        let card = BTCard(expirationMonth: "12", expirationYear: "2038", cvv: "321")
+
+        let params = try! card.graphQLParameters().toDictionary()
+
+        let variablesDict = params["variables"] as! [String: Any]
+        let inputDict = variablesDict["input"] as! [String: Any]
+        let creditCardDict = inputDict["creditCard"] as! [String: Any]
+        let optionsDict = inputDict["options"] as! [String: Any]
+
+        XCTAssertNil(creditCardDict["number"])
+        XCTAssertEqual(creditCardDict["expirationMonth"] as? String, "12")
+        XCTAssertEqual(creditCardDict["expirationYear"] as? String, "2038")
+        XCTAssertEqual(creditCardDict["cvv"] as? String, "321")
+        XCTAssertEqual(optionsDict["validate"] as? Bool, false)
+    }
+
     func testGraphQLParameters_whenMerchantAccountIDIsPresent_andAuthInsightRequestedIsTrue_requestsAuthInsight() {
         let card = BTCard(
             number: "5111111111111111",


### PR DESCRIPTION
### Summary of changes
- Make BTCard number optional to be in line with Android and Web SDK behavior. This allows some certain use cases where merchants wish to tokenize information other than just CVV (but without card number).

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Fix my bad commit history since I was on the wrong branch. Also, to double check and make sure I found all the areas that I needed to change

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 
