### PR TITLE
Fix spelling: occured → occurred

### DIFF
--- a/Sources/BraintreeCard/BTThreeDSecureInfo.swift
+++ b/Sources/BraintreeCard/BTThreeDSecureInfo.swift
@@ -18,7 +18,7 @@ import BraintreeCore
     /// On authentication, provides additional information as to why the transaction status has the specific value.
     public var authenticationTransactionStatusReason: String?
 
-    /// Cardholder authentication verification value or "CAVV" is the main encrypted message issuers and card networks use to verify authentication has occured.
+    /// Cardholder authentication verification value or "CAVV" is the main encrypted message issuers and card networks use to verify authentication has occurred.
     /// Mastercard uses an "AVV" message which will also be returned in the cavv parameter.
     public var cavv: String?
 

--- a/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
+++ b/Sources/BraintreeCore/Analytics/FPTIBatchData.swift
@@ -64,7 +64,7 @@ struct FPTIBatchData: Codable {
         let didPayPalServerAttemptAppSwitch: Bool?
         /// The experiment details associated with a shopper insights flow
         let merchantExperiment: String?
-        /// The type of page where the payment button is displayed or where an event occured.
+        /// The type of page where the payment button is displayed or where an event occurred.
         let pageType: String?
         /// UTC millisecond timestamp when a networking task started requesting a resource. See [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics#3162615).
         let requestStartTime: Int?

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentError.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentError.swift
@@ -86,7 +86,7 @@ public enum BTLocalPaymentError: Error, CustomNSError, LocalizedError, Equatable
         case .missingRedirectURL:
             return "Failed to complete payment flow due to missing redirectURL."
         case .missingReturnURL:
-            return "An error occured completing the payment authorization flow. The ASWebAuthenticationSession returned a nil URL."
+            return "An error occurred completing the payment authorization flow. The ASWebAuthenticationSession returned a nil URL."
         case .webSessionError(let error):
             return "ASWebAuthenticationSession failed with \(error.localizedDescription)"
         }

--- a/Sources/BraintreeShopperInsights/BTPageType.swift
+++ b/Sources/BraintreeShopperInsights/BTPageType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The type of page where the payment button is displayed or where an event occured.
+/// The type of page where the payment button is displayed or where an event occurred.
 /// - Warning: This module is in beta. It's public API may change or be removed in future releases.
 public enum BTPageType: String {
 

--- a/Sources/BraintreeShopperInsights/BTPresentmentDetails.swift
+++ b/Sources/BraintreeShopperInsights/BTPresentmentDetails.swift
@@ -14,7 +14,7 @@ public class BTPresentmentDetails {
     /// - Parameters:
     ///    - buttonOrder: The order or ranking in which payment buttons appear.
     ///    - experimentType: The experiment type that is sent to analytics to help improve the Shopper Insights feature experience.
-    ///    - pageType: The type of page where the payment button is displayed or where an event occured.
+    ///    - pageType: The type of page where the payment button is displayed or where an event occurred.
     public init(
         buttonOrder: BTButtonOrder,
         experimentType: BTExperimentType,


### PR DESCRIPTION
Corrects the misspelling "occured" → "occurred" in one user-facing error message (BTLocalPaymentError.missingReturnURL) and four public API doc comments. No behavioral change.

### Summary of changes
- 

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Analysis of code repository and and ranking of PR opportunities

**Estimated AI Code Contribution**
- [x ] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> @SpikeyCoder <Kevin Armstrong>
-

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. PR should be opened in a draft state with the `tech lead review required`, and `inner source` label
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, the PR can be moved to ready to review with the `tech lead review required` label removed
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [ ] Added all labels to the PR
- [ ] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [ ] Unit tests and builds have been run locally and pass/compile as expected
