### PR TITLE
Run Data Collector Setup on Main Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+
+* BraintreeDataCollector
+  * Fix intermittent crash in `collectDeviceData` caused by an internal SDK component accessing `UIPasteboard` off the main thread
+
 ## 7.6.0 (2026-05-18)
 * Fix inconsistency in minimum deployment target, which is now consistently iOS 16 (fixes #1757)
 * BraintreeShopperInsights

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -62,7 +62,10 @@ import BraintreeCore
     public func collectDeviceData() async throws -> String {
         let configuration = try await fetchConfiguration()
 
-        let clientMetadataID: String = generateClientMetadataID(with: configuration)
+        // MagnesSDK.setUp accesses UIPasteboard internally, which requires the main thread.
+        let clientMetadataID: String = await MainActor.run {
+            generateClientMetadataID(with: configuration)
+        }
         let dataDictionary: [String: String] = ["correlation_id": clientMetadataID]
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: dataDictionary) else {
@@ -101,13 +104,16 @@ import BraintreeCore
                 self.config = configuration
                 let magnesEnvironment = self.getMagnesEnvironment(from: self.config)
 
-                try? MagnesSDK.shared().setUp(
-                    setEnviroment: magnesEnvironment,
-                    setOptionalAppGuid: self.deviceIdentifier(),
-                    disableRemoteConfiguration: false,
-                    disableBeacon: false,
-                    magnesSource: .BRAINTREE
-                )
+                // MagnesSDK.setUp accesses UIPasteboard internally, which requires the main thread.
+                await MainActor.run {
+                    try? MagnesSDK.shared().setUp(
+                        setEnviroment: magnesEnvironment,
+                        setOptionalAppGuid: self.deviceIdentifier(),
+                        disableRemoteConfiguration: false,
+                        disableBeacon: false,
+                        magnesSource: .BRAINTREE
+                    )
+                }
 
                 var magnesResult: MagnesResult?
                 magnesResult = try? MagnesSDK.shared().collectAndSubmit(

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -62,7 +62,7 @@ import BraintreeCore
     public func collectDeviceData() async throws -> String {
         let configuration = try await fetchConfiguration()
 
-        // MagnesSDK.setUp accesses UIPasteboard internally, which requires the main thread.
+        // MagnesSDK.shared().setUp accesses UIPasteboard internally, which requires the main thread.
         let clientMetadataID: String = await MainActor.run {
             generateClientMetadataID(with: configuration)
         }

--- a/Sources/BraintreeDataCollector/BTDataCollector.swift
+++ b/Sources/BraintreeDataCollector/BTDataCollector.swift
@@ -104,7 +104,7 @@ import BraintreeCore
                 self.config = configuration
                 let magnesEnvironment = self.getMagnesEnvironment(from: self.config)
 
-                // MagnesSDK.setUp accesses UIPasteboard internally, which requires the main thread.
+                // MagnesSDK.shared().setUp accesses UIPasteboard internally, which requires the main thread.
                 await MainActor.run {
                     try? MagnesSDK.shared().setUp(
                         setEnviroment: magnesEnvironment,

--- a/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
+++ b/Sources/BraintreeLocalPayment/BTLocalPaymentClient.swift
@@ -93,7 +93,7 @@ import BraintreeDataCollector
         }
         
         let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
-        request.correlationID = dataCollector.clientMetadataID(nil)
+        request.correlationID = await MainActor.run { dataCollector.clientMetadataID(nil) }
         
         return try await start(request: request, configuration: configuration)
     }

--- a/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
+++ b/UnitTests/BraintreeDataCollectorTests/BTDataCollector_Tests.swift
@@ -283,6 +283,36 @@ class BTDataCollector_Tests: XCTestCase {
         XCTAssertEqual(error.errorCode, 4)
     }
     
+    // MARK: - Main Thread Safety Test
+
+    func testCollectDeviceData_invokesGenerateClientMetadataIDOnMainThread() async throws {
+        class ThreadCapturingDataCollector: BTDataCollector {
+            var capturedIsMainThread: Bool?
+
+            override func generateClientMetadataID(with configuration: BTConfiguration) -> String {
+                capturedIsMainThread = Thread.isMainThread
+                return "fake-client-metadata-id"
+            }
+        }
+
+        let config: [String: Any] = ["environment": "sandbox"]
+        let mockAPIClient = MockAPIClient(authorization: "development_tokenization_key")
+        mockAPIClient.cannedConfigurationResponseBody = BTJSON(value: config)
+
+        let dataCollector = ThreadCapturingDataCollector(authorization: authorization)
+        dataCollector.apiClient = mockAPIClient
+
+        _ = try await Task.detached {
+            try await dataCollector.collectDeviceData()
+        }.value
+
+        XCTAssertEqual(
+            dataCollector.capturedIsMainThread,
+            true,
+            "generateClientMetadataID must run on the main thread: MagnesSDK.setUp accesses UIPasteboard internally"
+        )
+    }
+
     // MARK: - Async/Await Tests
 
         func testCollectDeviceData_asyncAwait_collectsAllData() async throws {


### PR DESCRIPTION

### Summary of changes
-  During the setup process, Magnes uses UIPasteboard, which must run on the main thread. This can cause race conditions that lead to intermittent crashes. This fix puts the setup call and the `generateClientMetadataID` function (which calls setup) on the Main thread.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Assistance in discovering issue around UIPasteboard requiring main thread as well as assistance in how to write a test for this.

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 