### PR TITLE
Put PayPal MetadataID Call On Main Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * BraintreeDataCollector
   * Fix intermittent crash in `collectDeviceData` caused by an internal SDK component accessing `UIPasteboard` off the main thread
+* BraintreePayPal
+  * Fix `BTPayPalAccountNonce.clientMetadataID` returning `nil` caused by `clientMetadataID` being generated off the main thread
 
 ## 7.6.0 (2026-05-18)
 * Fix inconsistency in minimum deployment target, which is now consistently iOS 16 (fixes #1757)

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -481,7 +481,8 @@ import BraintreeDataCollector
             self.experiment = approvalURL.experiment
 
             let dataCollector = BTDataCollector(authorization: self.apiClient.authorization.originalValue)
-            let correlationID = self.payPalRequest?.riskCorrelationID ?? dataCollector.clientMetadataID(self.contextID)
+            let metadataID = await MainActor.run { dataCollector.clientMetadataID(self.contextID) }
+            let correlationID = self.payPalRequest?.riskCorrelationID ?? metadataID
 
             if let contextID = self.contextID {
                 self.clientMetadataIDs[contextID] = correlationID


### PR DESCRIPTION
### Summary of changes
- This is the same bug as the Data Collector and Local Payments fixes where due to a Magnes use of UIPasteboard the call needs to be on the main thread

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to find the location of the call to put on main thread since this is the same issue that came up in another place

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 