### PR TITLE
Fix ClientMetadataID Being Nil For PayPal Checkout With BillingAgreement Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Fix intermittent crash in `collectDeviceData` caused by an internal SDK component accessing `UIPasteboard` off the main thread
 * BraintreePayPal
   * Fix `BTPayPalAccountNonce.clientMetadataID` returning `nil` caused by `clientMetadataID` being generated off the main thread
+  * Fix `BTPayPalAccountNonce.clientMetadataID` returning `nil` for checkout flows with `requestBillingAgreement` enabled
 
 ## 7.6.0 (2026-05-18)
 * Fix inconsistency in minimum deployment target, which is now consistently iOS 16 (fixes #1757)

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import BraintreePayPal
 import BraintreeCore
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
     lazy var payPalClient = BTPayPalClient(

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -78,6 +78,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     let rbaDataToggle = Toggle(title: "Recurring Billing (RBA) Data")
     let contactInformationToggle = Toggle(title: "Add Contact Information")
     let amountBreakdownToggle = Toggle(title: "Amount Breakdown")
+    let requestBillingAgreementToggle = Toggle(title: "Request Billing Agreement")
 
     override func viewDidLoad() {
         super.heightConstraint = 500
@@ -112,6 +113,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         let oneTimeCheckoutStackView = buttonsStackView(label: "1-Time Checkout", views: [
             contactInformationToggle,
             amountBreakdownToggle,
+            requestBillingAgreementToggle,
             payPalCheckoutButton,
             payPalAppSwitchForCheckoutButton,
             payPalAppSwitchForCheckoutPayLaterButton,
@@ -180,6 +182,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             contactInformation: contactInformationToggle.isOn ? contactInformation : nil,
             contactPreference: .updateContactInformation,
             lineItems: [lineItem],
+            requestBillingAgreement: requestBillingAgreementToggle.isOn,
             userAuthenticationEmail: emailTextField.text,
             userPhoneNumber: BTPayPalPhoneNumber(
                 countryCode: countryCodeTextField.text ?? "",
@@ -243,9 +246,9 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             self.completionBlock(nonce)
         }
     }
-    
+
     // MARK: - Vault Flows
-    
+
     @objc func tappedPayPalVault(_ sender: UIButton) {
         progressBlock("Tapped PayPal - Vault using BTPayPalClient")
         sender.setTitle("Processing...", for: .disabled)
@@ -302,7 +305,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             self.completionBlock(nonce)
         }
     }
-    
+
     @objc func tappedPayPalAppSwitchForCheckout(_ sender: UIButton) {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
@@ -317,12 +320,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
-            
+
             guard let nonce else {
                 self.progressBlock(error?.localizedDescription)
                 return
             }
-            
+
             self.completionBlock(nonce)
         }
     }
@@ -341,12 +344,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
-            
+
             guard let nonce else {
                 self.progressBlock(error?.localizedDescription)
                 return
             }
-            
+
             self.completionBlock(nonce)
         }
     }
@@ -362,16 +365,16 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
-            
+
             guard let nonce else {
                 self.progressBlock(error?.localizedDescription)
                 return
             }
-            
+
             self.completionBlock(nonce)
         }
     }
-    
+
     @objc func tappedPayLaterForCheckout(_ sender: UIButton) {
         sender.setTitle("Processing...", for: .disabled)
         sender.isEnabled = false
@@ -387,12 +390,12 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
         payPalClient.tokenize(request) { nonce, error in
             sender.isEnabled = true
-            
+
             guard let nonce else {
                 self.progressBlock(error?.localizedDescription)
                 return
             }
-            
+
             self.completionBlock(nonce)
         }
     }

--- a/Sources/BraintreePayPal/BTPayPalClient.swift
+++ b/Sources/BraintreePayPal/BTPayPalClient.swift
@@ -28,7 +28,7 @@ import BraintreeDataCollector
     /// Used in POST body for FPTI analytics & `/paypal_account` fetch.
     /// The key is the PayPal context ID (e.g., BA or EC token), and the value is the corresponding client metadata ID.
     var clientMetadataIDs: [String: String] = [:]
-    
+
     /// Exposed for testing the intent associated with this request
     var payPalRequest: BTPayPalRequest?
     
@@ -748,9 +748,20 @@ import BraintreeDataCollector
     private func extractToken(from url: URL?) -> String? {
         guard let url else { return nil }
 
-        let baToken = BTURLUtils.queryParameters(for: url)["ba_token"]
-        let ecToken = BTURLUtils.queryParameters(for: url)["token"]
-        let token = baToken ?? ecToken
+        let params = BTURLUtils.queryParameters(for: url)
+        let baToken = params["ba_token"]
+        let ecToken = params["token"]
+
+        // For checkout+requestBillingAgreement, the return URL contains both an EC token and a newly-minted
+        // BA token. The CMID was stored under the EC token (from the approval URL), so we must look up by
+        // ecToken here rather than defaulting to baToken.
+        let token: String?
+        if payPalRequest?.paymentType == .checkout && shouldRequestBillingAgreement == true {
+            token = ecToken
+        } else {
+            token = baToken ?? ecToken
+        }
+
         return token?.isEmpty == true ? nil : token
     }
     


### PR DESCRIPTION
### Summary of changes
- When a merchant uses the checkout flow with PayPal and has `shouldRequestBillingAgreement` set to `true` the PP checkout token is returned for the CMID, but once the flow is completed a BA token is returned since a billing agreement has been requested. This caused the new BA token to override the existing CMID, which could no longer find the new token in the existing dictionary.  This fix resolves that issue by setting to the EC token for this specific scenario.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
For creating a quick testing scneario in the Demo app by adding a BA request toggle.

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 