### PR TITLE
Fix: make reaction step non-blocking, add pull-requests permission

### DIFF
--- a/.github/workflows/inner-source-labels.yml
+++ b/.github/workflows/inner-source-labels.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   add-inner-source-labels:
@@ -16,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acknowledge command
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -45,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acknowledge command
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
### Summary of changes
- The reaction step was failing with "Resource not accessible by integration", blocking the label step from running. Adding continue-on-error to the acknowledge steps so label actions proceed even if reactions are restricted. Also adds pull-requests: write permission which may be required for PR label operations.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

- @jaxdesmarais 