### PR TITLE
Fix Thread Crash Issue In APIClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeCore
+  * Fix crash caused by a data race on `BTAPIClient` HTTP properties when multiple clients are initialized concurrently (fixes #1818)
+
 ## 7.7.0 (2026-05-28)
 * BraintreeAmericanExpress
   * Fix `getRewardsBalance(forNonce:currencyISOCode:completion:)` completion handler not being called on the main thread (fixes #1801)

--- a/Sources/BraintreeCore/BTAPIClient.swift
+++ b/Sources/BraintreeCore/BTAPIClient.swift
@@ -23,7 +23,7 @@ import UIKit
     weak var analyticsService: AnalyticsSendable? = BTAnalyticsService.shared
 
     // MARK: - Initializers
-   
+
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     /// Initialize a new API client.
     /// - Parameter authorization: Your tokenization key or client token.
@@ -31,11 +31,11 @@ import UIKit
     public init(authorization: String) {
         self.authorization = Self.authorization(from: authorization)
         self.metadata = BTClientMetadata()
-                
+
         let btHTTP = BTHTTP(authorization: self.authorization)
         http = btHTTP
         configurationLoader = ConfigurationLoader(http: btHTTP)
-        
+
         super.init()
 
         analyticsService?.setAPIClient(self)
@@ -50,13 +50,9 @@ import UIKit
     // MARK: - Deinit
 
     deinit {
-        if http != nil && http?.session != nil {
-            http?.session.finishTasksAndInvalidate()
-        }
-
-        if graphQLHTTP != nil && graphQLHTTP?.session != nil {
-            graphQLHTTP?.session.finishTasksAndInvalidate()
-        }
+        http?.session.finishTasksAndInvalidate()
+        graphQLHTTP?.session.finishTasksAndInvalidate()
+        payPalHTTP?.session.finishTasksAndInvalidate()
     }
 
     // MARK: - Public Methods
@@ -85,13 +81,9 @@ import UIKit
     }
     
     public func fetchOrReturnRemoteConfiguration() async throws -> BTConfiguration {
-        do {
-            let configuration = try await configurationLoader.getConfig()
-            setupHTTPCredentials(configuration)
-            return configuration
-        } catch {
-            throw error
-        }
+        let configuration = try await configurationLoader.getConfig()
+        await MainActor.run { setupHTTPCredentials(configuration) }
+        return configuration
     }
        
     /// :nodoc: This method is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
@@ -143,8 +135,7 @@ import UIKit
             throw BTAPIClientError.invalidAuthorization(authorization.originalValue)
         }
 
-        let configuration = try await configurationLoader.getConfig()
-        setupHTTPCredentials(configuration)
+        let configuration = try await fetchOrReturnRemoteConfiguration()
 
         let postParameters = BTAPIRequest(requestBody: parameters, metadata: metadata, httpType: httpType)
         
@@ -241,6 +232,9 @@ import UIKit
     
     // MARK: Private Helpers
     
+    // @MainActor serializes writes to graphQLHTTP and payPalHTTP, preventing a data race
+    // where concurrent callers on different executors could each observe nil and race to set them.
+    @MainActor
     private func setupHTTPCredentials(_ configuration: BTConfiguration?) {
         if graphQLHTTP == nil {
             graphQLHTTP = BTGraphQLHTTP(authorization: authorization)
@@ -248,7 +242,7 @@ import UIKit
         }
         if payPalHTTP == nil {
             let paypalBaseURL: URL? = payPalAPIURL(forEnvironment: configuration?.environment ?? "")
-            
+
             if authorization.type == .clientToken {
                 payPalHTTP = BTHTTP(authorization: authorization, customBaseURL: paypalBaseURL)
                 payPalHTTP?.networkTimingDelegate = self


### PR DESCRIPTION

### Summary of changes
- This is a fix for issue #1818
- `setupHTTPCredentials()` function marked with @MainActor to ensure all function runs happen on same thread since this is used by both `graphQLHTTP` and `payPalHTTP`
- `fetchOrReturnRemoteConfiguration()` function. marked with @MainActor before calling `setupHTTPCredentials()` to ensure entire flow is on same thread
- `post()` calls `fetchOrReturnRemoteConfiguration()` instead of `setupHTTPCredentials` directly to use the now thread-safe path
- cleaned up `deinit` and added `payPalHTTP?.session.finishTasksAndInvalidate()` to ensure URLSession is removed

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to verify initial fix of `setupHTTPCredentials()` and `fetchOrReturnRemoteConfiguration()` were correct as well as review for any additional fixes. Claude pointed out last 2 bullet points ( verified with multiple agents)

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 