### PR TITLE
Fix CVV validation error state

### DIFF
--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldViewModel.swift
@@ -36,6 +36,10 @@ class CVVFieldViewModel: ObservableObject {
 
     func updateExpectedLength(_ length: Int?) {
         validator.expectedLength = length
+        guard !value.isEmpty else { return }
+
+        let result = validator.validate(value)
+        validationState = result == .validating ? .invalid("CVV is invalid") : result
     }
 
     func updateValue(_ newValue: String) {
@@ -85,9 +89,7 @@ class CVVFieldViewModel: ObservableObject {
         Task {
             try? await Task.sleep(for: .seconds(1))
             guard let index = characters.firstIndex(where: { $0.id == characterID }) else { return }
-            withAnimation(.easeInOut(duration: 0.3)) {
-                characters[index].isMasked = true
-            }
+            characters[index].isMasked = true
         }
     }
 }

--- a/Sources/BraintreeUIComponents/CardFields/CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFields.swift
@@ -99,7 +99,7 @@ public struct CardFields: View {
             apiClient.sendAnalyticsEvent(UIComponentsAnalytics.cardFieldsPresented)
             onValidityChange?(viewModel.isFormValid, submitAction)
         }
-        .onChange(of: viewModel.isFormValid) { _, isValid in
+        .onReceive(viewModel.formValidityPublisher) { isValid in
             onValidityChange?(isValid, submitAction)
         }
     }

--- a/Sources/BraintreeUIComponents/CardFields/CardFieldsViewModel.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFieldsViewModel.swift
@@ -13,6 +13,13 @@ final class CardFieldsViewModel: ObservableObject {
 
     @Published private(set) var isFormValid: Bool = false
 
+    // Debounced so rapid delete+retype coalesces — never delivers an intermediate invalid state.
+    lazy var formValidityPublisher: AnyPublisher<Bool, Never> = $isFormValid
+        .dropFirst()
+        .removeDuplicates()
+        .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
+        .eraseToAnyPublisher()
+
     // MARK: - Private Properties
 
     private let cardClient: BTCardClient
@@ -40,6 +47,7 @@ final class CardFieldsViewModel: ObservableObject {
 
         Publishers.CombineLatest3(cardValid, expValid, cvvValid)
             .map { $0 && $1 && $2 }
+            .removeDuplicates()
             .assign(to: &$isFormValid)
     }
 

--- a/UnitTests/BraintreeUIComponentsTests/CVVFieldViewModelTests.swift
+++ b/UnitTests/BraintreeUIComponentsTests/CVVFieldViewModelTests.swift
@@ -75,6 +75,39 @@ import XCTest
          XCTAssertEqual(viewModel.characters.map { $0.value }, ["4", "5", "6"])
      }
 
+
+     // MARK: - updateExpectedLength
+
+     func testUpdateExpectedLength_validCVVBecomesTooShort_showsError() {
+         viewModel.updateExpectedLength(3)
+         viewModel.updateValue("123")
+         XCTAssertEqual(viewModel.validationState, .valid)
+
+         viewModel.updateExpectedLength(4)
+
+         XCTAssertEqual(viewModel.validationState, .invalid("CVV is invalid"))
+     }
+
+     func testUpdateExpectedLength_invalidCVVBecomesValid_clearsError() {
+         viewModel.updateValue("1234")
+         XCTAssertEqual(viewModel.validationState, .valid)
+
+         viewModel.updateExpectedLength(3)
+         XCTAssertEqual(viewModel.validationState, .invalid("CVV is invalid"))
+
+         viewModel.updateExpectedLength(4)
+
+         XCTAssertEqual(viewModel.validationState, .valid)
+     }
+
+     func testUpdateExpectedLength_emptyField_doesNotShowError() {
+         XCTAssertEqual(viewModel.value, "")
+
+         viewModel.updateExpectedLength(3)
+
+         XCTAssertEqual(viewModel.validationState, .valid)
+     }
+
      // MARK: - Masking Timer
 
      func testMaskingTimer_characterMasksAfterDelay() {


### PR DESCRIPTION
### Summary of changes
- Fixes an issue where if CVV is entered and card number changes to a card type where CVV length changes, the validation error state wouldn't trigger unless the field was specifically focused again.
- Fixes an issue where typing in CVV would be laggy in certain situations.


https://github.com/user-attachments/assets/38c4a1c3-39f0-4d71-878b-660ccd958121



### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Track down cause of laggy CVV typing, write unit tests

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 