### PR TITLE
Fix Cardfields Popover

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		0878313B2F7C2839003BB460 /* CardFieldsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0878313A2F7C2839003BB460 /* CardFieldsContainerView.swift */; };
 		6BE88A2459BC408288DC463C /* CardFieldsConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802F8EBBED394EB59C531040 /* CardFieldsConstants.swift */; };
 		0878313D2F83FBDA003BB460 /* CVVCharacter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0878313C2F83FBDA003BB460 /* CVVCharacter.swift */; };
+		2786AB6520BA4E79A5EFB08B /* CVVHintCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BD3E21BC44E928B80A155 /* CVVHintCard.swift */; };
 		087CA76E2F0D72E80065D89B /* BTGraphQLHTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087CA76D2F0D72E80065D89B /* BTGraphQLHTTPError.swift */; };
 		08804D492F86D61E005ED3AC /* CVVFieldViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08804D472F86D61E005ED3AC /* CVVFieldViewModelTests.swift */; };
 		08804D4A2F86D61E005ED3AC /* CVVFieldValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08804D482F86D61E005ED3AC /* CVVFieldValidatorTests.swift */; };
@@ -860,6 +861,7 @@
 		0878313A2F7C2839003BB460 /* CardFieldsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsContainerView.swift; sourceTree = "<group>"; };
 		802F8EBBED394EB59C531040 /* CardFieldsConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFieldsConstants.swift; sourceTree = "<group>"; };
 		0878313C2F83FBDA003BB460 /* CVVCharacter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVCharacter.swift; sourceTree = "<group>"; };
+		731BD3E21BC44E928B80A155 /* CVVHintCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVHintCard.swift; sourceTree = "<group>"; };
 		087CA76D2F0D72E80065D89B /* BTGraphQLHTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLHTTPError.swift; sourceTree = "<group>"; };
 		08804D472F86D61E005ED3AC /* CVVFieldViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldViewModelTests.swift; sourceTree = "<group>"; };
 		08804D482F86D61E005ED3AC /* CVVFieldValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVVFieldValidatorTests.swift; sourceTree = "<group>"; };
@@ -1639,6 +1641,7 @@
 				08F6DB152F6AE18E002FA6EE /* CVVFieldValidator.swift */,
 				08F6DB252F6AEC30002FA6EE /* CVVFieldViewModel.swift */,
 				0878313C2F83FBDA003BB460 /* CVVCharacter.swift */,
+				731BD3E21BC44E928B80A155 /* CVVHintCard.swift */,
 			);
 			path = CVVField;
 			sourceTree = "<group>";
@@ -3669,6 +3672,7 @@
 				08F6DB112F69FD27002FA6EE /* CVVFieldView.swift in Sources */,
 				084135472ED0DCCC00884FE9 /* PaymentButtonColorProtocol.swift in Sources */,
 				0878313D2F83FBDA003BB460 /* CVVCharacter.swift in Sources */,
+				2786AB6520BA4E79A5EFB08B /* CVVHintCard.swift in Sources */,
 				08F6DB1A2F6AE222002FA6EE /* CardNumberFieldValidator.swift in Sources */,
 				046F007C2ED6406000F08512 /* PayPalButtonColor.swift in Sources */,
 				08F6DB142F69FD5E002FA6EE /* CardFieldsValidatorProtocol.swift in Sources */,
@@ -4724,7 +4728,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4783,7 +4787,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/BraintreeCore/Info.plist";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4839,7 +4843,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UnitTests/BraintreeUIComponentsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -4879,7 +4883,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UnitTests/BraintreeUIComponentsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreeUIComponents
-  * Fix minimum target version to 16.0 to match all other modules
+  * Fix minimum target version to iOS 16.0 to match all other modules
 
 ## 7.8.0 (2026-06-30)
 * BraintreeCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS SDK Release Notes
 
+## unreleased
+* BraintreeUIComponents
+  * Fix minimum target version to 16.0 to match all other modules
+
 ## 7.8.0 (2026-06-30)
 * BraintreeCore
   * Fix crash caused by a data race on `BTAPIClient` HTTP properties when multiple clients are initialized concurrently (fixes #1818)

--- a/Demo/Application/Features/UIComponentsViewController.swift
+++ b/Demo/Application/Features/UIComponentsViewController.swift
@@ -114,7 +114,13 @@ private struct UIComponentsDemoView: View {
                     submit?()
                 }
                 .disabled(!isFormValid)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(isFormValid ? Color.black : Color.black.opacity(0.3))
+                .clipShape(Capsule())
+                .padding(.horizontal, 8)
 
                 // Venmo + PayPal buttons side by side
                 GeometryReader { geo in

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -13,6 +13,7 @@ struct CVVFieldView: View {
 
     @FocusState private var isFocused: Bool
     @State private var textFieldText: String = ""
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var popoverWidth: CGFloat {
         let preferred = containerWidth - CardFieldsConstants.popoverWidthPadding
@@ -20,14 +21,15 @@ struct CVVFieldView: View {
     }
 
     // NEXT_MAJOR_VERSION: remove this and always return $showCVVHint when minimum target moved to iOS 16.4 or higher
-    /// Returns the real binding on iOS 16.4+ and iPad where `.popover` works correctly.
-    /// On iPhone < iOS 16.4, `.popover` degrades to a full-screen sheet — suppress it here
-    /// so `CardFields` can show the custom floating hint card instead.
+    /// Returns the real binding on iOS 16.4+ and regular horizontal size class, where `.popover`
+    /// works correctly. On a compact size class (iPhone, or iPad in Slide Over / narrow Split
+    /// View), `.popover` degrades to a full-screen sheet pre-16.4 — suppress it here so
+    /// `CardFields` can show the custom floating hint card instead.
     private var nativeHintBinding: Binding<Bool> {
         if #available(iOS 16.4, *) {
             return $showCVVHint
         }
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        if horizontalSizeClass == .regular {
             return $showCVVHint
         }
         return .constant(false)

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -22,6 +22,7 @@ struct CVVFieldView: View {
     /// Returns the real binding on iOS 16.4+ and iPad where `.popover` works correctly.
     /// On iPhone < iOS 16.4, `.popover` degrades to a full-screen sheet — suppress it here
     /// so `CardFields` can show the custom floating hint card instead.
+    // NEXT_MAJOR_VERSION: remove this and always return $showCVVHint when minimum target moved to iOS 16.4 or higher
     private var nativeHintBinding: Binding<Bool> {
         if #available(iOS 16.4, *) {
             return $showCVVHint
@@ -131,6 +132,8 @@ private extension View {
     
     /// Applies `.presentationCompactAdaptation(.popover)` on iOS 16.4+, keeping the `.popover`
     /// modifier from degrading to a full-screen sheet on iPhone compact size class.
+    // NEXT_MAJOR_VERSION: remove this and call .presentationCompactAdaptation(.popover) directly
+    // when minimum target moved to iOS 16.4 or higher
     @ViewBuilder
     func presentationCompactAdaptationIfAvailable() -> some View {
         if #available(iOS 16.4, *) {

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -5,18 +5,31 @@ struct CVVFieldView: View {
     // MARK: - Internal Properties
 
     @ObservedObject var viewModel: CVVFieldViewModel
+    @Binding var showCVVHint: Bool
     var containerWidth: CGFloat = CardFieldsConstants.defaultContainerWidth
     var onAutoAdvance: (() -> Void)?
 
     // MARK: - Private Properties
 
     @FocusState private var isFocused: Bool
-    @State private var showCVVHint: Bool = false
     @State private var textFieldText: String = ""
 
     private var popoverWidth: CGFloat {
         let preferred = containerWidth - CardFieldsConstants.popoverWidthPadding
         return min(max(CardFieldsConstants.popoverMinWidth, preferred), CardFieldsConstants.popoverMaxWidth)
+    }
+
+    /// Returns the real binding on iOS 16.4+ and iPad where `.popover` works correctly.
+    /// On iPhone < iOS 16.4, `.popover` degrades to a full-screen sheet — suppress it here
+    /// so `CardFields` can show the custom floating hint card instead.
+    private var nativeHintBinding: Binding<Bool> {
+        if #available(iOS 16.4, *) {
+            return $showCVVHint
+        }
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return $showCVVHint
+        }
+        return .constant(false)
     }
 
     // MARK: - View
@@ -40,7 +53,7 @@ struct CVVFieldView: View {
                     .font(.system(size: 16))
                     .accessibilityLabel("CVV")
                     .accessibilityHint("3 or 4-digit security code")
-                    .onChange(of: textFieldText) { _, newValue in
+                    .onChange(of: textFieldText) { newValue in
                         let digits = String(newValue.filter { $0.isNumber }.prefix(viewModel.maxLength))
                         if digits != textFieldText {
                             textFieldText = digits
@@ -78,7 +91,7 @@ struct CVVFieldView: View {
             }
             .accessibilityLabel("CVV help")
             .accessibilityHint("Tap for information about where to find your CVV")
-            .popover(isPresented: $showCVVHint, arrowEdge: .bottom) {
+            .popover(isPresented: nativeHintBinding, arrowEdge: .bottom) {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("CVV")
                         .font(.system(size: 16, weight: .semibold))
@@ -93,16 +106,16 @@ struct CVVFieldView: View {
                 .padding(CardFieldsConstants.popoverPadding)
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("CVV help information")
-                .presentationCompactAdaptation(.popover)
+                .presentationCompactAdaptationIfAvailable()
             }
         }
-        .onChange(of: isFocused) { _, focused in
+        .onChange(of: isFocused) { focused in
             viewModel.isFocused = focused
         }
-        .onChange(of: viewModel.shouldAutoAdvance) { _, shouldAdvance in
+        .onChange(of: viewModel.shouldAutoAdvance) { shouldAdvance in
             if shouldAdvance { onAutoAdvance?() }
         }
-        .onChange(of: viewModel.isFocused) { _, focused in
+        .onChange(of: viewModel.isFocused) { focused in
             if focused { isFocused = true }
         }
         .contentShape(Rectangle())
@@ -112,7 +125,30 @@ struct CVVFieldView: View {
     }
 }
 
+// MARK: - Private Extensions
+
+private extension View {
+    
+    /// Applies `.presentationCompactAdaptation(.popover)` on iOS 16.4+, keeping the `.popover`
+    /// modifier from degrading to a full-screen sheet on iPhone compact size class.
+    @ViewBuilder
+    func presentationCompactAdaptationIfAvailable() -> some View {
+        if #available(iOS 16.4, *) {
+            self.presentationCompactAdaptation(.popover)
+        } else {
+            self
+        }
+    }
+}
+
 #Preview {
-    CVVFieldView(viewModel: CVVFieldViewModel())
-        .padding()
+    struct PreviewWrapper: View {
+        
+        @State private var showHint = false
+        var body: some View {
+            CVVFieldView(viewModel: CVVFieldViewModel(), showCVVHint: $showHint)
+                .padding()
+        }
+    }
+    return PreviewWrapper()
 }

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVFieldView.swift
@@ -19,10 +19,10 @@ struct CVVFieldView: View {
         return min(max(CardFieldsConstants.popoverMinWidth, preferred), CardFieldsConstants.popoverMaxWidth)
     }
 
+    // NEXT_MAJOR_VERSION: remove this and always return $showCVVHint when minimum target moved to iOS 16.4 or higher
     /// Returns the real binding on iOS 16.4+ and iPad where `.popover` works correctly.
     /// On iPhone < iOS 16.4, `.popover` degrades to a full-screen sheet — suppress it here
     /// so `CardFields` can show the custom floating hint card instead.
-    // NEXT_MAJOR_VERSION: remove this and always return $showCVVHint when minimum target moved to iOS 16.4 or higher
     private var nativeHintBinding: Binding<Bool> {
         if #available(iOS 16.4, *) {
             return $showCVVHint
@@ -130,10 +130,10 @@ struct CVVFieldView: View {
 
 private extension View {
     
-    /// Applies `.presentationCompactAdaptation(.popover)` on iOS 16.4+, keeping the `.popover`
-    /// modifier from degrading to a full-screen sheet on iPhone compact size class.
     // NEXT_MAJOR_VERSION: remove this and call .presentationCompactAdaptation(.popover) directly
     // when minimum target moved to iOS 16.4 or higher
+    /// Applies `.presentationCompactAdaptation(.popover)` on iOS 16.4+, keeping the `.popover`
+    /// modifier from degrading to a full-screen sheet on iPhone compact size class.
     @ViewBuilder
     func presentationCompactAdaptationIfAvailable() -> some View {
         if #available(iOS 16.4, *) {

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Floating hint card shown on iPhone iOS 16.0–16.3 as a replacement for the native `.popover`,
+/// which degrades to a full-screen sheet on those OS versions.
+struct CVVHintCard: View {
+
+    let width: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("CVV")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(Color(.label))
+
+            Text("The CVV is the 3 or 4-digit number on the back of your card")
+                .font(.system(size: 14))
+                .foregroundColor(Color(.secondaryLabel))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(width: width)
+        .padding(CardFieldsConstants.popoverPadding)
+        .background(
+            RoundedRectangle(cornerRadius: CardFieldsConstants.cornerRadius)
+                .fill(Color(.systemBackground))
+                .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: -4)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("CVV help information")
+    }
+}

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
+// NEXT_MAJOR_VERSION: delete this file when minimum target moved to iOS 16.4 or higher
 /// Floating hint card shown on iPhone iOS 16.0–16.3 as a replacement for the native `.popover`,
 /// which degrades to a full-screen sheet on those OS versions.
-// NEXT_MAJOR_VERSION: delete this file when minimum target moved to iOS 16.4 or higher
 struct CVVHintCard: View {
 
     let width: CGFloat

--- a/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CVVField/CVVHintCard.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Floating hint card shown on iPhone iOS 16.0–16.3 as a replacement for the native `.popover`,
 /// which degrades to a full-screen sheet on those OS versions.
+// NEXT_MAJOR_VERSION: delete this file when minimum target moved to iOS 16.4 or higher
 struct CVVHintCard: View {
 
     let width: CGFloat

--- a/Sources/BraintreeUIComponents/CardFields/CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFields.swift
@@ -12,19 +12,19 @@ public struct CardFields: View {
     @StateObject private var viewModel: CardFieldsViewModel
     @State private var containerWidth: CGFloat = CardFieldsConstants.defaultContainerWidth
     @State private var showCVVHint = false
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private var onValidityChange: ((Bool, @escaping () -> Void) -> Void)?
     private var apiClient: BTAPIClient
 
     // NEXT_MAJOR_VERSION: remove useCustomHint, showCVVHint overlay, and CVVHintCard entirely
     // when minimum target moved to iOS 16.4 or higher — the native popover will always be used
-    /// True on iPhone running iOS 16.0–16.3, where `.popover` without
-    /// `.presentationCompactAdaptation` degrades to a full-screen sheet.
-    /// On those devices `CVVFieldView` suppresses the native popover and this view shows
-    /// a custom floating hint card instead.
+    /// True below iOS 16.4 on a compact horizontal size class (iPhone, or iPad in Slide Over /
+    /// narrow Split View), where `.popover` without `.presentationCompactAdaptation` degrades to
+    /// a full-screen sheet. On those layouts `CVVFieldView` suppresses the native popover and
+    /// this view shows a custom floating hint card instead.
     private var useCustomHint: Bool {
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         if #available(iOS 16.4, *) { return false }
-        return true
+        return horizontalSizeClass == .compact
     }
 
     private var cvvPopoverWidth: CGFloat {

--- a/Sources/BraintreeUIComponents/CardFields/CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFields.swift
@@ -11,8 +11,24 @@ public struct CardFields: View {
 
     @StateObject private var viewModel: CardFieldsViewModel
     @State private var containerWidth: CGFloat = CardFieldsConstants.defaultContainerWidth
+    @State private var showCVVHint = false
     private var onValidityChange: ((Bool, @escaping () -> Void) -> Void)?
     private var apiClient: BTAPIClient
+
+    /// True on iPhone running iOS 16.0–16.3, where `.popover` without
+    /// `.presentationCompactAdaptation` degrades to a full-screen sheet.
+    /// On those devices `CVVFieldView` suppresses the native popover and this view shows
+    /// a custom floating hint card instead.
+    private var useCustomHint: Bool {
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
+        if #available(iOS 16.4, *) { return false }
+        return true
+    }
+
+    private var cvvPopoverWidth: CGFloat {
+        let preferred = containerWidth - CardFieldsConstants.popoverWidthPadding
+        return min(max(CardFieldsConstants.popoverMinWidth, preferred), CardFieldsConstants.popoverMaxWidth)
+    }
 
     private var useHorizontalLayout: Bool {
         containerWidth >= CardFieldsConstants.horizontalLayoutThreshold
@@ -25,7 +41,7 @@ public struct CardFields: View {
     }
 
     private var cvvField: some View {
-        CVVFieldView(viewModel: viewModel.cvvViewModel, containerWidth: containerWidth)
+        CVVFieldView(viewModel: viewModel.cvvViewModel, showCVVHint: $showCVVHint, containerWidth: containerWidth)
     }
 
     // MARK: - Initializer
@@ -64,43 +80,61 @@ public struct CardFields: View {
     }
 
     public var body: some View {
-        VStack(spacing: 12) {
-            CardNumberFieldView(
-                viewModel: viewModel.cardNumberViewModel,
-                onAutoAdvance: {
-                    viewModel.expirationDateViewModel.isFocused = true
-                },
-                onBrandChanged: { brand in
-                    let length: Int? = brand == .unknown ? nil : brand.cvvLength
-                    viewModel.cvvViewModel.updateExpectedLength(length)
+        ZStack {
+            VStack(spacing: 12) {
+                CardNumberFieldView(
+                    viewModel: viewModel.cardNumberViewModel,
+                    onAutoAdvance: {
+                        viewModel.expirationDateViewModel.isFocused = true
+                    },
+                    onBrandChanged: { brand in
+                        let length: Int? = brand == .unknown ? nil : brand.cvvLength
+                        viewModel.cvvViewModel.updateExpectedLength(length)
+                    }
+                )
+
+                if useHorizontalLayout {
+                    HStack(alignment: .top, spacing: CardFieldsConstants.fieldSpacing) {
+                        expirationField
+                        cvvField
+                    }
+                } else {
+                    VStack(spacing: CardFieldsConstants.fieldSpacing) {
+                        expirationField
+                        cvvField
+                    }
+                }
+            }
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { containerWidth = geo.size.width }
+                        .onChange(of: geo.size.width) { newWidth in containerWidth = newWidth }
                 }
             )
+            .onAppear {
+                apiClient.sendAnalyticsEvent(UIComponentsAnalytics.cardFieldsPresented)
+                onValidityChange?(viewModel.isFormValid, submitAction)
+            }
+            .onReceive(viewModel.formValidityPublisher) { isValid in
+                onValidityChange?(isValid, submitAction)
+            }
 
-            if useHorizontalLayout {
-                HStack(alignment: .top, spacing: CardFieldsConstants.fieldSpacing) {
-                    expirationField
-                    cvvField
-                }
-            } else {
-                VStack(spacing: CardFieldsConstants.fieldSpacing) {
-                    expirationField
-                    cvvField
-                }
-            }
-        }
-        .background(
-            GeometryReader { geo in
+            // Custom CVV hint card for iPhone running iOS 16.0–16.3.
+            // On those versions `.popover` degrades to a sheet, so we render our own
+            // floating card anchored above the CVV field's help button.
+            if showCVVHint && useCustomHint {
                 Color.clear
-                    .onAppear { containerWidth = geo.size.width }
-                    .onChange(of: geo.size.width) { _, newWidth in containerWidth = newWidth }
+                    .contentShape(Rectangle())
+                    .onTapGesture { showCVVHint = false }
+
+                CVVHintCard(width: cvvPopoverWidth)
+                    .padding(
+                        .bottom,
+                        CardFieldsConstants.cardFieldHeight + CardFieldsConstants.fieldSpacing
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
-        )
-        .onAppear {
-            apiClient.sendAnalyticsEvent(UIComponentsAnalytics.cardFieldsPresented)
-            onValidityChange?(viewModel.isFormValid, submitAction)
-        }
-        .onReceive(viewModel.formValidityPublisher) { isValid in
-            onValidityChange?(isValid, submitAction)
         }
     }
 
@@ -122,29 +156,35 @@ public struct CardFields: View {
 }
 
 #Preview {
-    @Previewable @State var isValid = false
-    @Previewable @State var submit: (() -> Void)?
+    struct PreviewWrapper: View {
+        
+        @State private var isValid = false
+        @State private var submit: (() -> Void)?
 
-    VStack {
-        CardFields(
-            authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn",
-            card: BTCard()
-        ) { nonce, error in
-            if let nonce {
-                print("Tokenization succeeded: \(nonce.nonce)")
-            } else if let error {
-                print("Tokenization failed: \(error.localizedDescription)")
+        var body: some View {
+            VStack {
+                CardFields(
+                    authorization: "sandbox_9dbg82cq_dcpspy2brwdjr3qn",
+                    card: BTCard()
+                ) { nonce, error in
+                    if let nonce {
+                        print("Tokenization succeeded: \(nonce.nonce)")
+                    } else if let error {
+                        print("Tokenization failed: \(error.localizedDescription)")
+                    }
+                }
+                .onValidityChange { valid, tokenize in
+                    isValid = valid
+                    submit = tokenize
+                }
+
+                Button("Pay") {
+                    submit?()
+                }
+                .disabled(!isValid)
+                .padding()
             }
         }
-        .onValidityChange { valid, tokenize in
-            isValid = valid
-            submit = tokenize
-        }
-
-        Button("Pay") {
-            submit?()
-        }
-        .disabled(!isValid)
-        .padding()
     }
+    return PreviewWrapper()
 }

--- a/Sources/BraintreeUIComponents/CardFields/CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFields.swift
@@ -19,6 +19,8 @@ public struct CardFields: View {
     /// `.presentationCompactAdaptation` degrades to a full-screen sheet.
     /// On those devices `CVVFieldView` suppresses the native popover and this view shows
     /// a custom floating hint card instead.
+    // NEXT_MAJOR_VERSION: remove useCustomHint, showCVVHint overlay, and CVVHintCard entirely
+    // when minimum target moved to iOS 16.4 or higher — the native popover will always be used
     private var useCustomHint: Bool {
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         if #available(iOS 16.4, *) { return false }
@@ -123,6 +125,7 @@ public struct CardFields: View {
             // Custom CVV hint card for iPhone running iOS 16.0–16.3.
             // On those versions `.popover` degrades to a sheet, so we render our own
             // floating card anchored above the CVV field's help button.
+            // NEXT_MAJOR_VERSION: remove this block when minimum target moved to iOS 16.4 or higher
             if showCVVHint && useCustomHint {
                 Color.clear
                     .contentShape(Rectangle())

--- a/Sources/BraintreeUIComponents/CardFields/CardFields.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardFields.swift
@@ -15,12 +15,12 @@ public struct CardFields: View {
     private var onValidityChange: ((Bool, @escaping () -> Void) -> Void)?
     private var apiClient: BTAPIClient
 
+    // NEXT_MAJOR_VERSION: remove useCustomHint, showCVVHint overlay, and CVVHintCard entirely
+    // when minimum target moved to iOS 16.4 or higher — the native popover will always be used
     /// True on iPhone running iOS 16.0–16.3, where `.popover` without
     /// `.presentationCompactAdaptation` degrades to a full-screen sheet.
     /// On those devices `CVVFieldView` suppresses the native popover and this view shows
     /// a custom floating hint card instead.
-    // NEXT_MAJOR_VERSION: remove useCustomHint, showCVVHint overlay, and CVVHintCard entirely
-    // when minimum target moved to iOS 16.4 or higher — the native popover will always be used
     private var useCustomHint: Bool {
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         if #available(iOS 16.4, *) { return false }

--- a/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/CardNumberField/CardNumberFieldView.swift
@@ -26,7 +26,7 @@ struct CardNumberFieldView: View {
                     .font(.system(size: 16))
                     .foregroundColor(Color(.label))
                     .accessibilityLabel("Card Number")
-                    .onChange(of: textFieldText) { _, newValue in
+                    .onChange(of: textFieldText) { newValue in
                         let digits = String(newValue.filter { $0.isNumber }.prefix(viewModel.maxLength))
                         let formatted = viewModel.formatted(digits: digits)
                         if formatted != textFieldText {
@@ -45,7 +45,7 @@ struct CardNumberFieldView: View {
         .onChange(of: viewModel.shouldAutoAdvance) { shouldAdvance in
             if shouldAdvance { onAutoAdvance?() }
         }
-        .onChange(of: viewModel.cardBrand) { _, brand in
+        .onChange(of: viewModel.cardBrand) { brand in
             onBrandChanged(brand)
         }
     }

--- a/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldView.swift
+++ b/Sources/BraintreeUIComponents/CardFields/ExpirationDateField/ExpirationDateFieldView.swift
@@ -29,7 +29,7 @@ struct ExpirationDateFieldView: View {
                     .foregroundColor(Color(.label))
                     .accessibilityLabel("Expiration Date")
                     .accessibilityHint("Enter in MM/YY format")
-                    .onChange(of: textFieldText) { _, newValue in
+                    .onChange(of: textFieldText) { newValue in
                         var digits = String(newValue.filter { $0.isNumber }.prefix(viewModel.maxLength))
                         if digits.count == 1, let digit = digits.first?.wholeNumberValue, digit >= 2 {
                             digits = "0\(digits)"
@@ -46,13 +46,13 @@ struct ExpirationDateFieldView: View {
 
             Spacer()
         }
-        .onChange(of: isFocused) { _, focused in
+        .onChange(of: isFocused) { focused in
             viewModel.isFocused = focused
         }
-        .onChange(of: viewModel.shouldAutoAdvance) { _, shouldAutoAdvance in
+        .onChange(of: viewModel.shouldAutoAdvance) { shouldAutoAdvance in
             if shouldAutoAdvance { onAutoAdvance?() }
         }
-        .onChange(of: viewModel.isFocused) { _, focused in
+        .onChange(of: viewModel.isFocused) { focused in
             if focused { isFocused = true }
         }
     }

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
@@ -25,5 +25,6 @@ enum CardFieldsConstants {
 
     /// Approximate rendered height of a single card field (label + input + vertical padding).
     /// Used to position the custom CVV hint card above the CVV field on iOS < 16.4.
+    // NEXT_MAJOR_VERSION: remove when minimum target moved to iOS 16.4 or higher and CVVHintCard is deleted
     static let cardFieldHeight: CGFloat = 66
 }

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
@@ -20,4 +20,10 @@ enum CardFieldsConstants {
     static let popoverMaxWidth: CGFloat = 300
     static let popoverWidthPadding: CGFloat = 32
     static let popoverPadding: CGFloat = 16
+
+    // MARK: - Card Field Height
+
+    /// Approximate rendered height of a single card field (label + input + vertical padding).
+    /// Used to position the custom CVV hint card above the CVV field on iOS < 16.4.
+    static let cardFieldHeight: CGFloat = 66
 }

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
@@ -27,4 +27,8 @@ enum CardFieldsConstants {
     /// Approximate rendered height of a single card field (label + input + vertical padding).
     /// Used to position the custom CVV hint card above the CVV field on iOS < 16.4.
     static let cardFieldHeight: CGFloat = 66
+    
+    // MARK: - Text Values
+    
+    static let cvvHintText: String = "The CVV is the 3 or 4-digit number on the back of your card"
 }

--- a/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
+++ b/Sources/BraintreeUIComponents/CardFields/Shared/CardFieldsConstants.swift
@@ -23,8 +23,8 @@ enum CardFieldsConstants {
 
     // MARK: - Card Field Height
 
+    // NEXT_MAJOR_VERSION: remove when minimum target moved to iOS 16.4 or higher and CVVHintCard is deleted
     /// Approximate rendered height of a single card field (label + input + vertical padding).
     /// Used to position the custom CVV hint card above the CVV field on iOS < 16.4.
-    // NEXT_MAJOR_VERSION: remove when minimum target moved to iOS 16.4 or higher and CVVHintCard is deleted
     static let cardFieldHeight: CGFloat = 66
 }


### PR DESCRIPTION
### Summary of changes
- Corrects UIComponents minimum iOS version to 16.0 to match rest of SDK
- Fixes popover code for iOS versions 16.0-16.3 to use custom popover view. iPadOS and iOS 16.4 and above will use existing popover
- unrelated, but cleaned up the Demo view CardFields button to look better

26.2 iOS example:
<img width="482" height="1049" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-06 at 15 21 53" src="https://github.com/user-attachments/assets/3a0d40cd-4d73-47ac-acdb-a3b59741f17d" />

iOS 16.1 example:
<img width="468" height="1013" alt="Simulator Screenshot - iphone160 - 2026-07-06 at 15 22 56" src="https://github.com/user-attachments/assets/5a487585-ab73-439a-86be-efac9d1d55a1" />


### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to create custom popover view logic and explore best way to switch between 16.4+ and pre-16.4 code.

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 