### PR TITLE
OPEN DEV: convert SEPA Direct Debit demo to SwiftUI view

### DIFF
--- a/Demo/Application/Base/UIViewController+Embed.swift
+++ b/Demo/Application/Base/UIViewController+Embed.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import UIKit
+
+extension UIViewController {
+
+    /// Embeds a SwiftUI view as a child view controller, pinned to the safe area.
+    func embed(_ swiftUIView: some View) {
+        let hostingController = UIHostingController(rootView: swiftUIView)
+        addChild(hostingController)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingController.view)
+
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        hostingController.didMove(toParent: self)
+    }
+}

--- a/Demo/Application/Features/SEPADirectDebitView.swift
+++ b/Demo/Application/Features/SEPADirectDebitView.swift
@@ -1,11 +1,3 @@
-//
-//  SEPADirectDebitView.swift
-//  Demo
-//
-//  Created by Brent Busby on 7/10/26.
-//  Copyright © 2026 braintree. All rights reserved.
-//
-
 import SwiftUI
 import AuthenticationServices
 import BraintreeCore
@@ -30,7 +22,11 @@ struct SEPADirectDebitView: View {
 
     var body: some View {
         VStack {
-            Button(action: requestTokenization) {
+            Button {
+                Task {
+                    await requestTokenization()
+                }
+            } label: {
                 Text("SEPA Direct Debit")
                     .frame(maxWidth: .infinity)
             }
@@ -41,7 +37,7 @@ struct SEPADirectDebitView: View {
         }
     }
 
-    private func requestTokenization() {
+    private func requestTokenization() async {
         onProgress("Tapped SEPA Direct Debit")
 
         let billingAddress = BTPostalAddress(
@@ -62,15 +58,14 @@ struct SEPADirectDebitView: View {
             merchantAccountID: "EUR-sepa-direct-debit"
         )
 
-        sepaDirectDebitClient.tokenize(sepaDirectDebitRequest) { sepaDirectDebitNonce, error in
-            if let sepaDirectDebitNonce {
-                onComplete(sepaDirectDebitNonce)
-            } else if let error {
-                if error as? BTSEPADirectDebitError == .webFlowCanceled {
-                    onProgress("Canceled")
-                } else {
-                    onProgress(error.localizedDescription)
-                }
+        do {
+            let sepaDirectDebitNonce = try await sepaDirectDebitClient.tokenize(sepaDirectDebitRequest)
+            onComplete(sepaDirectDebitNonce)
+        } catch {
+            if error as? BTSEPADirectDebitError == .webFlowCanceled {
+                onProgress("Canceled")
+            } else {
+                onProgress(error.localizedDescription)
             }
         }
     }

--- a/Demo/Application/Features/SEPADirectDebitView.swift
+++ b/Demo/Application/Features/SEPADirectDebitView.swift
@@ -1,0 +1,85 @@
+//
+//  SEPADirectDebitView.swift
+//  Demo
+//
+//  Created by Brent Busby on 7/10/26.
+//  Copyright © 2026 braintree. All rights reserved.
+//
+
+import SwiftUI
+import AuthenticationServices
+import BraintreeCore
+import BraintreeSEPADirectDebit
+
+struct SEPADirectDebitView: View {
+
+    let sepaDirectDebitClient: BTSEPADirectDebitClient
+    let onProgress: (String?) -> Void
+    let onComplete: (BTPaymentMethodNonce?) -> Void
+
+    init(
+        authorization: String,
+        onProgress: @escaping (String?) -> Void = { _ in },
+        onComplete: @escaping (BTPaymentMethodNonce?) -> Void = { _ in }
+    ) {
+        self.sepaDirectDebitClient = BTSEPADirectDebitClient(authorization: authorization)
+        self.onProgress = onProgress
+        self.onComplete = onComplete
+    }
+
+
+    var body: some View {
+        VStack {
+            Button(action: requestTokenization) {
+                Text("SEPA Direct Debit")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .controlSize(.large)
+            .padding(.horizontal)
+        }
+    }
+
+    private func requestTokenization() {
+        onProgress("Tapped SEPA Direct Debit")
+
+        let billingAddress = BTPostalAddress(
+            streetAddress: "Kantstraße 70",
+            extendedAddress: "#170",
+            locality: "Freistaat Sachsen",
+            countryCodeAlpha2: "FR",
+            postalCode: "09456",
+            region: "Annaberg-buchholz"
+        )
+
+        let sepaDirectDebitRequest = BTSEPADirectDebitRequest(
+            accountHolderName: "John Doe",
+            iban: BTSEPADirectDebitTestHelper.generateValidSandboxIBAN(),
+            customerID: generateRandomCustomerID(),
+            billingAddress: billingAddress,
+            mandateType: .oneOff,
+            merchantAccountID: "EUR-sepa-direct-debit"
+        )
+
+        sepaDirectDebitClient.tokenize(sepaDirectDebitRequest) { sepaDirectDebitNonce, error in
+            if let sepaDirectDebitNonce {
+                onComplete(sepaDirectDebitNonce)
+            } else if let error {
+                if error as? BTSEPADirectDebitError == .webFlowCanceled {
+                    onProgress("Canceled")
+                } else {
+                    onProgress(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func generateRandomCustomerID() -> String {
+        String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(20))
+    }
+}
+
+#Preview {
+    SEPADirectDebitView(authorization: "")
+}

--- a/Demo/Application/Features/SEPADirectDebitView.swift
+++ b/Demo/Application/Features/SEPADirectDebitView.swift
@@ -10,11 +10,11 @@ struct SEPADirectDebitView: View {
     let onComplete: (BTPaymentMethodNonce?) -> Void
 
     init(
-        authorization: String,
+        client: BTSEPADirectDebitClient,
         onProgress: @escaping (String?) -> Void = { _ in },
         onComplete: @escaping (BTPaymentMethodNonce?) -> Void = { _ in }
     ) {
-        self.sepaDirectDebitClient = BTSEPADirectDebitClient(authorization: authorization)
+        self.sepaDirectDebitClient = client
         self.onProgress = onProgress
         self.onComplete = onComplete
     }
@@ -76,5 +76,5 @@ struct SEPADirectDebitView: View {
 }
 
 #Preview {
-    SEPADirectDebitView(authorization: "")
+    SEPADirectDebitView(client: BTSEPADirectDebitClient(authorization: ""))
 }

--- a/Demo/Application/Features/SEPADirectDebitViewController.swift
+++ b/Demo/Application/Features/SEPADirectDebitViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SwiftUI
 import AuthenticationServices
 import BraintreeCore
 import BraintreeSEPADirectDebit
@@ -11,27 +10,16 @@ class SEPADirectDebitViewController: PaymentButtonBaseViewController {
         title = "SEPA Direct Debit"
 
         let demoView = SEPADirectDebitView(
-            authorization: authorization,
+            client: BTSEPADirectDebitClient(authorization: authorization),
             onProgress: progressBlock,
             onComplete: completionBlock
         )
 
-        let hostingController = UIHostingController(rootView: demoView)
-        addChild(hostingController)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(hostingController.view)
-
-        NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        ])
-
-        hostingController.didMove(toParent: self)
+        embed(demoView)
     }
 
-    // This is to supress Constraint warnings when the payment button is not overriden. The actual Payment Button is within the SwiftUI view
+    // TODO: Remove or change createPaymentButton during full SwiftUI migration
+    // This is to suppress Constraint warnings when the payment button is not overriden. The actual Payment Button is within the SwiftUI view
     override func createPaymentButton() -> UIView {
         let placeholderView = UIView()
         placeholderView.translatesAutoresizingMaskIntoConstraints = false

--- a/Demo/Application/Features/SEPADirectDebitViewController.swift
+++ b/Demo/Application/Features/SEPADirectDebitViewController.swift
@@ -1,59 +1,40 @@
 import UIKit
+import SwiftUI
 import AuthenticationServices
 import BraintreeCore
 import BraintreeSEPADirectDebit
 
 class SEPADirectDebitViewController: PaymentButtonBaseViewController {
 
-    lazy var sepaDirectDebitClient = BTSEPADirectDebitClient(authorization: authorization)
-
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "SEPA Direct Debit"
+
+        let demoView = SEPADirectDebitView(
+            authorization: authorization,
+            onProgress: progressBlock,
+            onComplete: completionBlock
+        )
+
+        let hostingController = UIHostingController(rootView: demoView)
+        addChild(hostingController)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingController.view)
+
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        hostingController.didMove(toParent: self)
     }
 
+    // This is to supress Constraint warnings when the payment button is not overriden. The actual Payment Button is within the SwiftUI view
     override func createPaymentButton() -> UIView {
-        let sepaDirectDebitButton = createButton(title: "SEPA Direct Debit", action: #selector(sepaDirectDebitButtonTapped))
-        return sepaDirectDebitButton
-    }
-
-    // MARK: - SEPA Direct Debit implementation
-    
-    @objc func sepaDirectDebitButtonTapped() {
-        self.progressBlock("Tapped SEPA Direct Debit")
-
-        let billingAddress = BTPostalAddress(
-            streetAddress: "Kantstraße 70",
-            extendedAddress: "#170",
-            locality: "Freistaat Sachsen",
-            countryCodeAlpha2: "FR",
-            postalCode: "09456",
-            region: "Annaberg-buchholz"
-        )
-
-        let sepaDirectDebitRequest = BTSEPADirectDebitRequest(
-            accountHolderName: "John Doe",
-            iban: BTSEPADirectDebitTestHelper.generateValidSandboxIBAN(),
-            customerID: generateRandomCustomerID(),
-            billingAddress: billingAddress,
-            mandateType: .oneOff,
-            merchantAccountID: "EUR-sepa-direct-debit"
-        )
-
-        sepaDirectDebitClient.tokenize(sepaDirectDebitRequest) { sepaDirectDebitNonce, error in
-            if let sepaDirectDebitNonce {
-                self.completionBlock(sepaDirectDebitNonce)
-            } else if let error {
-                if error as? BTSEPADirectDebitError == .webFlowCanceled {
-                    self.progressBlock("Canceled")
-                } else {
-                    self.progressBlock(error.localizedDescription)
-                }
-            }
-        }
-    }
-
-    private func generateRandomCustomerID() -> String {
-        String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(20))
+        let placeholderView = UIView()
+        placeholderView.translatesAutoresizingMaskIntoConstraints = false
+        return placeholderView
     }
 }

--- a/Demo/Application/Features/UIComponentsViewController.swift
+++ b/Demo/Application/Features/UIComponentsViewController.swift
@@ -18,19 +18,7 @@ class UIComponentsViewController: PaymentButtonBaseViewController {
             onComplete: { [weak self] nonce in self?.completionBlock(nonce) }
         )
 
-        let hostingController = UIHostingController(rootView: demoView)
-        addChild(hostingController)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(hostingController.view)
-
-        NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        ])
-
-        hostingController.didMove(toParent: self)
+        embed(demoView)
     }
 }
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		04DDF4622EE8AA1900FBDE49 /* PaymentButtonHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DDF4612EE8AA1200FBDE49 /* PaymentButtonHelper.swift */; };
 		08222B07C311489F90D08D41 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */; };
+		0827D165300131C100D26DC4 /* SEPADirectDebitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0827D164300131C100D26DC4 /* SEPADirectDebitView.swift */; };
 		084C2C6E2FD85A960018BB01 /* CardFields_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C2C6D2FD85A960018BB01 /* CardFields_UITests.swift */; };
 		086561662EF1D4EF00B16439 /* BraintreeUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */; };
 		086561672EF1D4EF00B16439 /* BraintreeUIComponents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -133,6 +134,7 @@
 
 /* Begin PBXFileReference section */
 		04DDF4612EE8AA1200FBDE49 /* PaymentButtonHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonHelper.swift; sourceTree = "<group>"; };
+		0827D164300131C100D26DC4 /* SEPADirectDebitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADirectDebitView.swift; sourceTree = "<group>"; };
 		084C2C6D2FD85A960018BB01 /* CardFields_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFields_UITests.swift; sourceTree = "<group>"; };
 		08A83F582EDE268E0076BD28 /* UIComponentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponentsViewController.swift; sourceTree = "<group>"; };
 		08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeUIComponents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -384,6 +386,7 @@
 				BE67CDBF2B29FF7B00BA4904 /* PayPalMessagingViewController.swift */,
 				BED7C4C92ABDD35700EF8550 /* PayPalWebCheckoutViewController.swift */,
 				BE777AC327D9370400487D23 /* SEPADirectDebitViewController.swift */,
+				0827D164300131C100D26DC4 /* SEPADirectDebitView.swift */,
 				8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */,
 				B88F9CCD2E2196530014BCB7 /* ShopperInsightsViewControllerV2.swift */,
 				BEBD52862AABA513005D6687 /* ThreeDSecureViewController.swift */,
@@ -725,6 +728,7 @@
 				BEBD52852AAB9649005D6687 /* AmexViewController.swift in Sources */,
 				809E86A82AD01FE7004998B0 /* SceneDelegate.swift in Sources */,
 				BEE9304B2A992F6200C85779 /* CardTokenizationViewController.swift in Sources */,
+				0827D165300131C100D26DC4 /* SEPADirectDebitView.swift in Sources */,
 				BED461832AD072D9001B0DDF /* CardHelpers.swift in Sources */,
 				BE994B0B2AD8377D00470773 /* BaseViewController.swift in Sources */,
 				08A83F592EDE268E0076BD28 /* UIComponentsViewController.swift in Sources */,

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		809E86A62AD00AF4004998B0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809E86A52AD00AF4004998B0 /* AppDelegate.swift */; };
 		809E86A82AD01FE7004998B0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809E86A72AD01FE7004998B0 /* SceneDelegate.swift */; };
 		80D36DEE2A7967F20035380E /* VenmoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D36DED2A7967F20035380E /* VenmoViewController.swift */; };
+		91E24EA930E1F3EFF3329A16 /* UIViewController+Embed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B20BE362F706797A0A110B0 /* UIViewController+Embed.swift */; };
 		9C36BD2926B3071B00F0A559 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD2826B3071A00F0A559 /* PPRiskMagnes.xcframework */; };
 		9C36BD4C26B311D900F0A559 /* CardinalMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; };
 		9C36BD4D26B311D900F0A559 /* CardinalMobile.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9C36BD4826B3102B00F0A559 /* CardinalMobile.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -157,6 +158,7 @@
 		62240F592B67FE1100ECE5C9 /* TextFieldWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldWithLabel.swift; sourceTree = "<group>"; };
 		6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73498B4265CA7D315E2FBF38 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		7B20BE362F706797A0A110B0 /* UIViewController+Embed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIViewController+Embed.swift"; sourceTree = "<group>"; };
 		8025988C2CC1A95400E7D898 /* Toggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toggle.swift; sourceTree = "<group>"; };
 		8028B9752B28C9E100C88CE8 /* ShopperInsightsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShopperInsightsViewController.swift; sourceTree = "<group>"; };
 		8028B9772B28D42400C88CE8 /* BraintreeShopperInsights.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeShopperInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -352,6 +354,7 @@
 				809E86A72AD01FE7004998B0 /* SceneDelegate.swift */,
 				A0988E8824DB44B10095EEEE /* Launch Screen.storyboard */,
 				A0988E7D24DB44B10095EEEE /* Settings */,
+				7B20BE362F706797A0A110B0 /* UIViewController+Embed.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -740,6 +743,7 @@
 				8025988D2CC1A95400E7D898 /* Toggle.swift in Sources */,
 				04DDF4622EE8AA1900FBDE49 /* PaymentButtonHelper.swift in Sources */,
 				A0988F9224DB44B20095EEEE /* BraintreeDemoSettings.swift in Sources */,
+				91E24EA930E1F3EFF3329A16 /* UIViewController+Embed.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Summary of changes
- Converted SEPA Direct Debit Demo to use a SwiftUI view as a sort of POC for slowly migrating all other views to SwiftUI. 

After diving into this view it has become clear this won't be a 1 part lift and shift, but instead will need to first have the SwiftUI views created and called in the view controller. A 2nd part will also need to be done where we eventually remove a lot of the shared logic housed in the Base view controller. 


https://github.com/user-attachments/assets/c763bab4-fe99-4826-b128-b3aaa536107f




### AI Usage

**Which AI Agent Was Used?**
- [x] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used for discovering what was causing the Constraints errors and develop a fix

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 