### PR TITLE
Feature/ paypal campaign create order

### DIFF
--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -1704,6 +1704,7 @@
 		45E8CE4A2D1F291400D7A2DC /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				13A9C0D02F11B65000A1B2C3 /* BTPayPalCampaign.swift */,
 				B8F483CE2D6F8A5F00214627 /* PayPalAccountPOSTEncodable.swift */,
 				45E8CE4B2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift */,
 				45E8CE4F2D2C772000D7A2DC /* PayPalExperienceProfilePOSTBody.swift */,
@@ -1745,7 +1746,6 @@
 				5708E0A728809BC6007946B9 /* BTJSONError.swift */,
 				570B93D82853C6180041BAFE /* BTLogLevel.swift */,
 				570B93D62853C29A0041BAFE /* BTLogLevelDescription.swift */,
-				13A9C0D02F11B65000A1B2C3 /* BTPayPalCampaign.swift */,
 				BE9FB82A2898324C00D6FE2F /* BTPaymentMethodNonce.swift */,
 				BE63A3A6288F3026001936DA /* BTPostalAddress.swift */,
 				BED7493528579BAC0074C818 /* BTURLUtils.swift */,
@@ -3722,6 +3722,7 @@
 				5754481E294A2A1D00DEB7B0 /* BTPayPalCreditFinancingAmount.swift in Sources */,
 				57D9436E2968A8080079EAB1 /* BTPayPalLocaleCode.swift in Sources */,
 				45E8CE4C2D1F29BA00D7A2DC /* PayPalCheckoutPOSTBody.swift in Sources */,
+				13A9C0D12F11B65000A1B2C3 /* BTPayPalCampaign.swift in Sources */,
 				57544F582952298900DEB7B0 /* BTPayPalAccountNonce.swift in Sources */,
 				451508362D400C050071E385 /* BTPayPalPaymentType.swift in Sources */,
 				8014221C2BAE935B009F9999 /* BTPayPalApprovalURLParser.swift in Sources */,
@@ -3754,7 +3755,6 @@
 				BC17F9BC28D24C9E004B18CC /* BTGraphQLErrorTree.swift in Sources */,
 				BEF1089129019DB9003B2FDA /* BTAPIClient.swift in Sources */,
 				BC17F9C028D255B9004B18CC /* BTGraphQLSingleErrorNode.swift in Sources */,
-				13A9C0D12F11B65000A1B2C3 /* BTPayPalCampaign.swift in Sources */,
 				BE5C8C0328A2C183004F9130 /* BTConfiguration+Core.swift in Sources */,
 				CE836AA02E4FDCE300AC7FCA /* UIApplication+ApplicationState.swift in Sources */,
 				BEE2E4E6290080BD00C03FDD /* BTAnalyticsServiceError.swift in Sources */,

--- a/Braintree.xcodeproj/project.pbxproj
+++ b/Braintree.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13A9C0D12F11B65000A1B2C3 /* BTPayPalCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A9C0D02F11B65000A1B2C3 /* BTPayPalCampaign.swift */; };
 		0426CADF2DBC3E4100210697 /* BTAmountBreakdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0426CADE2DBC3E3700210697 /* BTAmountBreakdown.swift */; };
 		045241242EBEBAC100C25EA6 /* BraintreeUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 045241192EBEBAC100C25EA6 /* BraintreeUIComponents.framework */; };
 		045241302EBEBAD200C25EA6 /* BraintreeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570B93AC285397520041BAFE /* BraintreeCore.framework */; platformFilter = ios; };
@@ -1122,6 +1123,7 @@
 		A9E5C22824FD6D0800EE691F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A9E80AA224FEF4D800196BD3 /* MockLocalPaymentRequestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalPaymentRequestDelegate.swift; sourceTree = "<group>"; };
 		B8447AC32E3BCFE700A1D6E6 /* BTGraphQLEncodableBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTGraphQLEncodableBody.swift; sourceTree = "<group>"; };
+		13A9C0D02F11B65000A1B2C3 /* BTPayPalCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTPayPalCampaign.swift; sourceTree = "<group>"; };
 		B87B26232D54176F0002225F /* ThreeDSecurePOSTBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecurePOSTBody.swift; sourceTree = "<group>"; };
 		B8A330FE2D83746D00BC18EC /* BTContactPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTContactPreference.swift; sourceTree = "<group>"; };
 		B8BA342D2D4811560030423C /* BTContactInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTContactInformation.swift; sourceTree = "<group>"; };
@@ -1743,6 +1745,7 @@
 				5708E0A728809BC6007946B9 /* BTJSONError.swift */,
 				570B93D82853C6180041BAFE /* BTLogLevel.swift */,
 				570B93D62853C29A0041BAFE /* BTLogLevelDescription.swift */,
+				13A9C0D02F11B65000A1B2C3 /* BTPayPalCampaign.swift */,
 				BE9FB82A2898324C00D6FE2F /* BTPaymentMethodNonce.swift */,
 				BE63A3A6288F3026001936DA /* BTPostalAddress.swift */,
 				BED7493528579BAC0074C818 /* BTURLUtils.swift */,
@@ -3751,6 +3754,7 @@
 				BC17F9BC28D24C9E004B18CC /* BTGraphQLErrorTree.swift in Sources */,
 				BEF1089129019DB9003B2FDA /* BTAPIClient.swift in Sources */,
 				BC17F9C028D255B9004B18CC /* BTGraphQLSingleErrorNode.swift in Sources */,
+				13A9C0D12F11B65000A1B2C3 /* BTPayPalCampaign.swift in Sources */,
 				BE5C8C0328A2C183004F9130 /* BTConfiguration+Core.swift in Sources */,
 				CE836AA02E4FDCE300AC7FCA /* UIApplication+ApplicationState.swift in Sources */,
 				BEE2E4E6290080BD00C03FDD /* BTAnalyticsServiceError.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Braintree iOS SDK Release Notes
 
 ## unreleased
+* BraintreePayPal
+  * Add `payPalCampaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests.
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPal
-  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them in PayPal checkout requests so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
+  * Add `campaigns` to `BTPayPalCheckoutRequest` so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPal
-  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
+  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them in PayPal checkout requests so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPal
-  * Add `payPalCampaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests.
+  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests.
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 * BraintreePayPal
-  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests.
+  * Add `campaigns` to `BTPayPalCheckoutRequest` and pass them as `paypal_campaigns` in PayPal checkout requests so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -6,7 +6,10 @@ class PaymentButtonBaseViewController: BaseViewController {
     let authorization: String
 
     var heightConstraint: CGFloat?
+    var usesIntrinsicContentHeight = false
 
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
     private var paymentButton = UIView()
 
     override init(authorization: String) {
@@ -25,14 +28,61 @@ class PaymentButtonBaseViewController: BaseViewController {
         view.backgroundColor = .systemBackground
 
         paymentButton = createPaymentButton()
-        view.addSubview(paymentButton)
+        paymentButton.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
-            paymentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            paymentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            paymentButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            paymentButton.heightAnchor.constraint(equalToConstant: heightConstraint ?? 100)
-        ])
+        scrollView.keyboardDismissMode = .interactive
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubview(paymentButton)
+
+        let contentViewEqualHeightConstraint = contentView.heightAnchor.constraint(
+            equalTo: scrollView.frameLayoutGuide.heightAnchor
+        )
+        contentViewEqualHeightConstraint.priority = .defaultLow
+
+        let paymentButtonTopConstraint = paymentButton.topAnchor.constraint(
+            equalTo: contentView.topAnchor,
+            constant: 20
+        )
+        paymentButtonTopConstraint.priority = .defaultHigh
+
+        let paymentButtonBottomConstraint = paymentButton.bottomAnchor.constraint(
+            equalTo: contentView.bottomAnchor,
+            constant: -20
+        )
+        paymentButtonBottomConstraint.priority = .defaultHigh
+
+        var constraints = [
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            contentView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.frameLayoutGuide.heightAnchor),
+            contentViewEqualHeightConstraint,
+
+            paymentButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            paymentButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            paymentButton.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 20),
+            paymentButton.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -20),
+            paymentButtonTopConstraint,
+            paymentButtonBottomConstraint,
+            paymentButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ]
+
+        if !usesIntrinsicContentHeight {
+            constraints.append(paymentButton.heightAnchor.constraint(equalToConstant: heightConstraint ?? 100))
+        }
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     /// A factory method that subclasses must implement to return a payment button view.

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -43,21 +43,23 @@ class PaymentButtonBaseViewController: BaseViewController {
         )
         contentViewEqualHeightConstraint.priority = .defaultLow
 
+        let contentInset: CGFloat = usesIntrinsicContentHeight ? 10 : 20
+
         let paymentButtonTopConstraint = paymentButton.topAnchor.constraint(
             equalTo: contentView.topAnchor,
-            constant: 20
+            constant: contentInset
         )
         paymentButtonTopConstraint.priority = .defaultHigh
 
         let paymentButtonBottomConstraint = paymentButton.bottomAnchor.constraint(
             equalTo: contentView.bottomAnchor,
-            constant: -20
+            constant: -contentInset
         )
         paymentButtonBottomConstraint.priority = .defaultHigh
 
         var constraints = [
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
 
@@ -71,15 +73,15 @@ class PaymentButtonBaseViewController: BaseViewController {
 
             paymentButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             paymentButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            paymentButton.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 20),
-            paymentButton.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -20),
+            paymentButton.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: contentInset),
+            paymentButton.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -contentInset),
             paymentButtonTopConstraint,
-            paymentButtonBottomConstraint,
-            paymentButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+            paymentButtonBottomConstraint
         ]
 
         if !usesIntrinsicContentHeight {
             constraints.append(paymentButton.heightAnchor.constraint(equalToConstant: heightConstraint ?? 100))
+            constraints.append(paymentButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor))
         }
 
         NSLayoutConstraint.activate(constraints)

--- a/Demo/Application/Base/PaymentButtonBaseViewController.swift
+++ b/Demo/Application/Base/PaymentButtonBaseViewController.swift
@@ -34,9 +34,9 @@ class PaymentButtonBaseViewController: BaseViewController {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.addSubview(scrollView)
-        scrollView.addSubview(contentView)
         contentView.addSubview(paymentButton)
+        scrollView.addSubview(contentView)
+        view.addSubview(scrollView)
 
         let contentViewEqualHeightConstraint = contentView.heightAnchor.constraint(
             equalTo: scrollView.frameLayoutGuide.heightAnchor

--- a/Demo/Application/Features/PayPalWebCheckoutViewController.swift
+++ b/Demo/Application/Features/PayPalWebCheckoutViewController.swift
@@ -74,6 +74,39 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         stackView.distribution = .fillEqually
         return stackView
     }()
+
+    lazy var payPalCampaignsLabel: UILabel = {
+        let label = UILabel()
+        label.text = "PayPal Campaigns:"
+        return label
+    }()
+
+    lazy var payPalCampaignsTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "campaign-123-id"
+        textField.textAlignment = .right
+        textField.backgroundColor = .systemBackground
+        return textField
+    }()
+
+    lazy var payPalCampaignsStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [payPalCampaignsLabel, payPalCampaignsTextField])
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+
+    lazy var customerInfoStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            emailStackView,
+            countryCodeStackView,
+            nationalNumberStackView,
+            payPalCampaignsStackView
+        ])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        return stackView
+    }()
     
     let rbaDataToggle = Toggle(title: "Recurring Billing (RBA) Data")
     let contactInformationToggle = Toggle(title: "Add Contact Information")
@@ -81,7 +114,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
     let requestBillingAgreementToggle = Toggle(title: "Request Billing Agreement")
 
     override func viewDidLoad() {
-        super.heightConstraint = 500
+        super.usesIntrinsicContentHeight = true
         super.viewDidLoad()
     }
 
@@ -129,9 +162,7 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
         vaultStackView.spacing = 12
 
         let stackView = UIStackView(arrangedSubviews: [
-            emailStackView,
-            countryCodeStackView,
-            nationalNumberStackView,
+            customerInfoStackView,
             oneTimeCheckoutStackView,
             vaultStackView
         ])
@@ -187,7 +218,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             userPhoneNumber: BTPayPalPhoneNumber(
                 countryCode: countryCodeTextField.text ?? "",
                 nationalNumber: nationalNumberTextField.text ?? ""
-            )
+            ),
+            campaigns: payPalCampaigns
         )
 
         if amountBreakdownToggle.isOn {
@@ -231,7 +263,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
                 merchantAccountID: "quantumleapsandboxtesting-1",
                 recurringBillingDetails: recurringBillingDetails,
                 recurringBillingPlanType: .subscription,
-                requestBillingAgreement: true
+                requestBillingAgreement: true,
+                campaigns: payPalCampaigns
             )
         }
 
@@ -315,7 +348,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             amount: amount,
             enablePayPalAppSwitch: true,
             userAuthenticationEmail: emailTextField.text,
-            userAction: .payNow
+            userAction: .payNow,
+            campaigns: payPalCampaigns
         )
 
         payPalClient.tokenize(request) { nonce, error in
@@ -339,7 +373,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             enablePayPalAppSwitch: true,
             userAuthenticationEmail: emailTextField.text,
             userAction: .payNow,
-            offerCredit: true
+            offerCredit: true,
+            campaigns: payPalCampaigns
         )
 
         payPalClient.tokenize(request) { nonce, error in
@@ -385,7 +420,8 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
             enablePayPalAppSwitch: true,
             userAuthenticationEmail: emailTextField.text,
             userAction: .payNow,
-            offerPayLater: true
+            offerPayLater: true,
+            campaigns: payPalCampaigns
         )
 
         payPalClient.tokenize(request) { nonce, error in
@@ -398,5 +434,13 @@ class PayPalWebCheckoutViewController: PaymentButtonBaseViewController {
 
             self.completionBlock(nonce)
         }
+    }
+
+    private var payPalCampaigns: [BTPayPalCampaign] {
+        payPalCampaignsTextField.text?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { BTPayPalCampaign(id: $0) } ?? []
     }
 }

--- a/Sources/BraintreeCore/BTPayPalCampaign.swift
+++ b/Sources/BraintreeCore/BTPayPalCampaign.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A PayPal campaign applied to a checkout transaction.
+@objcMembers public class BTPayPalCampaign: NSObject, Encodable {
+
+    // MARK: - Public Properties
+
+    public let id: String
+
+    // MARK: - Public Initializer
+
+    /// Initializes a PayPal campaign.
+    /// - Parameter id: The PayPal campaign ID.
+    public init(id: String) {
+        self.id = id
+    }
+}

--- a/Sources/BraintreeCore/BTPayPalCampaign.swift
+++ b/Sources/BraintreeCore/BTPayPalCampaign.swift
@@ -10,7 +10,7 @@ import Foundation
     // MARK: - Public Initializer
 
     /// Initializes a PayPal campaign.
-    /// - Parameter id: The PayPal campaign ID.
+    /// - Parameter id: Required. The PayPal campaign ID.
     public init(id: String) {
         self.id = id
     }

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -181,7 +181,7 @@ import BraintreeCore
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil,
         offerCredit: Bool = false,
-        campaigns: [BTPayPalCampaign] = []
+        campaigns: [BTPayPalCampaign]? = nil
     ) {
         self.amount = amount
         self.intent = intent
@@ -204,7 +204,7 @@ import BraintreeCore
         self.lineItems = lineItems
         self.localeCode = localeCode
         self.merchantAccountID = merchantAccountID
-        self.campaigns = campaigns
+        self.campaigns = campaigns ?? []
         self.recurringBillingDetails = recurringBillingDetails
         self.recurringBillingPlanType = recurringBillingPlanType
         self.requestBillingAgreement = requestBillingAgreement

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -59,7 +59,7 @@ import BraintreeCore
     var lineItems: [BTPayPalLineItem]?
     var localeCode: BTPayPalLocaleCode?
     var merchantAccountID: String?
-    var payPalCampaigns: [BTPayPalCampaign]
+    var campaigns: [BTPayPalCampaign]
     var recurringBillingDetails: BTPayPalRecurringBillingDetails?
     var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
     var requestBillingAgreement: Bool
@@ -128,7 +128,7 @@ import BraintreeCore
     ///   during checkout. Defaults to `false`.
     ///   - contactPreference: Optional: Preference for the contact information section within the payment flow. Defaults to `.none` if not set.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
-    ///   - payPalCampaigns: Optional: PayPal campaigns applied to the transaction.
+    ///   - campaigns: Optional: PayPal campaigns applied to the transaction.
     /// - Warning: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
     /// - Note: The PayPal App Switch flow currently only supports the production environment.
     public convenience init(
@@ -142,7 +142,7 @@ import BraintreeCore
         requestBillingAgreement: Bool = false,
         contactPreference: BTContactPreference = .none,
         offerCredit: Bool = false,
-        payPalCampaigns: [BTPayPalCampaign]
+        campaigns: [BTPayPalCampaign]
     ) {
         self.init(
             amount: amount,
@@ -155,7 +155,7 @@ import BraintreeCore
             requestBillingAgreement: requestBillingAgreement,
             userAuthenticationEmail: userAuthenticationEmail,
             offerCredit: offerCredit,
-            payPalCampaigns: payPalCampaigns
+            campaigns: campaigns
         )
     }
 
@@ -194,7 +194,7 @@ import BraintreeCore
     ///   - userPhoneNumber: Optional: A user's phone number to initiate a quicker authentication flow in the scenario where the user has a PayPal account
     ///   identified with the same phone number.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
-    ///   - payPalCampaigns: Optional: PayPal campaigns applied to the transaction.
+    ///   - campaigns: Optional: PayPal campaigns applied to the transaction.
     public init(
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
@@ -223,7 +223,7 @@ import BraintreeCore
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil,
         offerCredit: Bool = false,
-        payPalCampaigns: [BTPayPalCampaign] = []
+        campaigns: [BTPayPalCampaign] = []
     ) {
         self.amount = amount
         self.intent = intent
@@ -246,7 +246,7 @@ import BraintreeCore
         self.lineItems = lineItems
         self.localeCode = localeCode
         self.merchantAccountID = merchantAccountID
-        self.payPalCampaigns = payPalCampaigns
+        self.campaigns = campaigns
         self.recurringBillingDetails = recurringBillingDetails
         self.recurringBillingPlanType = recurringBillingPlanType
         self.requestBillingAgreement = requestBillingAgreement

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -59,7 +59,7 @@ import BraintreeCore
     var lineItems: [BTPayPalLineItem]?
     var localeCode: BTPayPalLocaleCode?
     var merchantAccountID: String?
-    var campaigns: [BTPayPalCampaign]
+    var campaigns: [BTPayPalCampaign]?
     var recurringBillingDetails: BTPayPalRecurringBillingDetails?
     var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
     var requestBillingAgreement: Bool
@@ -113,7 +113,7 @@ import BraintreeCore
             requestBillingAgreement: requestBillingAgreement,
             userAuthenticationEmail: userAuthenticationEmail,
             offerCredit: offerCredit,
-            campaigns: campaigns ?? []
+            campaigns: campaigns
         )
     }
 
@@ -204,7 +204,7 @@ import BraintreeCore
         self.lineItems = lineItems
         self.localeCode = localeCode
         self.merchantAccountID = merchantAccountID
-        self.campaigns = campaigns ?? []
+        self.campaigns = campaigns
         self.recurringBillingDetails = recurringBillingDetails
         self.recurringBillingPlanType = recurringBillingPlanType
         self.requestBillingAgreement = requestBillingAgreement

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -59,6 +59,7 @@ import BraintreeCore
     var lineItems: [BTPayPalLineItem]?
     var localeCode: BTPayPalLocaleCode?
     var merchantAccountID: String?
+    var payPalCampaigns: [BTPayPalCampaign]
     var recurringBillingDetails: BTPayPalRecurringBillingDetails?
     var recurringBillingPlanType: BTPayPalRecurringBillingPlanType?
     var requestBillingAgreement: Bool
@@ -113,6 +114,51 @@ import BraintreeCore
         )
     }
 
+    /// Initializes a PayPal Checkout request for the PayPal App Switch flow with PayPal campaigns.
+    /// - Parameters:
+    ///   - amount: Required: Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
+    ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
+    ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
+    ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
+    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.none`.
+    ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
+    ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
+    ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
+    ///   - requestBillingAgreement: Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement
+    ///   during checkout. Defaults to `false`.
+    ///   - contactPreference: Optional: Preference for the contact information section within the payment flow. Defaults to `.none` if not set.
+    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    ///   - payPalCampaigns: Optional: PayPal campaigns applied to the transaction.
+    /// - Warning: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
+    /// - Note: The PayPal App Switch flow currently only supports the production environment.
+    public convenience init(
+        amount: String,
+        enablePayPalAppSwitch: Bool,
+        userAuthenticationEmail: String? = nil,
+        intent: BTPayPalRequestIntent = .authorize,
+        userAction: BTPayPalRequestUserAction = .none,
+        offerPayLater: Bool = false,
+        currencyCode: String? = nil,
+        requestBillingAgreement: Bool = false,
+        contactPreference: BTContactPreference = .none,
+        offerCredit: Bool = false,
+        payPalCampaigns: [BTPayPalCampaign]
+    ) {
+        self.init(
+            amount: amount,
+            intent: intent,
+            userAction: userAction,
+            offerPayLater: offerPayLater,
+            contactPreference: contactPreference,
+            currencyCode: currencyCode,
+            enablePayPalAppSwitch: enablePayPalAppSwitch,
+            requestBillingAgreement: requestBillingAgreement,
+            userAuthenticationEmail: userAuthenticationEmail,
+            offerCredit: offerCredit,
+            payPalCampaigns: payPalCampaigns
+        )
+    }
+
     /// Initializes a PayPal Checkout request
     /// - Parameters:
     ///   - amount: Required. Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
@@ -148,6 +194,7 @@ import BraintreeCore
     ///   - userPhoneNumber: Optional: A user's phone number to initiate a quicker authentication flow in the scenario where the user has a PayPal account
     ///   identified with the same phone number.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
+    ///   - payPalCampaigns: Optional: PayPal campaigns applied to the transaction.
     public init(
         amount: String,
         intent: BTPayPalRequestIntent = .authorize,
@@ -175,7 +222,8 @@ import BraintreeCore
         shopperSessionID: String? = nil,
         userAuthenticationEmail: String? = nil,
         userPhoneNumber: BTPayPalPhoneNumber? = nil,
-        offerCredit: Bool = false
+        offerCredit: Bool = false,
+        payPalCampaigns: [BTPayPalCampaign] = []
     ) {
         self.amount = amount
         self.intent = intent
@@ -198,6 +246,7 @@ import BraintreeCore
         self.lineItems = lineItems
         self.localeCode = localeCode
         self.merchantAccountID = merchantAccountID
+        self.payPalCampaigns = payPalCampaigns
         self.recurringBillingDetails = recurringBillingDetails
         self.recurringBillingPlanType = recurringBillingPlanType
         self.requestBillingAgreement = requestBillingAgreement

--- a/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
+++ b/Sources/BraintreePayPal/BTPayPalCheckoutRequest.swift
@@ -86,48 +86,6 @@ import BraintreeCore
     ///   during checkout. Defaults to `false`.
     ///   - contactPreference: Optional: Preference for the contact information section within the payment flow. Defaults to `.none` if not set.
     ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
-    /// - Warning: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
-    /// - Note: The PayPal App Switch flow currently only supports the production environment.
-    public convenience init(
-        amount: String,
-        enablePayPalAppSwitch: Bool,
-        userAuthenticationEmail: String? = nil,
-        intent: BTPayPalRequestIntent = .authorize,
-        userAction: BTPayPalRequestUserAction = .none,
-        offerPayLater: Bool = false,
-        currencyCode: String? = nil,
-        requestBillingAgreement: Bool = false,
-        contactPreference: BTContactPreference = .none,
-        offerCredit: Bool = false
-    ) {
-        self.init(
-            amount: amount,
-            intent: intent,
-            userAction: userAction,
-            offerPayLater: offerPayLater,
-            contactPreference: contactPreference,
-            currencyCode: currencyCode,
-            enablePayPalAppSwitch: enablePayPalAppSwitch,
-            requestBillingAgreement: requestBillingAgreement,
-            userAuthenticationEmail: userAuthenticationEmail,
-            offerCredit: offerCredit
-        )
-    }
-
-    /// Initializes a PayPal Checkout request for the PayPal App Switch flow with PayPal campaigns.
-    /// - Parameters:
-    ///   - amount: Required: Used for a one-time payment. Amount must be greater than or equal to zero, may optionally contain exactly 2 decimal places separated by '.' and is limited to 7 digits before the decimal point.
-    ///   - enablePayPalAppSwitch: Required: Used to determine if the customer will use the PayPal app switch flow.
-    ///   - userAuthenticationEmail: Optional: User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
-    ///   - intent: Optional: Payment intent. Defaults to `.authorize`. Only applies to PayPal Checkout.
-    ///   - userAction: Optional: Changes the call-to-action in the PayPal Checkout flow. Defaults to `.none`.
-    ///   - offerPayLater: Optional: Offers PayPal Pay Later if the customer qualifies. Defaults to `false`. Only available with PayPal Checkout.
-    ///   - currencyCode: Optional: A three-character ISO-4217 ISO currency code to use for the transaction. Defaults to merchant currency code if not set.
-    ///   See https://developer.paypal.com/docs/api/reference/currency-codes/ for a list of supported currency codes.
-    ///   - requestBillingAgreement: Optional: If set to `true`, this enables the Checkout with Vault flow, where the customer will be prompted to consent to a billing agreement
-    ///   during checkout. Defaults to `false`.
-    ///   - contactPreference: Optional: Preference for the contact information section within the payment flow. Defaults to `.none` if not set.
-    ///   - offerCredit: Optional: Offers PayPal Credit if the customer qualifies. Defaults to `false`.
     ///   - campaigns: Optional: PayPal campaigns applied to the transaction.
     /// - Warning: This initializer should be used for merchants using the PayPal App Switch flow. This feature is currently in beta and may change or be removed in future releases.
     /// - Note: The PayPal App Switch flow currently only supports the production environment.
@@ -142,7 +100,7 @@ import BraintreeCore
         requestBillingAgreement: Bool = false,
         contactPreference: BTContactPreference = .none,
         offerCredit: Bool = false,
-        campaigns: [BTPayPalCampaign]
+        campaigns: [BTPayPalCampaign]? = nil
     ) {
         self.init(
             amount: amount,
@@ -155,7 +113,7 @@ import BraintreeCore
             requestBillingAgreement: requestBillingAgreement,
             userAuthenticationEmail: userAuthenticationEmail,
             offerCredit: offerCredit,
-            campaigns: campaigns
+            campaigns: campaigns ?? []
         )
     }
 

--- a/Sources/BraintreePayPal/Models/BTPayPalCampaign.swift
+++ b/Sources/BraintreePayPal/Models/BTPayPalCampaign.swift
@@ -3,9 +3,9 @@ import Foundation
 /// A PayPal campaign applied to a checkout transaction.
 @objcMembers public class BTPayPalCampaign: NSObject, Encodable {
 
-    // MARK: - Public Properties
+    // MARK: - Internal Properties
 
-    public let id: String
+    let id: String
 
     // MARK: - Public Initializer
 

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,11 +65,11 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        let validPayPalCampaigns = payPalRequest.campaigns.filter {
+        let validCampaigns = payPalRequest.campaigns.filter {
             !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
-        if !validPayPalCampaigns.isEmpty {
-            self.payPalCampaigns = validPayPalCampaigns
+        if !validCampaigns.isEmpty {
+            self.payPalCampaigns = validCampaigns
         }
         
         let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,9 +65,8 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        let validPayPalCampaigns = payPalRequest.campaigns.compactMap {
-            let trimmedID = $0.id.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmedID.isEmpty ? nil : BTPayPalCampaign(id: trimmedID)
+        let validPayPalCampaigns = payPalRequest.campaigns.filter {
+            !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if !validPayPalCampaigns.isEmpty {
             self.payPalCampaigns = validPayPalCampaigns

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,8 +65,9 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        let validPayPalCampaigns = payPalRequest.campaigns.filter {
-            !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let validPayPalCampaigns = payPalRequest.campaigns.compactMap {
+            let trimmedID = $0.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedID.isEmpty ? nil : BTPayPalCampaign(id: trimmedID)
         }
         if !validPayPalCampaigns.isEmpty {
             self.payPalCampaigns = validPayPalCampaigns

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -26,6 +26,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
     private var merchantAccountID: String?
     private var osType: String?
     private var osVersion: String?
+    private var payPalCampaigns: [BTPayPalCampaign]?
     private var recipientPhoneNumber: BTPayPalPhoneNumber?
     private var recipientEmail: String?
     private var recurringBillingDetails: BTPayPalRecurringBillingDetails?
@@ -63,6 +64,13 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerPayLater = payPalRequest.offerPayLater
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
+
+        let validPayPalCampaigns = payPalRequest.payPalCampaigns.filter {
+            !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if !validPayPalCampaigns.isEmpty {
+            self.payPalCampaigns = validPayPalCampaigns
+        }
         
         let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode
         
@@ -169,6 +177,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
         case offerCredit = "offer_paypal_credit"
         case osType = "os_type"
         case osVersion = "os_version"
+        case payPalCampaigns = "paypal_campaigns"
         case recipientPhoneNumber = "international_phone"
         case recipientEmail = "recipient_email"
         case recurringBillingDetails = "plan_metadata"

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,13 +65,8 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        if let campaigns = payPalRequest.campaigns {
-            let validCampaigns = campaigns.filter {
-                !$0.id.isEmpty
-            }
-            if !validCampaigns.isEmpty {
-                self.payPalCampaigns = validCampaigns
-            }
+        if let campaigns = payPalRequest.campaigns, !campaigns.isEmpty {
+            self.payPalCampaigns = campaigns
         }
         
         let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,11 +65,13 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        let validCampaigns = payPalRequest.campaigns.filter {
-            !$0.id.isEmpty
-        }
-        if !validCampaigns.isEmpty {
-            self.payPalCampaigns = validCampaigns
+        if let campaigns = payPalRequest.campaigns {
+            let validCampaigns = campaigns.filter {
+                !$0.id.isEmpty
+            }
+            if !validCampaigns.isEmpty {
+                self.payPalCampaigns = validCampaigns
+            }
         }
         
         let currencyIsoCode = payPalRequest.currencyCode != nil ? payPalRequest.currencyCode : configuration.currencyIsoCode

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -66,7 +66,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.amountBreakdown = payPalRequest.amountBreakdown
 
         let validCampaigns = payPalRequest.campaigns.filter {
-            !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            !$0.id.isEmpty
         }
         if !validCampaigns.isEmpty {
             self.payPalCampaigns = validCampaigns

--- a/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
+++ b/Sources/BraintreePayPal/Models/PayPalCheckoutPOSTBody.swift
@@ -65,7 +65,7 @@ struct PayPalCheckoutPOSTBody: Encodable {
         self.offerCredit = payPalRequest.offerCredit
         self.amountBreakdown = payPalRequest.amountBreakdown
 
-        let validPayPalCampaigns = payPalRequest.payPalCampaigns.filter {
+        let validPayPalCampaigns = payPalRequest.campaigns.filter {
             !$0.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if !validPayPalCampaigns.isEmpty {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -86,6 +86,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         request.currencyCode = "currency-code"
         request.requestBillingAgreement = true
         request.billingAgreementDescription = "description"
+        request.payPalCampaigns = [BTPayPalCampaign(id: "campaign-123-id")]
         request.userAction = .payNow
         request.userAuthenticationEmail = "fake@email.com"
         request.userPhoneNumber = BTPayPalPhoneNumber(countryCode: "1", nationalNumber: "4087463271")
@@ -112,6 +113,14 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(parameters["offer_pay_later"] as? Bool, true)
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, true)
         XCTAssertEqual(parameters["currency_iso_code"] as? String, "currency-code")
+
+        guard let payPalCampaigns = parameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 1)
+        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, "campaign-123-id")
         XCTAssertEqual(parameters["line1"] as? String, "123 Main")
         XCTAssertEqual(parameters["line2"] as? String, "Unit 1")
         XCTAssertEqual(parameters["city"] as? String, "Chicago")
@@ -152,6 +161,83 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(parameters["amount"] as? String, "1")
         XCTAssertEqual(parameters["offer_pay_later"] as? Bool, false)
         XCTAssertEqual(parameters["offer_paypal_credit"] as? Bool, false)
+        XCTAssertNil(parameters["paypal_campaigns"])
+    }
+
+    func testParametersWithConfiguration_whenPayPalCampaignsAreSet_returnsPayPalCampaigns() {
+        let request = BTPayPalCheckoutRequest(
+            amount: "1",
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "campaign-123-id"),
+                BTPayPalCampaign(id: "campaign-456-id")
+            ]
+        )
+
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),
+              let payPalCampaigns = parameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 2)
+        XCTAssertEqual(payPalCampaigns[0]["id"] as? String, "campaign-123-id")
+        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
+    }
+
+    func testParametersWithConfiguration_whenPayPalCampaignIDsAreEmpty_doesNotReturnPayPalCampaigns() {
+        let request = BTPayPalCheckoutRequest(
+            amount: "1",
+            payPalCampaigns: [
+                BTPayPalCampaign(id: ""),
+                BTPayPalCampaign(id: "   ")
+            ]
+        )
+
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNil(parameters["paypal_campaigns"])
+    }
+
+    func testParametersWithConfiguration_whenSomePayPalCampaignIDsAreEmpty_returnsOnlyValidPayPalCampaignsInOrder() {
+        let request = BTPayPalCheckoutRequest(
+            amount: "1",
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "campaign-123-id"),
+                BTPayPalCampaign(id: ""),
+                BTPayPalCampaign(id: "campaign-456-id"),
+                BTPayPalCampaign(id: "   ")
+            ]
+        )
+
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),
+              let payPalCampaigns = parameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 2)
+        XCTAssertEqual(payPalCampaigns[0]["id"] as? String, "campaign-123-id")
+        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
+    }
+
+    func testParametersWithConfiguration_whenAppSwitchRequestHasPayPalCampaigns_returnsPayPalCampaigns() {
+        let request = BTPayPalCheckoutRequest(
+            amount: "1",
+            enablePayPalAppSwitch: true,
+            payPalCampaigns: [BTPayPalCampaign(id: "campaign-123-id")]
+        )
+
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),
+              let payPalCampaigns = parameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 1)
+        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, "campaign-123-id")
     }
 
     func testParametersWithConfiguration_whenCurrencyCodeNotSet_usesConfigCurrencyCode() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -189,7 +189,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
             amount: "1",
             campaigns: [
                 BTPayPalCampaign(id: ""),
-                BTPayPalCampaign(id: "   ")
+                BTPayPalCampaign(id: "")
             ]
         )
 
@@ -218,15 +218,19 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(payPalCampaigns.count, 2)
+        XCTAssertEqual(payPalCampaigns.count, 3)
         XCTAssertEqual(payPalCampaigns[0]["id"] as? String, "campaign-123-id")
         XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
+        XCTAssertEqual(payPalCampaigns[2]["id"] as? String, "   ")
     }
 
-    func testParametersWithConfiguration_whenPayPalCampaignIDHasSurroundingWhitespace_preservesPayPalCampaignID() {
+    func testParametersWithConfiguration_whenPayPalCampaignIDsContainWhitespace_preservesPayPalCampaignIDs() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
-            campaigns: [BTPayPalCampaign(id: " campaign-123-id ")]
+            campaigns: [
+                BTPayPalCampaign(id: " campaign-123-id "),
+                BTPayPalCampaign(id: "   ")
+            ]
         )
 
         guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),
@@ -235,8 +239,9 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(payPalCampaigns.count, 1)
-        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, " campaign-123-id ")
+        XCTAssertEqual(payPalCampaigns.count, 2)
+        XCTAssertEqual(payPalCampaigns[0]["id"] as? String, " campaign-123-id ")
+        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "   ")
     }
 
     func testParametersWithConfiguration_whenAppSwitchRequestHasPayPalCampaigns_returnsPayPalCampaigns() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -184,13 +184,10 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
     }
 
-    func testParametersWithConfiguration_whenPayPalCampaignIDsAreEmpty_doesNotReturnPayPalCampaigns() {
+    func testParametersWithConfiguration_whenPayPalCampaignsAreEmpty_doesNotReturnPayPalCampaigns() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
-            campaigns: [
-                BTPayPalCampaign(id: ""),
-                BTPayPalCampaign(id: "")
-            ]
+            campaigns: []
         )
 
         guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary() else {
@@ -201,7 +198,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertNil(parameters["paypal_campaigns"])
     }
 
-    func testParametersWithConfiguration_whenSomePayPalCampaignIDsAreEmpty_returnsOnlyValidPayPalCampaignsInOrder() {
+    func testParametersWithConfiguration_whenPayPalCampaignIDsAreEmpty_preservesPayPalCampaignsInOrder() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
             campaigns: [
@@ -218,10 +215,11 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(payPalCampaigns.count, 3)
+        XCTAssertEqual(payPalCampaigns.count, 4)
         XCTAssertEqual(payPalCampaigns[0]["id"] as? String, "campaign-123-id")
-        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
-        XCTAssertEqual(payPalCampaigns[2]["id"] as? String, "   ")
+        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "")
+        XCTAssertEqual(payPalCampaigns[2]["id"] as? String, "campaign-456-id")
+        XCTAssertEqual(payPalCampaigns[3]["id"] as? String, "   ")
     }
 
     func testParametersWithConfiguration_whenPayPalCampaignIDsContainWhitespace_preservesPayPalCampaignIDs() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -223,7 +223,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
     }
 
-    func testParametersWithConfiguration_whenPayPalCampaignIDHasSurroundingWhitespace_trimsPayPalCampaignID() {
+    func testParametersWithConfiguration_whenPayPalCampaignIDHasSurroundingWhitespace_preservesPayPalCampaignID() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
             campaigns: [BTPayPalCampaign(id: " campaign-123-id ")]
@@ -236,7 +236,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         }
 
         XCTAssertEqual(payPalCampaigns.count, 1)
-        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, "campaign-123-id")
+        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, " campaign-123-id ")
     }
 
     func testParametersWithConfiguration_whenAppSwitchRequestHasPayPalCampaigns_returnsPayPalCampaigns() {

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -86,7 +86,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         request.currencyCode = "currency-code"
         request.requestBillingAgreement = true
         request.billingAgreementDescription = "description"
-        request.payPalCampaigns = [BTPayPalCampaign(id: "campaign-123-id")]
+        request.campaigns = [BTPayPalCampaign(id: "campaign-123-id")]
         request.userAction = .payNow
         request.userAuthenticationEmail = "fake@email.com"
         request.userPhoneNumber = BTPayPalPhoneNumber(countryCode: "1", nationalNumber: "4087463271")
@@ -167,7 +167,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
     func testParametersWithConfiguration_whenPayPalCampaignsAreSet_returnsPayPalCampaigns() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
-            payPalCampaigns: [
+            campaigns: [
                 BTPayPalCampaign(id: "campaign-123-id"),
                 BTPayPalCampaign(id: "campaign-456-id")
             ]
@@ -187,7 +187,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
     func testParametersWithConfiguration_whenPayPalCampaignIDsAreEmpty_doesNotReturnPayPalCampaigns() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
-            payPalCampaigns: [
+            campaigns: [
                 BTPayPalCampaign(id: ""),
                 BTPayPalCampaign(id: "   ")
             ]
@@ -204,7 +204,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
     func testParametersWithConfiguration_whenSomePayPalCampaignIDsAreEmpty_returnsOnlyValidPayPalCampaignsInOrder() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
-            payPalCampaigns: [
+            campaigns: [
                 BTPayPalCampaign(id: "campaign-123-id"),
                 BTPayPalCampaign(id: ""),
                 BTPayPalCampaign(id: "campaign-456-id"),
@@ -227,7 +227,7 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         let request = BTPayPalCheckoutRequest(
             amount: "1",
             enablePayPalAppSwitch: true,
-            payPalCampaigns: [BTPayPalCampaign(id: "campaign-123-id")]
+            campaigns: [BTPayPalCampaign(id: "campaign-123-id")]
         )
 
         guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),

--- a/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalCheckoutRequest_Tests.swift
@@ -223,6 +223,22 @@ class BTPayPalCheckoutRequest_Tests: XCTestCase {
         XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
     }
 
+    func testParametersWithConfiguration_whenPayPalCampaignIDHasSurroundingWhitespace_trimsPayPalCampaignID() {
+        let request = BTPayPalCheckoutRequest(
+            amount: "1",
+            campaigns: [BTPayPalCampaign(id: " campaign-123-id ")]
+        )
+
+        guard let parameters = try? request.encodedPostBodyWith(configuration: configuration).toDictionary(),
+              let payPalCampaigns = parameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 1)
+        XCTAssertEqual(payPalCampaigns.first?["id"] as? String, "campaign-123-id")
+    }
+
     func testParametersWithConfiguration_whenAppSwitchRequestHasPayPalCampaigns_returnsPayPalCampaigns() {
         let request = BTPayPalCheckoutRequest(
             amount: "1",

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -72,7 +72,7 @@ class BTPayPalClient_Tests: XCTestCase {
     func testTokenizePayPalAccount_checkout_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
         let checkoutRequest = BTPayPalCheckoutRequest(
             amount: "1",
-            payPalCampaigns: [
+            campaigns: [
                 BTPayPalCampaign(id: "campaign-123-id"),
                 BTPayPalCampaign(id: "campaign-456-id")
             ]

--- a/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
+++ b/UnitTests/BraintreePayPalTests/BTPayPalClient_Tests.swift
@@ -70,7 +70,13 @@ class BTPayPalClient_Tests: XCTestCase {
 
     @MainActor
     func testTokenizePayPalAccount_checkout_whenRemoteConfigurationFetchSucceeds_postsToCorrectEndpoint() {
-        let checkoutRequest = BTPayPalCheckoutRequest(amount: "1")
+        let checkoutRequest = BTPayPalCheckoutRequest(
+            amount: "1",
+            payPalCampaigns: [
+                BTPayPalCampaign(id: "campaign-123-id"),
+                BTPayPalCampaign(id: "campaign-456-id")
+            ]
+        )
         checkoutRequest.intent = .sale
 
         let expectation = expectation(description: "Tokenize started")
@@ -86,6 +92,15 @@ class BTPayPalClient_Tests: XCTestCase {
 
         XCTAssertEqual(lastPostParameters["intent"] as? String, "sale")
         XCTAssertEqual(lastPostParameters["amount"] as? String, "1")
+
+        guard let payPalCampaigns = lastPostParameters["paypal_campaigns"] as? [[String: Any]] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(payPalCampaigns.count, 2)
+        XCTAssertEqual(payPalCampaigns[0]["id"] as? String, "campaign-123-id")
+        XCTAssertEqual(payPalCampaigns[1]["id"] as? String, "campaign-456-id")
         XCTAssertEqual(lastPostParameters["return_url"] as? String, "sdk.ios.braintree://onetouch/v1/success")
         XCTAssertEqual(lastPostParameters["cancel_url"] as? String, "sdk.ios.braintree://onetouch/v1/cancel")
     }


### PR DESCRIPTION
### Summary of changes
- PR 1 of 2 for PayPal Campaign IDs.
- Base branch: `braintree:paypal-campaigns-feature`.
- Dependency: none.
- Adds shared `BTPayPalCampaign` model in `BraintreeCore`.
- Adds public `campaigns` support to `BTPayPalCheckoutRequest`.
- Sends valid campaign IDs in PayPal Checkout create order requests as `paypal_campaigns`.
- Omits `paypal_campaigns` when the list is empty or contains only empty IDs.
- Preserves campaign ID order when serializing the request.
- Adds unit coverage for empty, single, multiple, and mixed campaign ID inputs.
- Adds Demo App support for entering comma-separated campaign IDs in the PayPal Checkout flow.
- Adds scrollable Demo layout support so the PayPal Checkout form content remains accessible.
- Test steps:
  - Run `xcodebuild test -project Braintree.xcodeproj -scheme BraintreePayPal -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.5' -only-testing:BraintreePayPalTests/BTPayPalCheckoutRequest_Tests -only-testing:BraintreePayPalTests/BTPayPalClient_Tests`.
  - Build/run the Demo App and verify PayPal Checkout requests include `paypal_campaigns` when campaign IDs are entered.

Video Evidence:


https://github.com/user-attachments/assets/0464aabd-2137-4717-b1c0-9bd52df88032
  
  CAL Logs for Create Order
  
<img width="658" height="626" alt="Screenshot 2026-07-22 at 12 32 46 PM" src="https://github.com/user-attachments/assets/b3b5c524-34d2-4fb4-b6bf-d3c34a7cd195" />


  
```
  [BT SDK Request] POST https://api.sandbox.braintreegateway.com:443/merchants/dcpspy2brwdjr3qn/client_api/v1/paypal_hermes/create_payment_resource
[BT SDK Request Headers] ["Accept": "application/json", "User-Agent": "Braintree/iOS/7.8.0", "Content-Type": "application/json; charset=utf-8", "Accept-Language": "en-US"]
[BT SDK Request Summary] correlation_id=<not present> paypal_campaigns=Can-123,cam-ii99
[BT SDK Request Body] {
  "_meta" : {
    "integration" : "custom",
    "platform" : "iOS",
    "sessionId" : "47A886FDA98F4A259F568C29014819EF",
    "source" : "unknown",
    "version" : "7.8.0"
  },
  "amount" : "5.00",
  "authorization_fingerprint" : "eyJraWQiOiIyMDE4MDQyNjE2LXNhbmRib3giLCJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tIiwiYWxnIjoiRVMyNTYifQ.eyJleHAiOjE3ODQ4MjY4MzUsImp0aSI6IjNmYTgyMThhLWNhNDktNDc2OC1iMzRiLWE0OWVhNjg0MmZjYiIsInN1YiI6ImRjcHNweTJicndkanIzcW4iLCJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tIiwibWVyY2hhbnQiOnsicHVibGljX2lkIjoiZGNwc3B5MmJyd2RqcjNxbiIsInZlcmlmeV9jYXJkX2J5X2RlZmF1bHQiOnRydWUsInZlcmlmeV93YWxsZXRfYnlfZGVmYXVsdCI6dHJ1ZX0sInJpZ2h0cyI6WyJtYW5hZ2VfdmF1bHQiXSwic2NvcGUiOlsiQnJhaW50cmVlOlZhdWx0IiwiQnJhaW50cmVlOkNsaWVudFNESyIsIkJyYWludHJlZTpBWE8iLCJCcmFpbnRyZWU6UGF5bWVudHNSZWFkeSJdLCJvcHRpb25zIjp7ImN1c3RvbWVyX2lkIjoiODI2OTdDODYtM0IyRS00MEE5LUE0QjgtQTRGOERFNjM5NURFIiwicGF5cGFsX2NsaWVudF9pZCI6IkFiNFRqckhJcjZqMWhJVWNUYVpaQmJmTGVBWjlxX1FBUmpQYUVVNXZ6TTFQUmJfZEUzR04zWk9LSExvcl9lSWdaRWszV08zSzFXVDE5VFg2In19.TaCzpJ9owSHvUpWqAE9Y7V_TYRv6cs8RSlq7RNzNlRk-nC1oIHvmDzcZ-vlJWNtcrG-rGXL0GZEVanIGiBrKIw?customer_id=",
  "cancel_url" : "sdk.ios.braintree:\/\/onetouch\/v1\/cancel",
  "contact_preference" : "UPDATE_CONTACT_INFO",
  "currency_iso_code" : "USD",
  "experience_profile" : {
    "address_override" : false,
    "brand_name" : "Acme Widgets, Ltd. (Sandbox)",
    "no_shipping" : true
  },
  "intent" : "authorize",
  "line_items" : [
    {
      "image_url" : "https:\/\/www.example.com\/example.jpg",
      "kind" : "debit",
      "name" : "item one 1234567",
      "quantity" : "1",
      "unit_amount" : "5.00",
      "upc_code" : "123456789",
      "upc_type" : "UPC-A"
    }
  ],
  "offer_pay_later" : false,
  "offer_paypal_credit" : false,
  "paypal_campaigns" : [
    {
      "id" : "Can-123"
    },
    {
      "id" : "cam-ii99"
    }
  ],
  "return_url" : "sdk.ios.braintree:\/\/onetouch\/v1\/success"
}

```




### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [x] Other: Codex

**How was AI used?**
Codex was used to inspect the SDK request flow, implement campaign ID support for PayPal Checkout create order requests, add focused unit tests, update the Demo App, and help split the changes into reviewable PRs.

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @Juan219