### PR TITLE
Revert "Bump version to 7.9.0"

### DIFF
--- a/Braintree.podspec
+++ b/Braintree.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Braintree"
-  s.version          = "7.9.0"
+  s.version          = "7.8.0"
   s.summary          = "Braintree iOS SDK: Helps you accept card and alternative payments in your iOS app."
   s.description      = <<-DESC
                        Braintree is a full-stack payments platform for developers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree iOS SDK Release Notes
 
-## 7.9.0 (2026-07-21)
+## unreleased
 * BraintreeUIComponents
   * Fix minimum target version to iOS 16.0 to match all other modules
 

--- a/Demo/Application/Supporting Files/Braintree-Demo-Info.plist
+++ b/Demo/Application/Supporting Files/Braintree-Demo-Info.plist
@@ -41,7 +41,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.0</string>
+	<string>7.8.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -56,7 +56,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7.9.0</string>
+	<string>7.8.0</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>com.braintreepayments.Demo.payments</string>

--- a/Sources/BraintreeCore/BTCoreConstants.swift
+++ b/Sources/BraintreeCore/BTCoreConstants.swift
@@ -5,7 +5,7 @@ import Foundation
 public class BTCoreConstants: NSObject {
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    public static var braintreeSDKVersion: String = "7.9.0"
+    public static var braintreeSDKVersion: String = "7.8.0"
 
     /// :nodoc: This property is exposed for internal Braintree use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     public static let callbackURLScheme: String = "sdk.ios.braintree"

--- a/Sources/BraintreeCore/Info.plist
+++ b/Sources/BraintreeCore/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.0</string>
+	<string>7.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>7.9.0</string>
+	<string>7.8.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## Summary
- Reverts commit 72978a0d793e12f3e2b7bf27d94f0f316efdf43e, restoring version to 7.8.0 and the `## unreleased` CHANGELOG section, since the 7.9.0 release build failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)