### PR TITLE
[Open Dev] Convert Apple Pay Demo to SwiftUI

### DIFF
--- a/Demo/Application/Features/ApplePayView.swift
+++ b/Demo/Application/Features/ApplePayView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import BraintreeApplePay
+import BraintreeCore
+import PassKit
+
+struct ApplePayView: View {
+
+    let applePayClient: BTApplePayClient
+    let onProgress: (String?) -> Void
+    let onComplete: (BTPaymentMethodNonce?) -> Void
+    let onPaymentRequestCreated: (PKPaymentRequest) -> Void
+
+    @State private var isApplePaySupported = false
+
+    // swiftlint:disable:next force_unwrapping
+    private let managementURL = URL(string: "https://www.merchant.com/update-payment")!
+
+    init(
+        client: BTApplePayClient,
+        onProgress: @escaping (String?) -> Void = { _ in },
+        onComplete: @escaping (BTPaymentMethodNonce?) -> Void = { _ in },
+        onPaymentRequestCreated: @escaping (PKPaymentRequest) -> Void = { _ in }
+    ) {
+        self.applePayClient = client
+        self.onProgress = onProgress
+        self.onComplete = onComplete
+        self.onPaymentRequestCreated = onPaymentRequestCreated
+    }
+
+    var body: some View {
+        VStack {
+            if isApplePaySupported {
+                PayWithApplePayButton(.plain) {
+                    Task {
+                        await requestApplePayPayment()
+                    }
+                }
+                .payWithApplePayButtonStyle(.automatic)
+                .frame(height: 50)
+                .padding(.horizontal)
+            }
+        }
+        .onAppear {
+            Task {
+                let isSupported = await applePayClient.isApplePaySupported()
+                if !isSupported {
+                    onProgress("canMakePayments returned false, hiding Apple Pay button")
+                }
+                isApplePaySupported = isSupported
+            }
+        }
+    }
+
+    private func requestApplePayPayment() async {
+        onProgress("Constructing PKPaymentRequest")
+
+        do {
+            let request = try await applePayClient.makePaymentRequest()
+            let paymentRequest = constructPaymentRequest(with: request)
+            paymentRequest.recurringPaymentRequest = recurringPaymentRequest()
+
+            onProgress("Presenting Apple Pay Sheet")
+            onPaymentRequestCreated(paymentRequest)
+        } catch {
+            onProgress(error.localizedDescription)
+        }
+    }
+
+    private func recurringPaymentRequest() -> PKRecurringPaymentRequest {
+        PKRecurringPaymentRequest(
+            paymentDescription: "Payment description.",
+            regularBilling: PKRecurringPaymentSummaryItem(label: "Payment label", amount: 10.99),
+            managementURL: managementURL
+        )
+    }
+
+    private func constructPaymentRequest(with paymentRequest: PKPaymentRequest) -> PKPaymentRequest {
+        paymentRequest.requiredBillingContactFields = [PKContactField.name]
+
+        let shippingMethod1 = PKShippingMethod(label: "✈️ Fast Shipping", amount: 4.99)
+        shippingMethod1.detail = "Fast but expensive"
+        shippingMethod1.identifier = "fast"
+
+        let shippingMethod2 = PKShippingMethod(label: "🐢 Slow Shipping", amount: 0.00)
+        shippingMethod2.detail = "Slow but free"
+        shippingMethod2.identifier = "slow"
+
+        let shippingMethod3 = PKShippingMethod(label: "💣 Unavailable Shipping", amount: NSDecimalNumber(string: "0xdeadbeef"))
+        shippingMethod3.detail = "It will make Apple Pay fail"
+        shippingMethod3.identifier = "fail"
+
+        paymentRequest.shippingMethods = [shippingMethod1, shippingMethod2, shippingMethod3]
+        paymentRequest.requiredShippingContactFields = [PKContactField.name, PKContactField.phoneNumber, PKContactField.emailAddress]
+
+        paymentRequest.paymentSummaryItems = [
+            PKPaymentSummaryItem(label: "SOME ITEM", amount: 10),
+            PKPaymentSummaryItem(label: "SHIPPING", amount: shippingMethod1.amount),
+            PKPaymentSummaryItem(label: "BRAINTREE", amount: 14.99)
+        ]
+
+        paymentRequest.merchantCapabilities = .capability3DS
+        return paymentRequest
+    }
+}
+
+#Preview {
+    ApplePayView(client: BTApplePayClient(authorization: ""))
+}

--- a/Demo/Application/Features/ApplePayViewController.swift
+++ b/Demo/Application/Features/ApplePayViewController.swift
@@ -5,90 +5,38 @@ import PassKit
 class ApplePayViewController: PaymentButtonBaseViewController {
 
     lazy var applePayClient = BTApplePayClient(authorization: authorization)
-    // swiftlint:disable:next force_unwrapping
-    let managementURL = URL(string: "https://www.merchant.com/update-payment")!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         title = "Apple Pay"
+
+        let demoView = ApplePayView(
+            client: applePayClient,
+            onProgress: progressBlock,
+            onComplete: completionBlock
+        ) { [weak self] paymentRequest in
+            self?.presentPaymentSheet(with: paymentRequest)
+        }
+
+        embed(demoView)
     }
 
+    // TODO: Remove or change createPaymentButton during full SwiftUI migration
+    // This is to suppress Constraint warnings when the payment button is not overriden. The actual Payment Button is within the SwiftUI view
     override func createPaymentButton() -> UIView {
-        applePayClient.isApplePaySupported { isSupported in
-            if !isSupported {
-                self.progressBlock("canMakePayments returned false, hiding Apple Pay button")
-                return
-            }
+        let placeholderView = UIView()
+        placeholderView.translatesAutoresizingMaskIntoConstraints = false
+        return placeholderView
+    }
+
+    private func presentPaymentSheet(with paymentRequest: PKPaymentRequest) {
+        guard let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest) else {
+            progressBlock("Could not create PKPaymentAuthorizationViewController")
+            return
         }
-
-        let applePayButton = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .automatic)
-        applePayButton.translatesAutoresizingMaskIntoConstraints = false
-        applePayButton.addTarget(self, action: #selector(tappedApplePayButton), for: .touchUpInside)
-
-        NSLayoutConstraint.activate([applePayButton.heightAnchor.constraint(equalToConstant: 50)])
-
-        return applePayButton
-    }
-
-    @objc func tappedApplePayButton() {
-        progressBlock("Constructing PKPaymentRequest")
-
-        applePayClient.makePaymentRequest { request, error in
-            guard let request else {
-                self.progressBlock(error?.localizedDescription)
-                return
-            }
-
-            let paymentRequest = self.constructPaymentRequest(with: request)
-            guard let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest) else {
-                self.progressBlock("Could not create PKPaymentAuthorizationViewController")
-                return
-            }
-            paymentAuthorizationViewController.delegate = self
-
-            paymentRequest.recurringPaymentRequest = self.recurringPaymentRequest()
-
-            self.progressBlock("Presenting Apple Pay Sheet")
-            self.present(paymentAuthorizationViewController, animated: true)
-        }
-    }
-
-    private func recurringPaymentRequest() -> PKRecurringPaymentRequest {
-        let recurringPaymentRequest = PKRecurringPaymentRequest(
-            paymentDescription: "Payment description.",
-            regularBilling: PKRecurringPaymentSummaryItem(label: "Payment label", amount: 10.99),
-            managementURL: managementURL
-        )
-        return recurringPaymentRequest
-    }
-
-    private func constructPaymentRequest(with paymentRequest: PKPaymentRequest) -> PKPaymentRequest {
-        paymentRequest.requiredBillingContactFields = [PKContactField.name]
-
-        let shippingMethod1 = PKShippingMethod(label: "✈️ Fast Shipping", amount: 4.99)
-        shippingMethod1.detail = "Fast but expensive"
-        shippingMethod1.identifier = "fast"
-
-        let shippingMethod2 = PKShippingMethod(label: "🐢 Slow Shipping", amount: 0.00)
-        shippingMethod2.detail = "Slow but free"
-        shippingMethod2.identifier = "slow"
-
-        let shippingMethod3 = PKShippingMethod(label: "💣 Unavailable Shipping", amount: NSDecimalNumber(string: "0xdeadbeef"))
-        shippingMethod3.detail = "It will make Apple Pay fail"
-        shippingMethod3.identifier = "fail"
-
-        paymentRequest.shippingMethods = [shippingMethod1, shippingMethod2, shippingMethod3]
-        paymentRequest.requiredShippingContactFields = [PKContactField.name, PKContactField.phoneNumber, PKContactField.emailAddress]
-
-        paymentRequest.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: "SOME ITEM", amount: 10),
-            PKPaymentSummaryItem(label: "SHIPPING", amount: shippingMethod1.amount),
-            PKPaymentSummaryItem(label: "BRAINTREE", amount: 14.99)
-        ]
-
-        paymentRequest.merchantCapabilities = .capability3DS
-        return paymentRequest
+        paymentAuthorizationViewController.delegate = self
+        present(paymentAuthorizationViewController, animated: true)
     }
 }
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		04DDF4622EE8AA1900FBDE49 /* PaymentButtonHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DDF4612EE8AA1200FBDE49 /* PaymentButtonHelper.swift */; };
 		08222B07C311489F90D08D41 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D23244B5E9EE59BAB3F3003 /* Pods_Demo.framework */; };
 		0827D165300131C100D26DC4 /* SEPADirectDebitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0827D164300131C100D26DC4 /* SEPADirectDebitView.swift */; };
+		0827D1673013AEDB00D26DC4 /* ApplePayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0827D1663013AEDB00D26DC4 /* ApplePayView.swift */; };
 		084C2C6E2FD85A960018BB01 /* CardFields_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C2C6D2FD85A960018BB01 /* CardFields_UITests.swift */; };
 		086561662EF1D4EF00B16439 /* BraintreeUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */; };
 		086561672EF1D4EF00B16439 /* BraintreeUIComponents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -136,6 +137,7 @@
 /* Begin PBXFileReference section */
 		04DDF4612EE8AA1200FBDE49 /* PaymentButtonHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonHelper.swift; sourceTree = "<group>"; };
 		0827D164300131C100D26DC4 /* SEPADirectDebitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEPADirectDebitView.swift; sourceTree = "<group>"; };
+		0827D1663013AEDB00D26DC4 /* ApplePayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayView.swift; sourceTree = "<group>"; };
 		084C2C6D2FD85A960018BB01 /* CardFields_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFields_UITests.swift; sourceTree = "<group>"; };
 		08A83F582EDE268E0076BD28 /* UIComponentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponentsViewController.swift; sourceTree = "<group>"; };
 		08A83F5A2EDF965E0076BD28 /* BraintreeUIComponents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BraintreeUIComponents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -382,6 +384,7 @@
 			children = (
 				BEBD52842AAB9649005D6687 /* AmexViewController.swift */,
 				BEBD52822AAB62FB005D6687 /* ApplePayViewController.swift */,
+				0827D1663013AEDB00D26DC4 /* ApplePayView.swift */,
 				BEE9304A2A992F6200C85779 /* CardTokenizationViewController.swift */,
 				BEE930482A98FE9200C85779 /* DataCollectorViewController.swift */,
 				BEAAAA332A98E5E6001ECA63 /* IdealViewController.swift */,
@@ -731,6 +734,7 @@
 				BEBD52852AAB9649005D6687 /* AmexViewController.swift in Sources */,
 				809E86A82AD01FE7004998B0 /* SceneDelegate.swift in Sources */,
 				BEE9304B2A992F6200C85779 /* CardTokenizationViewController.swift in Sources */,
+				0827D1673013AEDB00D26DC4 /* ApplePayView.swift in Sources */,
 				0827D165300131C100D26DC4 /* SEPADirectDebitView.swift in Sources */,
 				BED461832AD072D9001B0DDF /* CardHelpers.swift in Sources */,
 				BE994B0B2AD8377D00470773 /* BaseViewController.swift in Sources */,


### PR DESCRIPTION
### Summary of changes
- Converts the Apple Pay Demo to SwiftUI


https://github.com/user-attachments/assets/5afad0bd-b6cf-43ec-a461-fe127300c3b7




### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to change the Apple Pay button to use Apple's SwiftUI PayWithApplePayButton component

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 
