### PR TITLE
Carry Over Venmo Buyer info from Vault Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Add `payPalCampaigns` to `BTCustomerSessionRequest` for customer session and recommendations requests so eligible PayPal campaign context can be recorded during the shopping journey.
 * BraintreePayPal
   * Add `campaigns` to `BTPayPalCheckoutRequest` so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
+* BraintreeVenmo
+  * Fix `BTVenmoAccountNonce.externalID` returning `nil` after vaulting a Venmo account with a client token
 
 ## 7.9.0 (2026-07-21)
 * BraintreeUIComponents

--- a/Sources/BraintreeVenmo/BTVenmoAccountNonce.swift
+++ b/Sources/BraintreeVenmo/BTVenmoAccountNonce.swift
@@ -35,8 +35,9 @@ import BraintreeCore
 
     // MARK: - Initializers
 
-    init(with nonce: String, username: String, isDefault: Bool) {
+    init(with nonce: String, username: String, isDefault: Bool, externalID: String? = nil) {
         self.username = username
+        self.externalID = externalID
         super.init(nonce: nonce, type: "Venmo", isDefault: isDefault)
     }
 
@@ -60,10 +61,13 @@ import BraintreeCore
     // MARK: - Internal Methods
 
     static func venmoAccount(with json: BTJSON) -> BTVenmoAccountNonce {
+        // The vault response does not include an `externalId` field, but `details.commonId`
+        // contains the same underlying Venmo account identifier.
         BTVenmoAccountNonce(
             with: json["nonce"].asString() ?? "",
             username: json["details"]["username"].asString() ?? "",
-            isDefault: json["default"].isTrue
+            isDefault: json["default"].isTrue,
+            externalID: json["details"]["commonId"].asString()
         )
     }
 }

--- a/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
+++ b/UnitTests/BraintreeVenmoTests/BTVenmoAccountNonce_Tests.swift
@@ -107,4 +107,27 @@ class BTVenmoAccountNonce_Tests: XCTestCase {
         XCTAssertEqual(venmoAccountNonce.username, "jane.doe.username@example.com")
         XCTAssertTrue(venmoAccountNonce.isDefault)
     }
+
+    func testBTVenmoAccountNonceWithJSON_mapsCommonIDToExternalID() {
+        let venmoAccountNonce = BTVenmoAccountNonce.venmoAccount(
+            with: BTJSON(
+                value: [
+                    "consumed": false,
+                    "description": "VenmoAccount",
+                    "details": [
+                        "username": "jane.doe.username@example.com",
+                        "cardType": "Discover",
+                        "commonId": "9999999999999999999"
+                    ],
+                    "isLocked": false,
+                    "nonce": "a-nonce",
+                    "securityQuestions": [] as [Any?],
+                    "type": "VenmoAccount",
+                    "default": true
+                ] as [String: Any]
+            )
+        )
+
+        XCTAssertEqual(venmoAccountNonce.externalID, "9999999999999999999")
+    }
 }


### PR DESCRIPTION
### Summary of changes
- This PR carries over the external ID for the Venmo vault flow


### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Discover where issue was, write unit tests

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 