### PR TITLE
feat: add recommendation expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreeShopperInsights
   * Add `payPalCampaigns` to `BTCustomerSessionRequest` for customer session and recommendations requests so eligible PayPal campaign context can be recorded during the shopping journey.
-  * Add `expiresAt` to `BTCustomerRecommendationsResult` to expose the recommendation expiration timestamp.
+  * Add `expiresAt` as a `Date?` to `BTCustomerRecommendationsResult` to expose the recommendation expiration timestamp.
 * BraintreePayPal
   * Add `campaigns` to `BTPayPalCheckoutRequest` so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * BraintreeShopperInsights
   * Add `payPalCampaigns` to `BTCustomerSessionRequest` for customer session and recommendations requests so eligible PayPal campaign context can be recorded during the shopping journey.
+  * Add `expiresAt` to `BTCustomerRecommendationsResult` to expose the recommendation expiration timestamp.
 * BraintreePayPal
   * Add `campaigns` to `BTPayPalCheckoutRequest` so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * BraintreeShopperInsights
   * Add `payPalCampaigns` to `BTCustomerSessionRequest` for customer session and recommendations requests so eligible PayPal campaign context can be recorded during the shopping journey.
-  * Add `expiresAt` as a `Date?` to `BTCustomerRecommendationsResult` to expose the recommendation expiration timestamp.
+  * Add `expiresAt` as an optional ISO-8601 `String` to `BTCustomerRecommendationsResult` to expose the recommendation expiration timestamp.
 * BraintreePayPal
   * Add `campaigns` to `BTPayPalCheckoutRequest` so eligible campaign context can be persisted during order creation and surfaced in the PayPal checkout experience.
 

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -252,7 +252,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 let details = """
                     SessionID: \(String(describing: result.sessionID ?? ""))
                     InPayPalNetwork: \(result.isInPayPalNetwork?.description ?? "nil")
-                    ExpiresAt: \(formatExpirationDate(result.expiresAt))
+                    ExpiresAt: \(result.expiresAt ?? "nil")
                     PaymentRecommendations:
                     \(result.paymentRecommendations?.map {
                         "- Option: \($0.paymentOption), Priority: \($0.recommendedPriority)"
@@ -272,13 +272,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         recommendationsLabel.isHidden = true
     }
 
-    private func formatExpirationDate(_ date: Date?) -> String {
-        guard let date else { return "nil" }
-
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
-    }
 
     private var payPalCampaigns: [ShopperInsightsCampaign] {
         payPalCampaignsView.textField.text?

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -12,15 +12,11 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
     lazy var payPalClient = BTPayPalClient(authorization: authorization)
     lazy var venmoClient = BTVenmoClient(
         authorization: authorization,
-        // swiftlint:disable:next force_unwrapping
         universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
     )
-    
     lazy var payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(payPalVaultButtonTapped))
     lazy var venmoButton = createButton(title: "Venmo", action: #selector(venmoButtonTapped))
-    
     lazy var paymentOptions: [BTPaymentOptions]? = nil
-    
     lazy var emailView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "Email"
@@ -28,7 +24,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "sandbox1@pp.com"
         return view
     }()
-    
     lazy var countryCodeView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "Country Code"
@@ -36,7 +31,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "1"
         return view
     }()
-    
     lazy var nationalNumberView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "National Number"
@@ -44,7 +38,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "4085005005"
         return view
     }()
-    
     lazy var sessionIDView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "SessionID"

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -12,6 +12,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
     lazy var payPalClient = BTPayPalClient(authorization: authorization)
     lazy var venmoClient = BTVenmoClient(
         authorization: authorization,
+        // swiftlint:disable:next force_unwrapping
         universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
     )
     lazy var payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(payPalVaultButtonTapped))
@@ -394,7 +395,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
             progressBlock(error?.localizedDescription)
             return
         }
-
         completionBlock(nonce)
     }
 }

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -15,9 +15,12 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         // swiftlint:disable:next force_unwrapping
         universalLink: URL(string: "https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments")!
     )
+
     lazy var payPalVaultButton = createButton(title: "PayPal Vault", action: #selector(payPalVaultButtonTapped))
     lazy var venmoButton = createButton(title: "Venmo", action: #selector(venmoButtonTapped))
+
     lazy var paymentOptions: [BTPaymentOptions]? = nil
+
     lazy var emailView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "Email"
@@ -25,6 +28,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "sandbox1@pp.com"
         return view
     }()
+
     lazy var countryCodeView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "Country Code"
@@ -32,6 +36,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "1"
         return view
     }()
+
     lazy var nationalNumberView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "National Number"
@@ -39,6 +44,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         view.textField.text = "4085005005"
         return view
     }()
+
     lazy var sessionIDView: TextFieldWithLabel = {
         let view = TextFieldWithLabel()
         view.label.text = "SessionID"
@@ -271,7 +277,6 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
         recommendationsLabel.text = ""
         recommendationsLabel.isHidden = true
     }
-
 
     private var payPalCampaigns: [ShopperInsightsCampaign] {
         payPalCampaignsView.textField.text?

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -258,7 +258,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 let details = """
                     SessionID: \(String(describing: result.sessionID ?? ""))
                     InPayPalNetwork: \(result.isInPayPalNetwork?.description ?? "nil")
-                    ExpiresAt: \(result.expiresAt ?? "nil")
+                    ExpiresAt: \(formatExpirationDate(result.expiresAt))
                     PaymentRecommendations:
                     \(result.paymentRecommendations?.map {
                         "- Option: \($0.paymentOption), Priority: \($0.recommendedPriority)"
@@ -276,6 +276,14 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
     private func resetRecommendationsLabel() {
         recommendationsLabel.text = ""
         recommendationsLabel.isHidden = true
+    }
+
+    private func formatExpirationDate(_ date: Date?) -> String {
+        guard let date else { return "nil" }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 
     private var payPalCampaigns: [ShopperInsightsCampaign] {

--- a/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
+++ b/Demo/Application/Features/ShopperInsightsViewControllerV2.swift
@@ -258,6 +258,7 @@ class ShopperInsightsViewControllerV2: PaymentButtonBaseViewController {
                 let details = """
                     SessionID: \(String(describing: result.sessionID ?? ""))
                     InPayPalNetwork: \(result.isInPayPalNetwork?.description ?? "nil")
+                    ExpiresAt: \(result.expiresAt ?? "nil")
                     PaymentRecommendations:
                     \(result.paymentRecommendations?.map {
                         "- Option: \($0.paymentOption), Priority: \($0.recommendedPriority)"

--- a/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
+++ b/Sources/BraintreeShopperInsights/Models/GenerateCustomerRecommendationsGraphQLBody.swift
@@ -16,6 +16,7 @@ struct GenerateCustomerRecommendationsGraphQLBody: Encodable {
                         paymentOption
                         recommendedPriority
                     }
+                    expiresAt
                 }
             }
             """

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -90,5 +90,4 @@ final class BTCustomerRecommendationsAPI {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: value)
     }
-
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -43,7 +43,9 @@ final class BTCustomerRecommendationsAPI {
             
             let sessionID = body["data"]["generateCustomerRecommendations"]["sessionId"].asString()
             let isInPayPalNetwork = body["data"]["generateCustomerRecommendations"]["isInPayPalNetwork"].asBool()
-            let expiresAt = body["data"]["generateCustomerRecommendations"]["expiresAt"].asString()
+            let expiresAt = parseExpirationDate(
+                body["data"]["generateCustomerRecommendations"]["expiresAt"].asString()
+            )
             var paymentOptions: [BTPaymentOptions]? = []
             if let paymentRecommendations = body["data"]["generateCustomerRecommendations"]["paymentRecommendations"].asArray() {
                 for recommendation in paymentRecommendations {
@@ -74,6 +76,20 @@ final class BTCustomerRecommendationsAPI {
             )
             throw error
         }
+    }
+
+    private func parseExpirationDate(_ value: String?) -> Date? {
+        guard let value else { return nil }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        if let date = formatter.date(from: value) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
     }
 
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -75,5 +75,4 @@ final class BTCustomerRecommendationsAPI {
             throw error
         }
     }
-
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -43,6 +43,7 @@ final class BTCustomerRecommendationsAPI {
             
             let sessionID = body["data"]["generateCustomerRecommendations"]["sessionId"].asString()
             let isInPayPalNetwork = body["data"]["generateCustomerRecommendations"]["isInPayPalNetwork"].asBool()
+            let expiresAt = body["data"]["generateCustomerRecommendations"]["expiresAt"].asString()
             var paymentOptions: [BTPaymentOptions]? = []
             if let paymentRecommendations = body["data"]["generateCustomerRecommendations"]["paymentRecommendations"].asArray() {
                 for recommendation in paymentRecommendations {
@@ -62,7 +63,8 @@ final class BTCustomerRecommendationsAPI {
             return BTCustomerRecommendationsResult(
                 sessionID: sessionID,
                 isInPayPalNetwork: isInPayPalNetwork,
-                paymentRecommendations: paymentOptions
+                paymentRecommendations: paymentOptions,
+                expiresAt: expiresAt
             )
         } catch {
             apiClient.sendAnalyticsEvent(
@@ -73,4 +75,5 @@ final class BTCustomerRecommendationsAPI {
             throw error
         }
     }
+
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -43,9 +43,7 @@ final class BTCustomerRecommendationsAPI {
             
             let sessionID = body["data"]["generateCustomerRecommendations"]["sessionId"].asString()
             let isInPayPalNetwork = body["data"]["generateCustomerRecommendations"]["isInPayPalNetwork"].asBool()
-            let expiresAt = parseExpirationDate(
-                body["data"]["generateCustomerRecommendations"]["expiresAt"].asString()
-            )
+            let expiresAt = body["data"]["generateCustomerRecommendations"]["expiresAt"].asString()
             var paymentOptions: [BTPaymentOptions]? = []
             if let paymentRecommendations = body["data"]["generateCustomerRecommendations"]["paymentRecommendations"].asArray() {
                 for recommendation in paymentRecommendations {
@@ -78,16 +76,4 @@ final class BTCustomerRecommendationsAPI {
         }
     }
 
-    private func parseExpirationDate(_ value: String?) -> Date? {
-        guard let value else { return nil }
-
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        if let date = formatter.date(from: value) {
-            return date
-        }
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.date(from: value)
-    }
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsAPI.swift
@@ -87,7 +87,6 @@ final class BTCustomerRecommendationsAPI {
         if let date = formatter.date(from: value) {
             return date
         }
-
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: value)
     }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
@@ -12,4 +12,7 @@ public struct BTCustomerRecommendationsResult {
     
     /// The payment recommendations for the shopper.
     public let paymentRecommendations: [BTPaymentOptions]?
+
+    /// The date and time at which the recommendations expire.
+    public let expiresAt: String?
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
@@ -14,5 +14,5 @@ public struct BTCustomerRecommendationsResult {
     public let paymentRecommendations: [BTPaymentOptions]?
 
     /// The date and time at which the recommendations expire.
-    public let expiresAt: String?
+    public let expiresAt: Date?
 }

--- a/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
+++ b/Sources/BraintreeShopperInsights/V2/BTCustomerRecommendationsResult.swift
@@ -13,6 +13,6 @@ public struct BTCustomerRecommendationsResult {
     /// The payment recommendations for the shopper.
     public let paymentRecommendations: [BTPaymentOptions]?
 
-    /// The date and time at which the recommendations expire.
-    public let expiresAt: Date?
+    /// The ISO-8601 date and time at which the recommendations expire.
+    public let expiresAt: String?
 }

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -67,8 +67,7 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         XCTAssertEqual(expectedResult.isInPayPalNetwork, true)
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.paymentOption, "PAYPAL")
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.recommendedPriority, 1)
-        let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11Z")
-        XCTAssertEqual(expectedResult.expiresAt, expectedExpirationDate)
+        XCTAssertEqual(expectedResult.expiresAt, "2026-08-12T14:01:11Z")
     }
     
     func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {
@@ -103,7 +102,7 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         XCTAssertNil(result.expiresAt)
     }
 
-    func testExecute_whenExpirationIncludesFractionalSeconds_parsesExpirationDate() async throws {
+    func testExecute_whenExpirationIncludesFractionalSeconds_preservesExpirationString() async throws {
         mockAPIClient.cannedResponseBody = BTJSON(
             value: [
                 "data": [
@@ -115,11 +114,7 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         )
 
         let result = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let expectedExpirationDate = formatter.date(from: "2026-08-12T14:01:11.123Z")
-
-        XCTAssertEqual(result.expiresAt, expectedExpirationDate)
+        XCTAssertEqual(result.expiresAt, "2026-08-12T14:01:11.123Z")
     }
     
     func testExceute_whenGenerateCustomerRecommendationsAPIFails_throwsNSError() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -115,7 +115,9 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         )
 
         let result = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
-        let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11.123Z")
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expectedExpirationDate = formatter.date(from: "2026-08-12T14:01:11.123Z")
 
         XCTAssertEqual(result.expiresAt, expectedExpirationDate)
     }

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -83,6 +83,24 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testExecute_whenResponseDoesNotIncludeExpiration_returnsNilExpiration() async throws {
+        mockAPIClient.cannedResponseBody = BTJSON(
+            value: [
+                "data": [
+                    "generateCustomerRecommendations": [
+                        "sessionId": sessionID,
+                        "isInPayPalNetwork": false,
+                        "paymentRecommendations": []
+                    ]
+                ]
+            ]
+        )
+
+        let result = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+
+        XCTAssertNil(result.expiresAt)
+    }
     
     func testExceute_whenGenerateCustomerRecommendationsAPIFails_throwsNSError() async {
         let mockError = NSError(domain: "generate-customer-recommendations-error", code: 1, userInfo: nil)

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -67,7 +67,8 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         XCTAssertEqual(expectedResult.isInPayPalNetwork, true)
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.paymentOption, "PAYPAL")
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.recommendedPriority, 1)
-        XCTAssertEqual(expectedResult.expiresAt, "2026-08-12T14:01:11Z")
+        let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11Z")
+        XCTAssertEqual(expectedResult.expiresAt, expectedExpirationDate)
     }
     
     func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {
@@ -100,6 +101,23 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         let result = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
 
         XCTAssertNil(result.expiresAt)
+    }
+
+    func testExecute_whenExpirationIncludesFractionalSeconds_parsesExpirationDate() async throws {
+        mockAPIClient.cannedResponseBody = BTJSON(
+            value: [
+                "data": [
+                    "generateCustomerRecommendations": [
+                        "expiresAt": "2026-08-12T14:01:11.123Z"
+                    ]
+                ]
+            ]
+        )
+
+        let result = try await sut.execute(generateCustomerRecommendationsRequest, sessionID: sessionID)
+        let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11.123Z")
+
+        XCTAssertEqual(result.expiresAt, expectedExpirationDate)
     }
     
     func testExceute_whenGenerateCustomerRecommendationsAPIFails_throwsNSError() async {

--- a/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTGenerateCustomerRecommendationAPI_Tests.swift
@@ -53,7 +53,8 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
                                 "paymentOption": "PAYPAL",
                                 "recommendedPriority": 1
                             ]
-                        ]
+                        ],
+                        "expiresAt": "2026-08-12T14:01:11Z"
                     ]
                 ]
             ]
@@ -66,6 +67,7 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         XCTAssertEqual(expectedResult.isInPayPalNetwork, true)
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.paymentOption, "PAYPAL")
         XCTAssertEqual(expectedResult.paymentRecommendations?.first?.recommendedPriority, 1)
+        XCTAssertEqual(expectedResult.expiresAt, "2026-08-12T14:01:11Z")
     }
     
     func testExecute_whenEmptyResponseBodyReturned_throwsBTShopperInsightsError() async {
@@ -94,4 +96,3 @@ class BTGenerateCustomerRecommendationAPI_Tests: XCTestCase {
         }
     }
 }
-

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -306,7 +306,8 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
                                 "paymentOption": "Venmo",
                                 "recommendedPriority": 2
                             ]
-                        ]
+                        ],
+                        "expiresAt": "2026-08-12T14:01:11Z"
                     ]
                 ]
             ]
@@ -336,6 +337,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
 
             XCTAssertEqual(recommendations[1].paymentOption, "Venmo")
             XCTAssertEqual(recommendations[1].recommendedPriority, 2)
+            XCTAssertEqual(result.expiresAt, "2026-08-12T14:01:11Z")
             
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:succeeded")

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -337,7 +337,8 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
 
             XCTAssertEqual(recommendations[1].paymentOption, "Venmo")
             XCTAssertEqual(recommendations[1].recommendedPriority, 2)
-            XCTAssertEqual(result.expiresAt, "2026-08-12T14:01:11Z")
+            let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11Z")
+            XCTAssertEqual(result.expiresAt, expectedExpirationDate)
             
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:succeeded")

--- a/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/BTShopperInsightsClientV2_Tests.swift
@@ -337,8 +337,7 @@ class BTShopperInsightsClientV2_Tests: XCTestCase {
 
             XCTAssertEqual(recommendations[1].paymentOption, "Venmo")
             XCTAssertEqual(recommendations[1].recommendedPriority, 2)
-            let expectedExpirationDate = ISO8601DateFormatter().date(from: "2026-08-12T14:01:11Z")
-            XCTAssertEqual(result.expiresAt, expectedExpirationDate)
+            XCTAssertEqual(result.expiresAt, "2026-08-12T14:01:11Z")
             
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents[mockAPIClient.postedAnalyticsEvents.count - 2], "shopper-insights:generate-customer-recommendations:started")
             XCTAssertEqual(mockAPIClient.postedAnalyticsEvents.last, "shopper-insights:generate-customer-recommendations:succeeded")

--- a/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
+++ b/UnitTests/BraintreeShopperInsightsTests/GenerateCustomerRecommendationsGraphQLBody_Tests.swift
@@ -34,6 +34,7 @@ class GenerateCustomerRecommendationsGraphQLBody_Tests: XCTestCase {
                         paymentOption
                         recommendedPriority
                     }
+                    expiresAt
                 }
             }
             """


### PR DESCRIPTION
### Description

This change propagates the Shopper Insights recommendation expiration timestamp from the GraphQL response to iOS SDK consumers.

### Why are we making these changes?

The Shopper Insights / Payment Ready recommendation response includes `expires_at_iso_date_time`. Merchants need access to this value to determine when payment recommendations become stale.

### What changed?

- Added `expiresAt` to the Shopper Insights V2 GraphQL recommendation flow.
- Mapped `expiresAt` into `BTCustomerRecommendationsResult` as an optional ISO-8601 `String`.
- Displayed the expiration timestamp in the Demo App.
- Updated unit tests for response parsing, including fractional-second timestamps.
- No Analytics changes were required.
- No client-side expiration, retry, or refresh handling was added.

### Testing

- Shopper Insights unit tests passed: 65 tests, 0 failures.
- SwiftLint passed for the affected API file with 0 violations.
- The unrelated card tokenization integration test depends on the external Sandbox environment and timed out.

### AI Usage

**Which AI Agent Was Used?**

- [ ] Copilot
- [ ] Claude
- [x] Other (Codex)

**How was AI used?**

AI was used for repository analysis, implementation support, test updates, lint troubleshooting, and debugging integration test failures.

**Estimated AI Code Contribution**

- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist

- [x] Added a changelog entry
- [x] Tested and confirmed the affected Shopper Insights flows are functioning as expected

### Authors

[@Juan219](https://github.com/Juan219)

----
### Inner Source Process

Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [x] Added all labels to the PR
- [ ] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [ ] Unit tests and builds have been run locally and pass/compile as expected