### PR TITLE
Add eftpos network support for Apple Pay

### DIFF
--- a/Sources/BraintreeApplePay/BTConfiguration+ApplePay.swift
+++ b/Sources/BraintreeApplePay/BTConfiguration+ApplePay.swift
@@ -55,6 +55,8 @@ extension BTConfiguration {
                 supportedNetworks.append(.maestro)
             } else if gatewaySupportedNetwork.localizedCaseInsensitiveCompare("elo") == .orderedSame {
                 supportedNetworks.append(.elo)
+            } else if gatewaySupportedNetwork.localizedCaseInsensitiveCompare("eftpos") == .orderedSame {
+                supportedNetworks.append(.eftpos)
             }
         }
 

--- a/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
+++ b/UnitTests/BraintreeApplePayTests/BTConfiguration+ApplePay_Tests.swift
@@ -65,11 +65,11 @@ class BTConfiguration_ApplePay_Tests : XCTestCase {
 
     func testApplePaySupportedNetworks_returnsSupportedNetworks() {
         let configurationJSON = BTJSON(value: [
-            "applePay": [ "supportedNetworks": ["visa", "mastercard", "amex", "discover"] ]
+            "applePay": [ "supportedNetworks": ["visa", "mastercard", "amex", "discover", "eftpos"] ]
         ])
         let configuration = BTConfiguration(json: configurationJSON)
 
-        XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.visa, PKPaymentNetwork.masterCard, PKPaymentNetwork.amex, PKPaymentNetwork.discover])
+        XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.visa, PKPaymentNetwork.masterCard, PKPaymentNetwork.amex, PKPaymentNetwork.discover, PKPaymentNetwork.eftpos])
     }
 
     func testApplePaySupportedNetworks_whenSupportedNetworksIncludesMaestro_returnsSupportedNetworks() {
@@ -89,6 +89,15 @@ class BTConfiguration_ApplePay_Tests : XCTestCase {
 
         XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.elo])
     }
+
+    func testApplePaySupportedNetworks_whenSupportedNetworksIncludesEftpos_returnsSupportedNetworks() {
+            let configurationJSON = BTJSON(value: [
+                "applePay": [ "supportedNetworks": ["eftpos"] ]
+                ])
+            let configuration = BTConfiguration(json: configurationJSON)
+
+            XCTAssertEqual(configuration.applePaySupportedNetworks!, [PKPaymentNetwork.eftpos])
+        }
 
     func testApplePaySupportedNetworks_doesNotPassesThroughUnknownValuesFromConfiguration() {
         let configurationJSON = BTJSON(value: [


### PR DESCRIPTION
### Summary of changes
- Add support of EFTPOS payment network for Apple Pay

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
<!-- Describe how AI was used (e.g., code generation, refactoring, debugging, writing tests, etc.) -->

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
-

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [ ] Added all labels to the PR
- [ ] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [ ] Unit tests and builds have been run locally and pass/compile as expected
